### PR TITLE
Add F2 help and F3 debug overlays

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -1,4 +1,3 @@
-local input = require("src.game.input")
 local mapEditor = require("src.game.map_editor")
 local mapStorage = require("src.game.map_storage")
 local world = require("src.game.world")
@@ -33,6 +32,7 @@ function Game.new()
     self.availableMaps = {}
     self.currentMapDescriptor = nil
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
 
     self:updateRenderTransform()
     self:refreshMaps()
@@ -55,34 +55,24 @@ function Game:refreshMaps()
     self.availableMaps = mapStorage.listMaps()
 end
 
-function Game:getBuiltinShortcutMap(index)
-    local builtinIndex = 0
-    for _, descriptor in ipairs(self.availableMaps or {}) do
-        if descriptor.source == "builtin" then
-            builtinIndex = builtinIndex + 1
-            if builtinIndex == index then
-                return descriptor
-            end
-        end
-    end
-    return nil
-end
-
 function Game:openMenu()
     self.screen = "menu"
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
     self:refreshMaps()
 end
 
 function Game:openLevelSelect()
     self.screen = "level_select"
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
     self:refreshMaps()
 end
 
 function Game:openEditorBlank()
     self.screen = "editor"
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
     self.editor:resetFromMap(nil, nil)
 end
 
@@ -96,6 +86,7 @@ function Game:openEditorMap(mapDescriptor)
 
     self.screen = "editor"
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
     self.editor:resetFromMap(mapData, mapDescriptor)
     return true
 end
@@ -122,6 +113,7 @@ function Game:startMap(mapDescriptor)
     self.failureReason = nil
     self.currentMapDescriptor = mapDescriptor
     self.levelSelectIssue = nil
+    self.playOverlayMode = nil
     self.world = world.new(self.viewport.w, self.viewport.h, mapData.level)
     self.screen = "play"
     return true
@@ -217,16 +209,6 @@ function Game:keypressed(key)
             self:openEditorMap(self.levelSelectIssue.map)
             return
         end
-        local requestedLevel = input.getLevelShortcut(key)
-        if requestedLevel then
-            local descriptor = self:getBuiltinShortcutMap(requestedLevel)
-            if descriptor then
-                local ok, startError, mapData = self:startMap(descriptor)
-                if not ok then
-                    self:showMapIssue(descriptor, mapData, startError)
-                end
-            end
-        end
         return
     end
 
@@ -246,6 +228,24 @@ function Game:keypressed(key)
         return
     end
 
+    if key == "f2" then
+        if self.playOverlayMode == "help" then
+            self.playOverlayMode = nil
+        else
+            self.playOverlayMode = "help"
+        end
+        return
+    end
+
+    if key == "f3" then
+        if self.playOverlayMode == "debug" then
+            self.playOverlayMode = nil
+        else
+            self.playOverlayMode = "debug"
+        end
+        return
+    end
+
     if key == "m" then
         self:openMenu()
         return
@@ -254,15 +254,6 @@ function Game:keypressed(key)
     if key == "e" or key == "tab" then
         if self.currentMapDescriptor then
             self:openEditorMap(self.currentMapDescriptor)
-        end
-        return
-    end
-
-    local requestedLevel = input.getLevelShortcut(key)
-    if requestedLevel then
-        local descriptor = self:getBuiltinShortcutMap(requestedLevel)
-        if descriptor then
-            self:startMap(descriptor)
         end
         return
     end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -1,5 +1,24 @@
 local ui = {}
 
+local PLAY_OVERLAY = {
+    margin = 24,
+    width = 420,
+    padding = 18,
+    radius = 18,
+    lineGap = 6,
+    sectionGap = 14,
+}
+
+local PLAY_HEADER = {
+    x = 22,
+    y = 20,
+    paddingX = 18,
+    paddingY = 12,
+    titleGap = 14,
+    rowGap = 8,
+    radius = 18,
+}
+
 local function pointInRect(x, y, rect)
     return x >= rect.x
         and x <= rect.x + rect.w
@@ -91,6 +110,207 @@ local function getLevelIssueOverlayRects(game)
             h = 40,
         },
     }
+end
+
+local function getPlayInfoOverlayRect(game)
+    return {
+        x = game.viewport.w - PLAY_OVERLAY.margin - PLAY_OVERLAY.width,
+        y = PLAY_OVERLAY.margin,
+        w = PLAY_OVERLAY.width,
+        h = game.viewport.h - PLAY_OVERLAY.margin * 2,
+    }
+end
+
+local function getJunctionRouteText(junction)
+    local activeInput = junction.inputs[junction.activeInputIndex]
+    local activeOutput = junction.outputs[junction.activeOutputIndex]
+    return string.format(
+        "%s -> %s",
+        activeInput and activeInput.label or ("Input " .. tostring(junction.activeInputIndex)),
+        activeOutput and activeOutput.label or ("Output " .. tostring(junction.activeOutputIndex))
+    )
+end
+
+local function getJunctionHelpText(junction)
+    local control = junction.control or {}
+
+    if control.type == "delayed" then
+        return string.format("Click the junction to arm a %.1fs delayed swap.", control.delay or 0)
+    end
+
+    if control.type == "pump" then
+        return string.format("Click the junction %d times before the charge drains.", control.target or 0)
+    end
+
+    return "Click the junction to switch the active input immediately."
+end
+
+local function getJunctionStateText(junction)
+    local control = junction.control or {}
+
+    if control.type == "delayed" then
+        if control.armed then
+            return string.format("State: armed, %.1fs left", control.remainingDelay or 0)
+        end
+        return string.format("State: idle, %.1fs delay", control.delay or 0)
+    end
+
+    if control.type == "pump" then
+        return string.format("State: charge %d / %d", control.pumpCount or 0, control.target or 0)
+    end
+
+    return "State: instant switch"
+end
+
+local function getTrainStatusText(worldState, train)
+    if train.completed then
+        return "cleared"
+    end
+
+    local currentEdge, occupiedEdges = worldState:getCurrentEdge(train)
+    if not currentEdge then
+        return "inactive"
+    end
+
+    if currentEdge.targetType == "junction" then
+        local junction = worldState.junctions[currentEdge.targetId]
+        local activeInput = junction and junction.inputs[junction.activeInputIndex] or nil
+        if activeInput and activeInput.id ~= currentEdge.id then
+            return string.format("waiting at %s", junction.label or currentEdge.targetId)
+        end
+
+        local localProgress = worldState:getHeadLocalProgress(train, occupiedEdges)
+        return string.format("%s %.0f / %.0f", junction and (junction.label or junction.id) or currentEdge.targetId, localProgress, currentEdge.path.length)
+    end
+
+    return currentEdge.label or currentEdge.id
+end
+
+local function buildPlayHelpSections(game)
+    local sections = {
+        {
+            title = "Controls",
+            lines = {
+                "Left click a junction to activate its control.",
+                "Left click the selector below a junction to cycle outputs forward.",
+                "Right click the selector below a junction to cycle outputs backward.",
+                "M opens the menu. E opens the editor. R restarts the run.",
+                "F2 closes this help panel. F3 opens the debug panel.",
+            },
+        },
+        {
+            title = "Junctions",
+            lines = {},
+        },
+    }
+
+    for _, junction in ipairs(game.world.junctionOrder or {}) do
+        sections[2].lines[#sections[2].lines + 1] = string.format("%s | %s", junction.label, getJunctionRouteText(junction))
+        sections[2].lines[#sections[2].lines + 1] = getJunctionHelpText(junction)
+    end
+
+    return sections
+end
+
+local function buildPlayDebugSections(game)
+    local sections = {
+        {
+            title = "Junction State",
+            lines = {},
+        },
+        {
+            title = "Train Queue",
+            lines = {},
+        },
+    }
+    local worldState = game.world
+    local queueGroups = {}
+    local orderedGroups = {}
+
+    for _, junction in ipairs(worldState.junctionOrder or {}) do
+        sections[1].lines[#sections[1].lines + 1] = string.format("%s | %s", junction.label, getJunctionRouteText(junction))
+        sections[1].lines[#sections[1].lines + 1] = getJunctionStateText(junction)
+    end
+
+    for _, train in ipairs(worldState.trains or {}) do
+        local startEdgeId = train.startEdgeId or train.edgeId
+        local startEdge = worldState.edges[startEdgeId]
+        if not queueGroups[startEdgeId] then
+            queueGroups[startEdgeId] = {
+                label = startEdge and startEdge.label or startEdgeId,
+                trains = {},
+            }
+            orderedGroups[#orderedGroups + 1] = queueGroups[startEdgeId]
+        end
+        queueGroups[startEdgeId].trains[#queueGroups[startEdgeId].trains + 1] = train
+    end
+
+    table.sort(orderedGroups, function(firstGroup, secondGroup)
+        return firstGroup.label < secondGroup.label
+    end)
+
+    for _, group in ipairs(orderedGroups) do
+        table.sort(group.trains, function(firstTrain, secondTrain)
+            return (firstTrain.startProgress or 0) > (secondTrain.startProgress or 0)
+        end)
+
+        sections[2].lines[#sections[2].lines + 1] = string.format("%s queue", group.label)
+        for index, train in ipairs(group.trains) do
+            sections[2].lines[#sections[2].lines + 1] = string.format(
+                "%d. %s | start %.0f | %.2fx | %s",
+                index,
+                train.id,
+                train.startProgress or 0,
+                train.speedScale or 1,
+                getTrainStatusText(worldState, train)
+            )
+        end
+    end
+
+    return sections
+end
+
+local function drawPlayInfoOverlay(game)
+    if game.playOverlayMode ~= "help" and game.playOverlayMode ~= "debug" then
+        return
+    end
+
+    local graphics = love.graphics
+    local rect = getPlayInfoOverlayRect(game)
+    local title = game.playOverlayMode == "help" and "Route Help" or "Route Debug"
+    local accentColor = game.playOverlayMode == "help" and { 0.48, 0.92, 0.62, 1 } or { 0.99, 0.78, 0.32, 1 }
+    local sections = game.playOverlayMode == "help" and buildPlayHelpSections(game) or buildPlayDebugSections(game)
+    local currentY = rect.y + PLAY_OVERLAY.padding
+    local contentX = rect.x + PLAY_OVERLAY.padding
+    local contentWidth = rect.w - PLAY_OVERLAY.padding * 2
+
+    graphics.setColor(0, 0, 0, 0.62)
+    graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, PLAY_OVERLAY.radius, PLAY_OVERLAY.radius)
+    graphics.setColor(0.24, 0.3, 0.36, 1)
+    graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, PLAY_OVERLAY.radius, PLAY_OVERLAY.radius)
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(title, contentX, currentY, contentWidth, "left")
+    currentY = currentY + game.fonts.title:getHeight() + PLAY_OVERLAY.sectionGap
+
+    for _, section in ipairs(sections) do
+        love.graphics.setFont(game.fonts.body)
+        graphics.setColor(accentColor[1], accentColor[2], accentColor[3], accentColor[4])
+        graphics.printf(section.title, contentX, currentY, contentWidth, "left")
+        currentY = currentY + game.fonts.body:getHeight() + PLAY_OVERLAY.lineGap
+
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        for _, line in ipairs(section.lines or {}) do
+            graphics.printf(line, contentX, currentY, contentWidth, "left")
+            currentY = currentY
+                + getWrappedLineCount(game.fonts.small, line, contentWidth) * game.fonts.small:getHeight()
+                + PLAY_OVERLAY.lineGap
+        end
+
+        currentY = currentY + PLAY_OVERLAY.sectionGap
+    end
 end
 
 local function filterMapsBySource(game, source)
@@ -232,7 +452,7 @@ function ui.getLevelSelectHit(game, x, y)
     return nil
 end
 
-function ui.getPlayBackHit(_, x, y)
+function ui.getPlayBackHit(game, x, y)
     return pointInRect(x, y, {
         x = 1114,
         y = 28,
@@ -408,30 +628,56 @@ end
 function ui.drawPlay(game)
     local graphics = love.graphics
     local level = game.world:getLevel()
+    local gameTitleText = "Out of Signal"
+    local levelTitleText = level.title or ""
+    local titleFont = game.fonts.title
+    local levelFont = game.fonts.body
+    local timerFont = game.fonts.small
+    local timerText = game.world.timeRemaining and string.format("Time left: %.1fs", game.world.timeRemaining) or nil
+    local titleRowWidth = titleFont:getWidth(gameTitleText)
+    local levelRowWidth = 0
+    local timerRowWidth = timerText and timerFont:getWidth(timerText) or 0
+    local titleRowHeight = math.max(titleFont:getHeight(), levelFont:getHeight())
+    local headerHeight = titleRowHeight + PLAY_HEADER.paddingY * 2
+
+    if levelTitleText ~= "" then
+        levelRowWidth = PLAY_HEADER.titleGap + levelFont:getWidth(levelTitleText)
+    end
+
+    if timerText then
+        headerHeight = headerHeight + PLAY_HEADER.rowGap + timerFont:getHeight()
+    end
+
+    local playHeaderRect = {
+        x = PLAY_HEADER.x,
+        y = PLAY_HEADER.y,
+        w = math.max(titleRowWidth + levelRowWidth, timerRowWidth) + PLAY_HEADER.paddingX * 2,
+        h = headerHeight,
+    }
+    local titleRowY = playHeaderRect.y + PLAY_HEADER.paddingY
+    local textX = playHeaderRect.x + PLAY_HEADER.paddingX
 
     graphics.setColor(0, 0, 0, 0.34)
-    graphics.rectangle("fill", 22, 20, 620, 170, 18, 18)
+    graphics.rectangle("fill", playHeaderRect.x, playHeaderRect.y, playHeaderRect.w, playHeaderRect.h, PLAY_HEADER.radius, PLAY_HEADER.radius)
 
-    love.graphics.setFont(game.fonts.title)
+    love.graphics.setFont(titleFont)
     graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.print("Out of Signal", 40, 32)
+    graphics.print(gameTitleText, textX, titleRowY)
 
-    love.graphics.setFont(game.fonts.body)
-    graphics.setColor(0.84, 0.88, 0.92, 1)
-    graphics.print(level.title, 42, 80)
-    graphics.printf(level.description, 42, 108, 570)
+    if levelTitleText ~= "" then
+        love.graphics.setFont(levelFont)
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        graphics.print(
+            levelTitleText,
+            textX + titleRowWidth + PLAY_HEADER.titleGap,
+            titleRowY + math.floor((titleRowHeight - levelFont:getHeight()) * 0.5 + 0.5)
+        )
+    end
 
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.48, 0.92, 0.62, 1)
-    graphics.print(game.world:getActiveRouteSummary(), 42, 152)
-
-    local trainsText = string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #game.world.trains)
-    graphics.setColor(0.84, 0.88, 0.92, 0.95)
-    graphics.print(trainsText, 42, 172)
-
-    if game.world.timeRemaining then
+    if timerText then
+        love.graphics.setFont(timerFont)
         graphics.setColor(0.99, 0.83, 0.44, 1)
-        graphics.print(string.format("Time left: %.1fs", game.world.timeRemaining), 220, 172)
+        graphics.print(timerText, textX, titleRowY + titleRowHeight + PLAY_HEADER.rowGap)
     end
 
     drawButton(
@@ -443,9 +689,9 @@ function ui.drawPlay(game)
     )
 
     graphics.setColor(0.8, 0.84, 0.9, 0.82)
-    graphics.printf(level.hint, 0, game.viewport.h - 66, game.viewport.w, "center")
-    graphics.printf(level.footer, 0, game.viewport.h - 42, game.viewport.w, "center")
-    graphics.printf("Press M for the main menu, E for the editor, or R to restart", 0, game.viewport.h - 90, game.viewport.w, "center")
+    graphics.printf("Press F2 for help, F3 for debug, M for menu, E for editor, or R to restart", 0, game.viewport.h - 42, game.viewport.w, "center")
+
+    drawPlayInfoOverlay(game)
 
     if game.failureReason == "collision" then
         drawCenteredOverlay(

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -489,9 +489,12 @@ function world:initializeLevel()
                 self.trains[#self.trains + 1] = {
                     id = trainDefinition.id,
                     edgeId = trainDefinition.edgeId,
+                    startEdgeId = trainDefinition.edgeId,
                     occupiedEdgeIds = { trainDefinition.edgeId },
                     headDistance = trainDefinition.progress,
+                    startProgress = trainDefinition.progress,
                     speed = self.trainSpeed * (trainDefinition.speedScale or 1),
+                    speedScale = trainDefinition.speedScale or 1,
                     currentSpeed = 0,
                     color = copyColor(baseColor),
                     darkColor = darkerColor(baseColor),
@@ -502,8 +505,11 @@ function world:initializeLevel()
     else
         for _, train in ipairs(self.trains) do
             if self.edges[train.edgeId] then
+                train.startEdgeId = train.startEdgeId or train.edgeId
                 train.occupiedEdgeIds = train.occupiedEdgeIds or { train.edgeId }
                 train.headDistance = train.headDistance or train.progress or 0
+                train.startProgress = train.startProgress or train.headDistance or 0
+                train.speedScale = train.speedScale or (train.speed / self.trainSpeed)
             end
         end
     end


### PR DESCRIPTION
## Summary
- Replace F2 and F3 level switching with in-play help and debug overlays.
- Keep the normal play screen cleaner by removing duplicated route and progress text.
- Add compact, content-sized header sizing so the level label sits beside the main title.

## Testing
- Not run (not requested)

## Feature request
- Show a help window on F2 with the current junction routes and usage hints.
- Show a debug window on F3 with junction state, train queue, and speed details.
- Do not switch maps when pressing F2 or F3.