### PR TITLE
Add train sequencer, scoring, and results flow

### DIFF
--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -1,4 +1,8 @@
 local authoredMap = {}
+local DEFAULT_WAGON_COUNT = 4
+local LEGACY_TRAIN_SPACING = 110
+local LEGACY_TRAIN_OFFSET = 70
+local LEGACY_TRAIN_SPEED = 168
 
 local COLOR_LOOKUP = {
     blue = { 0.33, 0.80, 0.98 },
@@ -299,6 +303,97 @@ local function sortEdgesByEnd(edges)
     end)
 end
 
+local function containsValue(list, expected)
+    for _, value in ipairs(list or {}) do
+        if value == expected then
+            return true
+        end
+    end
+    return false
+end
+
+local function getSortedLookupKeys(lookup)
+    local keys = {}
+    for key, enabled in pairs(lookup or {}) do
+        if enabled then
+            keys[#keys + 1] = key
+        end
+    end
+    table.sort(keys)
+    return keys
+end
+
+local function buildLegacyAuthoredTrains(startEdgeRecords)
+    local trains = {}
+
+    for _, startEdge in pairs(startEdgeRecords) do
+        local colorIds = getSortedLookupKeys(startEdge.colors)
+        for colorIndex, colorId in ipairs(colorIds) do
+            trains[#trains + 1] = {
+                id = string.format("%s_train_%s_%d", startEdge.edgeId, colorId, colorIndex),
+                lineColor = colorId,
+                trainColor = colorId,
+                spawnTime = (LEGACY_TRAIN_OFFSET + (colorIndex - 1) * LEGACY_TRAIN_SPACING) / LEGACY_TRAIN_SPEED,
+                wagonCount = DEFAULT_WAGON_COUNT,
+                deadline = nil,
+            }
+        end
+    end
+
+    table.sort(trains, function(a, b)
+        if math.abs((a.spawnTime or 0) - (b.spawnTime or 0)) > 0.0001 then
+            return (a.spawnTime or 0) < (b.spawnTime or 0)
+        end
+        if a.trainColor ~= b.trainColor then
+            return tostring(a.trainColor) < tostring(b.trainColor)
+        end
+        return tostring(a.id) < tostring(b.id)
+    end)
+
+    return trains
+end
+
+local function edgeSupportsGoalColor(edge, goalColor)
+    return containsValue(edge and edge.colors or {}, goalColor)
+end
+
+local function canReachGoalColor(startEdgeId, goalColor, edgeById, junctionLookup)
+    if not startEdgeId or not goalColor then
+        return false
+    end
+
+    local queue = { startEdgeId }
+    local visited = {}
+    local index = 1
+
+    while index <= #queue do
+        local edgeId = queue[index]
+        index = index + 1
+
+        if not visited[edgeId] then
+            visited[edgeId] = true
+            local edge = edgeById[edgeId]
+
+            if edge then
+                if edge.targetType == "exit" and edgeSupportsGoalColor(edge, goalColor) then
+                    return true
+                end
+
+                if edge.targetType == "junction" then
+                    local junction = junctionLookup[edge.targetId]
+                    for _, nextEdgeId in ipairs(junction and junction.outputEdgeIds or {}) do
+                        if not visited[nextEdgeId] then
+                            queue[#queue + 1] = nextEdgeId
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return false
+end
+
 function authoredMap.validateEditorMap(mapName, editorData)
     local errors = {}
 
@@ -347,6 +442,9 @@ function authoredMap.validateEditorMap(mapName, editorData)
 
     local edgeLookup = {}
     local startEdgeRecords = {}
+    local lineColorToEdgeId = {}
+    local outputColorLookup = {}
+    local duplicateInputColorErrors = {}
 
     for _, route in ipairs(editorData.routes or {}) do
         local routeHits = routeJunctions[route.id] or {}
@@ -453,6 +551,18 @@ function authoredMap.validateEditorMap(mapName, editorData)
                 }
                 for _, colorId in ipairs(sourceEndpoint and (sourceEndpoint.colors or {}) or {}) do
                     startEdgeRecords[edge.id].colors[colorId] = true
+                    if lineColorToEdgeId[colorId] and lineColorToEdgeId[colorId] ~= edge.id then
+                        if not duplicateInputColorErrors[colorId] then
+                            duplicateInputColorErrors[colorId] = true
+                            errors[#errors + 1] = string.format("Input color '%s' is used on more than one source line.", colorId)
+                        end
+                    else
+                        lineColorToEdgeId[colorId] = edge.id
+                    end
+                end
+            elseif targetNode.kind == "exit" then
+                for _, colorId in ipairs(targetEndpoint and (targetEndpoint.colors or {}) or {}) do
+                    outputColorLookup[colorId] = true
                 end
             end
         end
@@ -468,7 +578,6 @@ function authoredMap.validateEditorMap(mapName, editorData)
         return a.id < b.id
     end)
 
-    local trains = {}
     local edgeById = {}
     for _, edge in ipairs(edges) do
         edgeById[edge.id] = edge
@@ -516,26 +625,60 @@ function authoredMap.validateEditorMap(mapName, editorData)
         junction.activeOutputIndex = math.min(junction.activeOutputIndex, math.max(1, #junction.outputEdgeIds))
     end
 
-    local trainOffsetByEdge = {}
-    for _, startEdge in pairs(startEdgeRecords) do
-        local colorIds = {}
-        for colorId, enabled in pairs(startEdge.colors or {}) do
-            if enabled then
-                colorIds[#colorIds + 1] = colorId
-            end
+    local authoredTrains = editorData.trains
+    if not authoredTrains or #authoredTrains == 0 then
+        authoredTrains = buildLegacyAuthoredTrains(startEdgeRecords)
+    end
+
+    local trains = {}
+    local timeLimit = editorData.timeLimit
+    for trainIndex, trainData in ipairs(authoredTrains or {}) do
+        local lineColor = trainData.lineColor
+        local trainColor = trainData.trainColor
+        local spawnTime = tonumber(trainData.spawnTime or 0) or 0
+        local wagonCount = math.floor(tonumber(trainData.wagonCount or DEFAULT_WAGON_COUNT) or DEFAULT_WAGON_COUNT)
+        local deadline = trainData.deadline ~= nil and (tonumber(trainData.deadline) or 0) or nil
+
+        if spawnTime < 0 then
+            errors[#errors + 1] = string.format("Train %d has a negative spawn time.", trainIndex)
         end
-        table.sort(colorIds)
-        for colorIndex, colorId in ipairs(colorIds) do
-            local trainOffset = trainOffsetByEdge[startEdge.edgeId] or 0
-            trains[#trains + 1] = {
-                id = string.format("%s_train_%s_%d", startEdge.edgeId, colorId, colorIndex),
-                edgeId = startEdge.edgeId,
-                progress = -70 - trainOffset,
-                speedScale = 1.0 - math.min(0.18, (colorIndex - 1) * 0.05),
-                color = getColor(colorId),
-            }
-            trainOffsetByEdge[startEdge.edgeId] = trainOffset + 110
+        if wagonCount < 1 then
+            errors[#errors + 1] = string.format("Train %d needs at least one wagon.", trainIndex)
         end
+        if deadline ~= nil and deadline < spawnTime then
+            errors[#errors + 1] = string.format("Train %d has a deadline earlier than its spawn time.", trainIndex)
+        end
+        if timeLimit ~= nil and deadline ~= nil and deadline > timeLimit then
+            errors[#errors + 1] = string.format("Train %d has a deadline after the map deadline.", trainIndex)
+        end
+        if not lineColorToEdgeId[lineColor] then
+            errors[#errors + 1] = string.format("Train %d uses source color '%s', but no matching input line exists.", trainIndex, tostring(lineColor))
+        end
+        if not outputColorLookup[trainColor] then
+            errors[#errors + 1] = string.format("Train %d targets color '%s', but no matching output exists.", trainIndex, tostring(trainColor))
+        end
+        if lineColorToEdgeId[lineColor]
+            and outputColorLookup[trainColor]
+            and not canReachGoalColor(lineColorToEdgeId[lineColor], trainColor, edgeById, junctionLookup) then
+            errors[#errors + 1] = string.format(
+                "Train %d cannot reach goal color '%s' from source line '%s'.",
+                trainIndex,
+                tostring(trainColor),
+                tostring(lineColor)
+            )
+        end
+
+        trains[#trains + 1] = {
+            id = trainData.id or string.format("train_%d", trainIndex),
+            edgeId = lineColorToEdgeId[lineColor],
+            lineColor = lineColor,
+            trainColor = trainColor,
+            goalColor = trainColor,
+            spawnTime = spawnTime,
+            wagonCount = wagonCount,
+            deadline = deadline,
+            color = getColor(trainColor),
+        }
     end
 
     if #errors > 0 then
@@ -546,8 +689,8 @@ function authoredMap.validateEditorMap(mapName, editorData)
         title = mapName,
         description = "Custom map loaded from the editor.",
         hint = "Click the junction center to switch inputs. Use the bottom selector to switch outputs.",
-        footer = "Saved maps support up to five input tracks and five output tracks per junction.",
-        timeLimit = nil,
+        footer = "Sequence trains from the editor pane and clear every goal on time.",
+        timeLimit = timeLimit,
         junctions = orderedJunctions,
         edges = edges,
         trains = trains,

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -33,6 +33,7 @@ function Game.new()
     self.availableMaps = {}
     self.currentMapDescriptor = nil
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
 
     self:updateRenderTransform()
     self:refreshMaps()
@@ -71,18 +72,21 @@ end
 function Game:openMenu()
     self.screen = "menu"
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
     self:refreshMaps()
 end
 
 function Game:openLevelSelect()
     self.screen = "level_select"
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
     self:refreshMaps()
 end
 
 function Game:openEditorBlank()
     self.screen = "editor"
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
     self.editor:resetFromMap(nil, nil)
 end
 
@@ -96,6 +100,7 @@ function Game:openEditorMap(mapDescriptor)
 
     self.screen = "editor"
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
     self.editor:resetFromMap(mapData, mapDescriptor)
     return true
 end
@@ -122,6 +127,7 @@ function Game:startMap(mapDescriptor)
     self.failureReason = nil
     self.currentMapDescriptor = mapDescriptor
     self.levelSelectIssue = nil
+    self.resultsSummary = nil
     self.world = world.new(self.viewport.w, self.viewport.h, mapData.level)
     self.screen = "play"
     return true
@@ -139,24 +145,36 @@ function Game:isRunLocked()
     return self.levelComplete or self.failureReason ~= nil
 end
 
+function Game:openResults()
+    if not self.world then
+        return
+    end
+
+    self.resultsSummary = self.world:getRunSummary()
+    self.failureReason = self.resultsSummary.endReason == "level_clear" and nil or self.resultsSummary.endReason
+    self.levelComplete = self.resultsSummary.endReason == "level_clear"
+    self.screen = "results"
+end
+
 function Game:update(dt)
     if self.screen == "editor" then
         self.editor:update(dt)
         return
     end
 
-    if self.screen ~= "play" or not self.world then
+    if (self.screen ~= "play" and self.screen ~= "results") or not self.world then
         return
     end
 
-    if self:isRunLocked() then
+    if self.screen == "results" or self:isRunLocked() then
         return
     end
 
     self.world:update(dt)
     self.failureReason = self.world:getFailureReason()
-    if not self.failureReason then
-        self.levelComplete = self.world:isLevelComplete()
+    self.levelComplete = self.world:isLevelComplete()
+    if self.failureReason or self.levelComplete then
+        self:openResults()
     end
 end
 
@@ -173,6 +191,8 @@ function Game:draw()
         ui.drawLevelSelect(self)
     elseif self.screen == "editor" then
         self.editor:draw(self)
+    elseif self.screen == "results" then
+        ui.drawResults(self)
     elseif self.screen == "play" and self.world then
         self.world:draw()
         ui.drawPlay(self)
@@ -238,6 +258,21 @@ function Game:keypressed(key)
 
         if key == "tab" then
             self:openMenu()
+        end
+        return
+    end
+
+    if self.screen == "results" then
+        if key == "m" then
+            self:openMenu()
+            return
+        end
+        if (key == "e" or key == "tab") and self.currentMapDescriptor then
+            self:openEditorMap(self.currentMapDescriptor)
+            return
+        end
+        if key == "r" or key == "return" or key == "space" then
+            self:restart()
         end
         return
     end
@@ -329,6 +364,26 @@ function Game:mousepressed(x, y, button)
         return
     end
 
+    if self.screen == "results" then
+        if button ~= 1 then
+            return
+        end
+
+        local hit = ui.getResultsHit(self, viewportX, viewportY)
+        if not hit then
+            return
+        end
+
+        if hit == "replay" then
+            self:restart()
+        elseif hit == "menu" then
+            self:openMenu()
+        elseif hit == "editor" and self.currentMapDescriptor then
+            self:openEditorMap(self.currentMapDescriptor)
+        end
+        return
+    end
+
     if self.screen ~= "play" or not self.world then
         return
     end
@@ -339,11 +394,6 @@ function Game:mousepressed(x, y, button)
 
     if ui.getPlayBackHit(self, viewportX, viewportY) then
         self:openMenu()
-        return
-    end
-
-    if self:isRunLocked() then
-        self:restart()
         return
     end
 

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -365,6 +365,13 @@ function Game:mousereleased(x, y, button)
     end
 end
 
+function Game:wheelmoved(screenX, screenY)
+    if self.screen == "editor" then
+        return self.editor:wheelmoved(screenX, screenY)
+    end
+    return false
+end
+
 function Game:keyreleased(_)
 end
 

--- a/src/game/main.lua
+++ b/src/game/main.lua
@@ -44,6 +44,10 @@ function love.mousereleased(x, y, button)
     game:mousereleased(x, y, button)
 end
 
+function love.wheelmoved(x, y)
+    game:wheelmoved(x, y)
+end
+
 function love.gamepadpressed(joystick, button)
     game:gamepadpressed(joystick, button)
 end

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -5,6 +5,8 @@ local mapEditor = {}
 mapEditor.__index = mapEditor
 
 local DEFAULT_CONTROL = "direct"
+local DEFAULT_TRAIN_WAGONS = 4
+local LEGACY_TRAIN_SPEED = 168
 local CONTROL_ORDER = { "direct", "delayed", "pump" }
 local CONTROL_LABELS = {
     direct = "D",
@@ -23,6 +25,34 @@ local COLOR_OPTIONS = {
     { id = "rose", label = "Rose", color = { 0.98, 0.48, 0.62 } },
     { id = "orange", label = "Orange", color = { 0.98, 0.7, 0.28 } },
     { id = "violet", label = "Violet", color = { 0.82, 0.56, 0.98 } },
+}
+local SAO_CAST = {
+    "Kirito",
+    "Asuna",
+    "Klein",
+    "Agil",
+    "Silica",
+    "Lisbeth",
+    "Sinon",
+    "Leafa",
+    "Yuuki",
+    "Alice",
+    "Eugeo",
+    "Yui",
+    "Sachi",
+    "Argo",
+    "Heathcliff",
+    "Bercouli",
+    "Fanatio",
+    "Tiese",
+    "Ronie",
+    "Liena",
+    "Selka",
+    "Suguha",
+    "Keiko",
+    "Shino",
+    "Andrew",
+    "Rinko",
 }
 
 local DEFAULT_CONTROL_CONFIGS = {
@@ -162,6 +192,28 @@ local function getColorById(colorId)
     return COLOR_OPTIONS[1].color
 end
 
+local function getColorOrderIndex(colorId)
+    for index, option in ipairs(COLOR_OPTIONS) do
+        if option.id == colorId then
+            return index
+        end
+    end
+    return #COLOR_OPTIONS + 1
+end
+
+local function roundStep(value, step)
+    local divisor = step or 1
+    return math.floor((value / divisor) + 0.5) * divisor
+end
+
+local function copyArray(source)
+    local copy = {}
+    for _, value in ipairs(source or {}) do
+        copy[#copy + 1] = value
+    end
+    return copy
+end
+
 local function nearestColorId(color)
     if not color then
         return COLOR_OPTIONS[1].id
@@ -292,6 +344,13 @@ function mapEditor.new(viewportW, viewportH, level)
     self.statusTimer = 0
     self.intersections = {}
     self.importedJunctionState = {}
+    self.trains = {}
+    self.nextTrainId = 1
+    self.timeLimit = nil
+    self.sidePanelMode = "default"
+    self.sequencerScroll = 0
+    self.activeTextField = nil
+    self.sequencerScrollDrag = nil
 
     self:updateLayout()
     self:resetFromMap(level and { level = level, name = level.title } or nil, nil)
@@ -321,6 +380,170 @@ end
 function mapEditor:clearSelection()
     self.selectedRouteId = nil
     self.selectedPointIndex = nil
+end
+
+function mapEditor:generateTrainId()
+    local trainId = "train_" .. self.nextTrainId
+    self.nextTrainId = self.nextTrainId + 1
+    return trainId
+end
+
+function mapEditor:createTrainDefinition(definition)
+    local trainId = definition and definition.id or self:generateTrainId()
+    local train = {
+        id = trainId,
+        lineColor = (definition and definition.lineColor) or COLOR_OPTIONS[1].id,
+        trainColor = (definition and definition.trainColor) or ((definition and definition.lineColor) or COLOR_OPTIONS[1].id),
+        spawnTime = math.max(0, roundStep((definition and definition.spawnTime) or 0, 0.5)),
+        wagonCount = math.max(1, math.floor((definition and definition.wagonCount) or DEFAULT_TRAIN_WAGONS)),
+        deadline = definition and definition.deadline or nil,
+        collapsed = definition and definition.collapsed == true or false,
+    }
+
+    if definition and definition.deadline ~= nil then
+        train.deadline = math.max(0, roundStep(definition.deadline, 0.5))
+    end
+
+    return train
+end
+
+function mapEditor:getSortedTrainEntries()
+    local entries = {}
+
+    for trainIndex, train in ipairs(self.trains) do
+        entries[#entries + 1] = {
+            train = train,
+            trainIndex = trainIndex,
+        }
+    end
+
+    table.sort(entries, function(a, b)
+        if math.abs((a.train.spawnTime or 0) - (b.train.spawnTime or 0)) > 0.0001 then
+            return (a.train.spawnTime or 0) < (b.train.spawnTime or 0)
+        end
+        local firstColorIndex = getColorOrderIndex(a.train.trainColor)
+        local secondColorIndex = getColorOrderIndex(b.train.trainColor)
+        if firstColorIndex ~= secondColorIndex then
+            return firstColorIndex < secondColorIndex
+        end
+        return tostring(a.train.id) < tostring(b.train.id)
+    end)
+
+    for entryIndex, entry in ipairs(entries) do
+        entry.castName = SAO_CAST[((entryIndex - 1) % #SAO_CAST) + 1]
+    end
+
+    return entries
+end
+
+function mapEditor:getAvailableLineColorIds()
+    local lookup = {}
+    local colors = {}
+
+    for _, endpoint in ipairs(self.endpoints) do
+        if endpoint.kind == "input" then
+            for _, colorId in ipairs(lookupToSortedIds(endpoint.colors)) do
+                if not lookup[colorId] then
+                    lookup[colorId] = true
+                    colors[#colors + 1] = colorId
+                end
+            end
+        end
+    end
+
+    for _, train in ipairs(self.trains) do
+        if train.lineColor and not lookup[train.lineColor] then
+            lookup[train.lineColor] = true
+            colors[#colors + 1] = train.lineColor
+        end
+    end
+
+    table.sort(colors, function(a, b)
+        return getColorOrderIndex(a) < getColorOrderIndex(b)
+    end)
+
+    if #colors == 0 then
+        colors[1] = COLOR_OPTIONS[1].id
+    end
+
+    return colors
+end
+
+function mapEditor:cycleColorValue(currentColor, availableColors, direction)
+    local options = availableColors or {}
+    if #options == 0 then
+        return currentColor
+    end
+
+    local currentIndex = 1
+    for colorIndex, colorId in ipairs(options) do
+        if colorId == currentColor then
+            currentIndex = colorIndex
+            break
+        end
+    end
+
+    local nextIndex = currentIndex + direction
+    if nextIndex < 1 then
+        nextIndex = #options
+    elseif nextIndex > #options then
+        nextIndex = 1
+    end
+    return options[nextIndex]
+end
+
+function mapEditor:clampSequencerScroll()
+    local entries = self:getSortedTrainEntries()
+    local backRect = self:getSequencerBackButtonRect()
+    local listHeight = backRect.y - (self.sidePanel.y + 192) - 12
+    local totalHeight = 0
+    for _, entry in ipairs(entries) do
+        totalHeight = totalHeight + self:getTrainRowHeight(entry.train) + 8
+    end
+    if totalHeight > 0 then
+        totalHeight = totalHeight - 8
+    end
+    self.sequencerScroll = clamp(self.sequencerScroll or 0, 0, math.max(0, totalHeight - listHeight))
+end
+
+function mapEditor:addTrain()
+    local lineColors = self:getAvailableLineColorIds()
+    local spawnTime = 0
+    for _, train in ipairs(self.trains) do
+        spawnTime = math.max(spawnTime, (train.spawnTime or 0) + 0.5)
+    end
+    self.trains[#self.trains + 1] = self:createTrainDefinition({
+        lineColor = lineColors[1],
+        trainColor = lineColors[1],
+        spawnTime = spawnTime,
+        wagonCount = DEFAULT_TRAIN_WAGONS,
+    })
+    self:clampSequencerScroll()
+    self:refreshValidation()
+    self:showStatus("Train added to the sequencer.")
+end
+
+function mapEditor:getTrainRowHeight(_)
+    return 38
+end
+
+function mapEditor:removeTrainByIndex(trainIndex)
+    if not self.trains[trainIndex] then
+        return
+    end
+    table.remove(self.trains, trainIndex)
+    self:clampSequencerScroll()
+    self:refreshValidation()
+    self:showStatus("Train removed from the sequencer.")
+end
+
+function mapEditor:getTrainById(trainId)
+    for _, train in ipairs(self.trains) do
+        if train.id == trainId then
+            return train
+        end
+    end
+    return nil
 end
 
 function mapEditor:getSelectedRoute()
@@ -491,7 +714,7 @@ function mapEditor:getOpenButtonRect()
     }
 end
 
-function mapEditor:getCopyButtonRect()
+function mapEditor:getSequencerButtonRect()
     return {
         x = self.sidePanel.x + 18,
         y = self.sidePanel.y + self.sidePanel.h - 110,
@@ -506,6 +729,112 @@ function mapEditor:getResetButtonRect()
         y = self.sidePanel.y + self.sidePanel.h - 60,
         w = self.sidePanel.w - 36,
         h = 38,
+    }
+end
+
+function mapEditor:getSequencerBackButtonRect()
+    return self:getResetButtonRect()
+end
+
+function mapEditor:getSequencerAddButtonRect()
+    return {
+        x = self.sidePanel.x + 18,
+        y = self.sidePanel.y + 126,
+        w = self.sidePanel.w - 36,
+        h = 34,
+    }
+end
+
+function mapEditor:getSequencerLayout()
+    local panelX = self.sidePanel.x + 18
+    local panelWidth = self.sidePanel.w - 36
+    local backRect = self:getSequencerBackButtonRect()
+    local sortedEntries = self:getSortedTrainEntries()
+    local listHeaderRect = {
+        x = panelX,
+        y = self.sidePanel.y + 170,
+        w = panelWidth,
+        h = 18,
+    }
+    local listRect = {
+        x = panelX,
+        y = self.sidePanel.y + 192,
+        w = panelWidth,
+        h = backRect.y - (self.sidePanel.y + 192) - 12,
+    }
+    local totalContentHeight = 0
+    for _, entry in ipairs(sortedEntries) do
+        totalContentHeight = totalContentHeight + self:getTrainRowHeight(entry.train) + 8
+    end
+    if totalContentHeight > 0 then
+        totalContentHeight = totalContentHeight - 8
+    end
+    local maxScroll = math.max(0, totalContentHeight - listRect.h)
+    self.sequencerScroll = clamp(self.sequencerScroll or 0, 0, maxScroll)
+
+    local scrollbar = nil
+    local contentWidth = panelWidth
+    if maxScroll > 0 then
+        local track = {
+            x = panelX + panelWidth - 8,
+            y = listRect.y,
+            w = 8,
+            h = listRect.h,
+        }
+        local thumbHeight = math.max(28, track.h * (listRect.h / math.max(totalContentHeight, listRect.h)))
+        local thumbY = track.y + (track.h - thumbHeight) * ((self.sequencerScroll or 0) / maxScroll)
+        scrollbar = {
+            track = track,
+            thumb = {
+                x = track.x,
+                y = thumbY,
+                w = track.w,
+                h = thumbHeight,
+            },
+            maxScroll = maxScroll,
+        }
+        contentWidth = panelWidth - 16
+    end
+
+    self:clampSequencerScroll()
+
+    local rows = {}
+    local currentY = listRect.y - (self.sequencerScroll or 0)
+    for _, entry in ipairs(sortedEntries) do
+        local rowHeight = self:getTrainRowHeight(entry.train)
+        local rowRect = {
+            x = panelX,
+            y = currentY,
+            w = contentWidth,
+            h = rowHeight,
+        }
+        if rowRect.y + rowRect.h >= listRect.y and rowRect.y <= listRect.y + listRect.h then
+            rows[#rows + 1] = {
+                entry = entry,
+                rect = rowRect,
+            }
+        end
+        currentY = currentY + rowHeight + 8
+    end
+
+    return {
+        panelX = panelX,
+        panelWidth = panelWidth,
+        sortedEntries = sortedEntries,
+        mapDeadlineRect = {
+            x = panelX,
+            y = self.sidePanel.y + 74,
+            w = panelWidth,
+            h = 32,
+        },
+        addRect = self:getSequencerAddButtonRect(),
+        listHeaderRect = listHeaderRect,
+        listRect = listRect,
+        totalContentHeight = totalContentHeight,
+        maxScroll = maxScroll,
+        scrollbar = scrollbar,
+        rows = rows,
+        backRect = backRect,
     }
 end
 
@@ -536,10 +865,21 @@ end
 function mapEditor:openColorPicker(route, magnetKind)
     local point = magnetKind == "start" and route.points[1] or route.points[#route.points]
     self.colorPicker = {
+        mode = "route",
         routeId = route.id,
         magnetKind = magnetKind,
         anchorX = point.x,
         anchorY = point.y,
+    }
+end
+
+function mapEditor:openSequencerColorPicker(trainId, fieldName, anchorX, anchorY)
+    self.colorPicker = {
+        mode = "sequencer",
+        trainId = trainId,
+        fieldName = fieldName,
+        anchorX = anchorX,
+        anchorY = anchorY,
     }
 end
 
@@ -549,8 +889,8 @@ function mapEditor:getColorPickerLayout()
     end
 
     local rect = {
-        w = 196,
-        h = 146,
+        w = 154,
+        h = 110,
     }
     rect.x = clamp(
         self.colorPicker.anchorX + 18,
@@ -566,9 +906,9 @@ function mapEditor:getColorPickerLayout()
     local swatches = {}
     local columns = 3
     local swatchSize = 34
-    local gap = 12
+    local gap = 10
     local startX = rect.x + 16
-    local startY = rect.y + 52
+    local startY = rect.y + 16
 
     for index, option in ipairs(COLOR_OPTIONS) do
         local column = (index - 1) % columns
@@ -577,7 +917,7 @@ function mapEditor:getColorPickerLayout()
             option = option,
             rect = {
                 x = startX + column * (swatchSize + gap),
-                y = startY + row * (swatchSize + 28),
+                y = startY + row * (swatchSize + gap),
                 w = swatchSize,
                 h = swatchSize,
             },
@@ -621,11 +961,68 @@ function mapEditor:getDialogRect()
     }
 end
 
+function mapEditor:synthesizeTrainsFromLevel(levelData)
+    local trains = {}
+    local sourceTrains = levelData and levelData.trains or {}
+
+    for _, trainDefinition in ipairs(sourceTrains) do
+        local lineColor = trainDefinition.lineColor
+        if not lineColor and trainDefinition.edgeId and levelData and levelData.edges then
+            for _, edgeDefinition in ipairs(levelData.edges or {}) do
+                if edgeDefinition.id == trainDefinition.edgeId then
+                    lineColor = (edgeDefinition.colors or {})[1] or nearestColorId(edgeDefinition.color)
+                    break
+                end
+            end
+        end
+
+        if not lineColor and trainDefinition.junctionId and levelData then
+            for _, junctionDefinition in ipairs(levelData.junctions or {}) do
+                if junctionDefinition.id == trainDefinition.junctionId then
+                    local inputDefinition = (junctionDefinition.inputs or {})[trainDefinition.inputIndex or trainDefinition.branchIndex or 1]
+                    if inputDefinition then
+                        lineColor = (inputDefinition.colors or {})[1] or nearestColorId(inputDefinition.color)
+                    end
+                    break
+                end
+            end
+        end
+
+        local trainColor = trainDefinition.goalColor
+            or trainDefinition.trainColor
+            or nearestColorId(trainDefinition.color)
+            or lineColor
+            or COLOR_OPTIONS[1].id
+
+        local spawnTime = trainDefinition.spawnTime
+        if spawnTime == nil then
+            local speedScale = trainDefinition.speedScale or 1
+            local speed = LEGACY_TRAIN_SPEED * speedScale
+            spawnTime = trainDefinition.progress and trainDefinition.progress < 0
+                and math.abs(trainDefinition.progress) / math.max(1, speed)
+                or 0
+        end
+
+        trains[#trains + 1] = self:createTrainDefinition({
+            id = trainDefinition.id,
+            lineColor = lineColor or trainColor,
+            trainColor = trainColor,
+            spawnTime = spawnTime,
+            wagonCount = trainDefinition.wagonCount or DEFAULT_TRAIN_WAGONS,
+            deadline = trainDefinition.deadline,
+        })
+    end
+
+    return trains
+end
+
 function mapEditor:getExportData()
     local export = {
+        timeLimit = self.timeLimit,
         endpoints = {},
         routes = {},
         junctions = {},
+        trains = {},
     }
 
     for _, endpoint in ipairs(self.endpoints) do
@@ -682,6 +1079,17 @@ function mapEditor:getExportData()
         export.junctions[#export.junctions + 1] = exportJunction
     end
 
+    for _, train in ipairs(self.trains) do
+        export.trains[#export.trains + 1] = {
+            id = train.id,
+            lineColor = train.lineColor,
+            trainColor = train.trainColor,
+            spawnTime = train.spawnTime,
+            wagonCount = train.wagonCount,
+            deadline = train.deadline,
+        }
+    end
+
     return export
 end
 
@@ -691,10 +1099,16 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
     self.routes = {}
     self.nextEndpointId = 1
     self.nextRouteId = 1
+    self.nextTrainId = 1
     self.importedJunctionState = {}
     self.drag = nil
     self.currentMapName = mapName
     self.sourceInfo = sourceInfo
+    self.timeLimit = (editorData and editorData.timeLimit) or (levelData and levelData.timeLimit) or nil
+    self.sidePanelMode = "default"
+    self.sequencerScroll = 0
+    self.activeTextField = nil
+    self.sequencerScrollDrag = nil
     self:closeDialog()
     self:closeColorPicker()
     self:clearSelection()
@@ -747,6 +1161,23 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
             inputEndpointIds = junctionData.inputEndpointIds,
             outputEndpointIds = junctionData.outputEndpointIds,
         }
+    end
+
+    self.trains = {}
+    local trainSource = (editorData or {}).trains
+    if trainSource and #trainSource > 0 then
+        for _, trainDefinition in ipairs(trainSource) do
+            self.trains[#self.trains + 1] = self:createTrainDefinition(trainDefinition)
+        end
+    else
+        self.trains = self:synthesizeTrainsFromLevel(levelData)
+    end
+
+    for _, train in ipairs(self.trains) do
+        local numericId = tonumber((train.id or ""):match("train_(%d+)$"))
+        if numericId and numericId >= self.nextTrainId then
+            self.nextTrainId = numericId + 1
+        end
     end
 
     self:rebuildIntersections()
@@ -909,10 +1340,17 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
         self.currentMapName = nil
         self.endpoints = {}
         self.routes = {}
+        self.trains = {}
+        self.timeLimit = nil
         self.nextEndpointId = 1
         self.nextRouteId = 1
+        self.nextTrainId = 1
         self.importedJunctionState = {}
         self.drag = nil
+        self.sidePanelMode = "default"
+        self.sequencerScroll = 0
+        self.activeTextField = nil
+        self.sequencerScrollDrag = nil
         self:closeColorPicker()
         self:clearSelection()
         self:rebuildIntersections()
@@ -934,12 +1372,26 @@ function mapEditor:resetFromLevel(level)
     self.currentMapName = level and level.title or nil
     self.endpoints = {}
     self.routes = {}
+    self.trains = self:synthesizeTrainsFromLevel(level)
+    self.timeLimit = level and level.timeLimit or nil
     self.nextEndpointId = 1
     self.nextRouteId = 1
+    self.nextTrainId = 1
     self.importedJunctionState = {}
     self.drag = nil
+    self.sidePanelMode = "default"
+    self.sequencerScroll = 0
+    self.activeTextField = nil
+    self.sequencerScrollDrag = nil
     self:closeColorPicker()
     self:clearSelection()
+
+    for _, train in ipairs(self.trains) do
+        local numericId = tonumber((train.id or ""):match("train_(%d+)$"))
+        if numericId and numericId >= self.nextTrainId then
+            self.nextTrainId = numericId + 1
+        end
+    end
 
     if not level then
         self:rebuildIntersections()
@@ -1522,6 +1974,106 @@ function mapEditor:mergeEndpointInto(route, magnetKind, targetEndpoint)
     return true
 end
 
+function mapEditor:getActiveTextFieldValue(kind, targetId, fieldName, fallback)
+    local field = self.activeTextField
+    if field
+        and field.kind == kind
+        and field.targetId == targetId
+        and field.fieldName == fieldName then
+        return field.buffer
+    end
+    return fallback
+end
+
+function mapEditor:openTextField(kind, targetId, fieldName, buffer, valueType)
+    self.activeTextField = {
+        kind = kind,
+        targetId = targetId,
+        fieldName = fieldName,
+        buffer = buffer or "",
+        valueType = valueType,
+    }
+end
+
+function mapEditor:cancelTextField()
+    self.activeTextField = nil
+end
+
+function mapEditor:commitTextField()
+    local field = self.activeTextField
+    if not field then
+        return false
+    end
+
+    local target = nil
+    if field.kind == "map" then
+        target = self
+    elseif field.kind == "train" then
+        target = self:getTrainById(field.targetId)
+    end
+
+    if not target then
+        self.activeTextField = nil
+        return false
+    end
+
+    local rawValue = field.buffer or ""
+    local trimmedValue = rawValue:gsub("^%s+", ""):gsub("%s+$", "")
+    local changed = false
+
+    if trimmedValue == "" then
+        if field.valueType == "optional_float" then
+            target[field.fieldName] = nil
+            changed = true
+        end
+    else
+        local numericValue = tonumber(trimmedValue)
+        if numericValue then
+            if field.valueType == "int" then
+                numericValue = math.max(1, math.floor(numericValue))
+            else
+                numericValue = math.max(0, numericValue)
+            end
+            target[field.fieldName] = numericValue
+            changed = true
+        end
+    end
+
+    if field.kind == "train" and target.deadline ~= nil and target.deadline < target.spawnTime then
+        target.deadline = target.spawnTime
+    end
+
+    self.activeTextField = nil
+
+    if changed then
+        self:refreshValidation()
+        self:showStatus("Sequencer updated.")
+    end
+
+    return changed
+end
+
+function mapEditor:appendTextFieldInput(text)
+    local field = self.activeTextField
+    if not field then
+        return
+    end
+
+    local filtered = {}
+    for index = 1, #text do
+        local character = text:sub(index, index)
+        if character:match("%d") then
+            filtered[#filtered + 1] = character
+        elseif character == "." and field.valueType ~= "int" and not field.buffer:find("%.", 1, true) then
+            filtered[#filtered + 1] = character
+        end
+    end
+
+    if #filtered > 0 then
+        field.buffer = field.buffer .. table.concat(filtered)
+    end
+end
+
 function mapEditor:handleColorPickerClick(x, y, button)
     local layout = self:getColorPickerLayout()
     if not layout then
@@ -1533,14 +2085,25 @@ function mapEditor:handleColorPickerClick(x, y, button)
         return false
     end
 
-    local route = self:getSelectedRoute()
-    if not route or route.id ~= self.colorPicker.routeId then
-        self:closeColorPicker()
-        return true
-    end
-
     for _, swatch in ipairs(layout.swatches) do
         if pointInRect(x, y, swatch.rect) then
+            if self.colorPicker.mode == "sequencer" then
+                local train = self:getTrainById(self.colorPicker.trainId)
+                if train then
+                    train[self.colorPicker.fieldName] = swatch.option.id
+                    self:refreshValidation()
+                    self:showStatus("Sequencer updated.")
+                end
+                self:closeColorPicker()
+                return true
+            end
+
+            local route = self:getSelectedRoute()
+            if not route or route.id ~= self.colorPicker.routeId then
+                self:closeColorPicker()
+                return true
+            end
+
             if button == 2 then
                 self:splitEndpointColor(route, self.colorPicker.magnetKind, swatch.option.id)
             else
@@ -1551,6 +2114,140 @@ function mapEditor:handleColorPickerClick(x, y, button)
     end
 
     return true
+end
+
+function mapEditor:getTextFieldRect(x, y, width)
+    return {
+        x = x,
+        y = y,
+        w = width,
+        h = 26,
+    }
+end
+
+function mapEditor:getSequencerSummaryRects(rowRect)
+    local x = rowRect.x + 8
+    local y = rowRect.y + 8
+    local gap = 4
+
+    local startRect = { x = x, y = y, w = 34, h = 18 }
+    local nameRect = { x = startRect.x + startRect.w + gap, y = y, w = 60, h = 18 }
+    local lineRect = { x = nameRect.x + nameRect.w + gap, y = y, w = 16, h = 16 }
+    local goalRect = { x = lineRect.x + lineRect.w + gap, y = y, w = 16, h = 16 }
+    local wagonsRect = { x = goalRect.x + goalRect.w + gap, y = y, w = 30, h = 18 }
+    local removeRect = { x = rowRect.x + rowRect.w - 20, y = rowRect.y + 8, w = 16, h = 16 }
+    local deadlineRect = {
+        x = wagonsRect.x + wagonsRect.w + gap,
+        y = y,
+        w = math.max(42, removeRect.x - gap - (wagonsRect.x + wagonsRect.w + gap)),
+        h = 18,
+    }
+
+    return {
+        start = startRect,
+        name = nameRect,
+        lineChip = lineRect,
+        goalChip = goalRect,
+        wagons = wagonsRect,
+        deadline = deadlineRect,
+        remove = removeRect,
+    }
+end
+
+function mapEditor:getSequencerRowControlRects(rowRect)
+    return {
+        summary = self:getSequencerSummaryRects(rowRect),
+    }
+end
+
+function mapEditor:handleSequencerClick(x, y, button)
+    local layout = self:getSequencerLayout()
+    local deadlineRect = layout.mapDeadlineRect
+
+    if self.colorPicker then
+        self:closeColorPicker()
+    end
+
+    if pointInRect(x, y, layout.backRect) then
+        self:commitTextField()
+        self.sidePanelMode = "default"
+        self:showStatus("Returned to the map editor pane.")
+        return true
+    end
+
+    if pointInRect(x, y, layout.addRect) then
+        self:commitTextField()
+        self:addTrain()
+        return true
+    end
+
+    if pointInRect(x, y, deadlineRect) then
+        self:commitTextField()
+        self:openTextField("map", "map", "timeLimit", self.timeLimit and tostring(self.timeLimit) or "", "optional_float")
+        return true
+    end
+
+    if layout.scrollbar and pointInRect(x, y, layout.scrollbar.thumb) then
+        self:commitTextField()
+        self.sequencerScrollDrag = {
+            offsetY = y - layout.scrollbar.thumb.y,
+            track = layout.scrollbar.track,
+            thumbHeight = layout.scrollbar.thumb.h,
+            maxScroll = layout.scrollbar.maxScroll,
+        }
+        return true
+    end
+
+    if layout.scrollbar and pointInRect(x, y, layout.scrollbar.track) then
+        self:commitTextField()
+        local thumbTravel = math.max(1, layout.scrollbar.track.h - layout.scrollbar.thumb.h)
+        local targetY = clamp(y - layout.scrollbar.thumb.h * 0.5, layout.scrollbar.track.y, layout.scrollbar.track.y + thumbTravel)
+        self.sequencerScroll = ((targetY - layout.scrollbar.track.y) / thumbTravel) * layout.scrollbar.maxScroll
+        return true
+    end
+
+    for _, row in ipairs(layout.rows) do
+        local train = row.entry.train
+        local controls = self:getSequencerRowControlRects(row.rect)
+        if pointInRect(x, y, controls.summary.remove) then
+            self:commitTextField()
+            self:removeTrainByIndex(row.entry.trainIndex)
+            return true
+        end
+
+        if pointInRect(x, y, controls.summary.lineChip) then
+            self:commitTextField()
+            self:openSequencerColorPicker(train.id, "lineColor", controls.summary.lineChip.x, controls.summary.lineChip.y)
+            return true
+        end
+
+        if pointInRect(x, y, controls.summary.goalChip) then
+            self:commitTextField()
+            self:openSequencerColorPicker(train.id, "trainColor", controls.summary.goalChip.x, controls.summary.goalChip.y)
+            return true
+        end
+
+        if pointInRect(x, y, controls.summary.start) then
+            self:commitTextField()
+            self:openTextField("train", train.id, "spawnTime", tostring(train.spawnTime or 0), "float")
+            return true
+        end
+
+        if pointInRect(x, y, controls.summary.wagons) then
+            self:commitTextField()
+            self:openTextField("train", train.id, "wagonCount", tostring(train.wagonCount or DEFAULT_TRAIN_WAGONS), "int")
+            return true
+        end
+
+        if pointInRect(x, y, controls.summary.deadline) then
+            self:commitTextField()
+            self:openTextField("train", train.id, "deadline", train.deadline and tostring(train.deadline) or "", "optional_float")
+            return true
+        end
+    end
+
+    self:commitTextField()
+    return pointInRect(x, y, self.sidePanel)
 end
 
 function mapEditor:handleDialogClick(x, y)
@@ -1588,16 +2285,25 @@ function mapEditor:handleDialogClick(x, y)
     return true
 end
 
-function mapEditor:copyToClipboard()
-    love.system.setClipboardText(self:serialize())
-    self:showStatus("Editor data copied to the clipboard.")
-end
-
 function mapEditor:keypressed(key)
     if key == "escape" then
         if self.dialog then
             self:closeDialog()
             self:showStatus("Dialog closed.")
+            return true
+        end
+        if self.activeTextField then
+            self:cancelTextField()
+            self:showStatus("Text edit cancelled.")
+            return true
+        end
+        if self.colorPicker then
+            self:closeColorPicker()
+            return true
+        end
+        if self.sidePanelMode == "sequencer" then
+            self.sidePanelMode = "default"
+            self:showStatus("Returned to the map editor pane.")
             return true
         end
         return false
@@ -1624,27 +2330,46 @@ function mapEditor:keypressed(key)
         return true
     end
 
+    if self.activeTextField then
+        if key == "backspace" then
+            if #self.activeTextField.buffer > 0 then
+                self.activeTextField.buffer = string.sub(self.activeTextField.buffer, 1, #self.activeTextField.buffer - 1)
+            end
+            return true
+        end
+
+        if key == "return" or key == "kpenter" then
+            self:commitTextField()
+            return true
+        end
+    end
+
     if key == "delete" or key == "backspace" then
         self:deleteSelection()
         return true
     end
 
     if key == "s" then
+        self:commitTextField()
         self:openSaveDialog()
         return true
     end
 
     if key == "o" then
+        self:commitTextField()
         self:openOpenDialog()
         return true
     end
 
     if key == "c" then
-        self:copyToClipboard()
+        self:commitTextField()
+        self.sidePanelMode = self.sidePanelMode == "sequencer" and "default" or "sequencer"
+        self:showStatus(self.sidePanelMode == "sequencer" and "Sequencer opened." or "Returned to the map editor pane.")
         return true
     end
 
     if key == "r" then
+        self:commitTextField()
         self:resetFromMap(self.loadedMapPayload, self.sourceInfo)
         self:showStatus("Editor reset to the current map.")
         return true
@@ -1656,6 +2381,8 @@ end
 function mapEditor:textinput(text)
     if self.dialog and self.dialog.type == "save" then
         self.dialog.input = self.dialog.input .. text
+    elseif self.activeTextField then
+        self:appendTextFieldInput(text)
     end
 end
 
@@ -1666,6 +2393,10 @@ function mapEditor:mousepressed(x, y, button)
 
     if self.dialog and self:handleDialogClick(x, y) then
         return true
+    end
+
+    if self.activeTextField and not pointInRect(x, y, self.sidePanel) then
+        self:commitTextField()
     end
 
     if self.colorPicker and self:handleColorPickerClick(x, y, button) then
@@ -1683,6 +2414,10 @@ function mapEditor:mousepressed(x, y, button)
         return false
     end
 
+    if self.sidePanelMode == "sequencer" and self:handleSequencerClick(x, y, button) then
+        return true
+    end
+
     if pointInRect(x, y, self:getSaveButtonRect()) then
         self:openSaveDialog()
         return true
@@ -1693,8 +2428,9 @@ function mapEditor:mousepressed(x, y, button)
         return true
     end
 
-    if pointInRect(x, y, self:getCopyButtonRect()) then
-        self:copyToClipboard()
+    if pointInRect(x, y, self:getSequencerButtonRect()) then
+        self.sidePanelMode = "sequencer"
+        self:showStatus("Sequencer opened.")
         return true
     end
 
@@ -1767,7 +2503,34 @@ function mapEditor:mousepressed(x, y, button)
     return false
 end
 
+function mapEditor:wheelmoved(_, y)
+    if self.sidePanelMode ~= "sequencer" then
+        return false
+    end
+
+    local layout = self:getSequencerLayout()
+    if layout.maxScroll <= 0 then
+        return false
+    end
+
+    if y > 0 then
+        self.sequencerScroll = math.max(0, (self.sequencerScroll or 0) - 40)
+    elseif y < 0 then
+        self.sequencerScroll = math.min(layout.maxScroll, (self.sequencerScroll or 0) + 40)
+    end
+
+    return true
+end
+
 function mapEditor:mousemoved(x, y)
+    if self.sequencerScrollDrag then
+        local drag = self.sequencerScrollDrag
+        local thumbTravel = math.max(1, drag.track.h - drag.thumbHeight)
+        local thumbY = clamp(y - drag.offsetY, drag.track.y, drag.track.y + thumbTravel)
+        self.sequencerScroll = ((thumbY - drag.track.y) / thumbTravel) * drag.maxScroll
+        return true
+    end
+
     if not self.drag then
         return false
     end
@@ -1777,7 +2540,16 @@ function mapEditor:mousemoved(x, y)
 end
 
 function mapEditor:mousereleased(x, y, button)
-    if button ~= 1 or not self.drag then
+    if button ~= 1 then
+        return false
+    end
+
+    if self.sequencerScrollDrag then
+        self.sequencerScrollDrag = nil
+        return true
+    end
+
+    if not self.drag then
         return false
     end
 
@@ -1816,6 +2588,7 @@ end
 function mapEditor:serialize()
     local lines = {
         "return {",
+        string.format("    timeLimit = %s,", self.timeLimit and formatNumber(self.timeLimit) or "nil"),
         "    endpoints = {",
     }
 
@@ -1852,6 +2625,20 @@ function mapEditor:serialize()
             )
         end
         lines[#lines + 1] = "            },"
+        lines[#lines + 1] = "        },"
+    end
+
+    lines[#lines + 1] = "    },"
+    lines[#lines + 1] = "    trains = {"
+
+    for _, train in ipairs(self.trains) do
+        lines[#lines + 1] = "        {"
+        lines[#lines + 1] = string.format("            id = %q,", train.id)
+        lines[#lines + 1] = string.format("            lineColor = %q,", train.lineColor)
+        lines[#lines + 1] = string.format("            trainColor = %q,", train.trainColor)
+        lines[#lines + 1] = string.format("            spawnTime = %s,", formatNumber(train.spawnTime))
+        lines[#lines + 1] = string.format("            wagonCount = %d,", train.wagonCount)
+        lines[#lines + 1] = string.format("            deadline = %s,", train.deadline and formatNumber(train.deadline) or "nil")
         lines[#lines + 1] = "        },"
     end
 
@@ -2024,12 +2811,14 @@ end
 
 function mapEditor:drawPanelButton(rect, label, accentColor)
     local graphics = love.graphics
+    local font = graphics.getFont()
     graphics.setColor(0.1, 0.12, 0.16, 0.96)
     graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 12, 12)
+    graphics.setLineWidth(1.5)
     graphics.setColor(accentColor[1], accentColor[2], accentColor[3], 1)
     graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 12, 12)
     graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf(label, rect.x, rect.y + 11, rect.w, "center")
+    graphics.printf(label, rect.x, rect.y + math.floor((rect.h - font:getHeight()) * 0.5), rect.w, "center")
 end
 
 function mapEditor:drawWrappedList(font, items, x, y, width, limitY, color, numberColor)
@@ -2065,29 +2854,29 @@ function mapEditor:drawColorPicker(game)
         return
     end
 
-    local route = self:getSelectedRoute()
-    if not route or route.id ~= self.colorPicker.routeId then
-        return
-    end
-
     local graphics = love.graphics
-    local endpoint = self.colorPicker.magnetKind == "start" and self:getRouteStartEndpoint(route) or self:getRouteEndEndpoint(route)
-    local lookup = endpoint and endpoint.colors or {}
+    local lookup = {}
+
+    if self.colorPicker.mode == "route" then
+        local route = self:getSelectedRoute()
+        if not route or route.id ~= self.colorPicker.routeId then
+            return
+        end
+        local endpoint = self.colorPicker.magnetKind == "start" and self:getRouteStartEndpoint(route) or self:getRouteEndEndpoint(route)
+        lookup = endpoint and endpoint.colors or {}
+    elseif self.colorPicker.mode == "sequencer" then
+        local train = self:getTrainById(self.colorPicker.trainId)
+        if not train then
+            return
+        end
+        lookup[train[self.colorPicker.fieldName]] = true
+    end
 
     graphics.setColor(0.08, 0.1, 0.14, 0.98)
     graphics.rectangle("fill", layout.rect.x, layout.rect.y, layout.rect.w, layout.rect.h, 16, 16)
     graphics.setColor(0.24, 0.32, 0.4, 1)
+    graphics.setLineWidth(1.2)
     graphics.rectangle("line", layout.rect.x, layout.rect.y, layout.rect.w, layout.rect.h, 16, 16)
-
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf(
-        self.colorPicker.magnetKind == "start" and "Allowed Start Colors" or "Allowed Exit Colors",
-        layout.rect.x + 14,
-        layout.rect.y + 14,
-        layout.rect.w - 28,
-        "center"
-    )
 
     for _, swatch in ipairs(layout.swatches) do
         local rect = swatch.rect
@@ -2101,12 +2890,9 @@ function mapEditor:drawColorPicker(game)
 
         if selected then
             graphics.setColor(0.97, 0.98, 1, 1)
-            graphics.setLineWidth(3)
+            graphics.setLineWidth(2)
             graphics.rectangle("line", rect.x - 3, rect.y - 3, rect.w + 6, rect.h + 6, 10, 10)
         end
-
-        graphics.setColor(0.84, 0.88, 0.92, 1)
-        graphics.printf(option.label, rect.x - 14, rect.y + rect.h + 6, rect.w + 28, "center")
     end
 end
 
@@ -2172,53 +2958,171 @@ function mapEditor:drawDialog(game)
     end
 end
 
-function mapEditor:draw(game)
+function mapEditor:drawTextField(label, rect, valueText, accentColor, active)
     local graphics = love.graphics
+    local color = accentColor or { 0.48, 0.92, 0.62 }
 
-    graphics.setColor(0.05, 0.07, 0.09, 1)
-    graphics.rectangle("fill", 0, 0, self.viewport.w, self.viewport.h)
+    graphics.setColor(0.72, 0.78, 0.84, 1)
+    graphics.printf(label, rect.x - 4, rect.y - 17, rect.w + 8, "center")
 
-    graphics.setColor(0.07, 0.09, 0.12, 1)
-    graphics.rectangle("fill", self.canvas.x, self.canvas.y, self.canvas.w, self.canvas.h, 18, 18)
+    graphics.setColor(0.06, 0.08, 0.1, 1)
+    graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 8, 8)
+    graphics.setLineWidth(active and 2 or 1.2)
+    graphics.setColor(color[1], color[2], color[3], 1)
+    graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 8, 8)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(valueText, rect.x + 6, rect.y + 5, rect.w - 12, "left")
+end
 
-    graphics.setColor(0.1, 0.14, 0.18, 0.96)
-    graphics.rectangle("fill", self.canvas.x, self.canvas.y, self.canvas.w, self.spawnBandHeight, 18, 18)
+function mapEditor:drawColorChip(label, rect, colorId, accentColor)
+    local graphics = love.graphics
+    local color = accentColor or getColorById(colorId)
+    local labelWidth = love.graphics.getFont():getWidth(label)
 
-    graphics.setColor(0.25, 0.34, 0.42, 1)
-    graphics.setLineWidth(2)
-    graphics.rectangle("line", self.canvas.x, self.canvas.y, self.canvas.w, self.canvas.h, 18, 18)
+    graphics.setColor(0.72, 0.78, 0.84, 1)
+    graphics.print(label, rect.x - labelWidth - 6, rect.y - 1)
 
-    graphics.setColor(0.16, 0.2, 0.24, 1)
-    graphics.line(
-        self.canvas.x + 16,
-        self.canvas.y + self.spawnBandHeight,
-        self.canvas.x + self.canvas.w - 16,
-        self.canvas.y + self.spawnBandHeight
-    )
+    graphics.setColor(0.06, 0.08, 0.1, 1)
+    graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 5, 5)
+    graphics.setColor(color[1], color[2], color[3], 1)
+    graphics.rectangle("fill", rect.x + 2, rect.y + 2, rect.w - 4, rect.h - 4, 4, 4)
+    graphics.setLineWidth(1.1)
+    graphics.setColor(0.24, 0.32, 0.4, 1)
+    graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 5, 5)
+end
 
-    for _, route in ipairs(self.routes) do
-        self:drawRoute(route, self.selectedRouteId)
-    end
+function mapEditor:drawSequencerSummaryChip(rect, colorId)
+    local graphics = love.graphics
+    local color = getColorById(colorId)
 
-    for _, intersection in ipairs(self.intersections) do
-        self:drawIntersection(intersection)
-    end
+    graphics.setColor(0.06, 0.08, 0.1, 1)
+    graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 4, 4)
+    graphics.setColor(color[1], color[2], color[3], 1)
+    graphics.rectangle("fill", rect.x + 2, rect.y + 2, rect.w - 4, rect.h - 4, 3, 3)
+    graphics.setLineWidth(1)
+    graphics.setColor(0.24, 0.32, 0.4, 1)
+    graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 4, 4)
+end
 
-    self:drawColorPicker(game)
+function mapEditor:drawSequencerSummaryValue(rect, valueText, align)
+    local graphics = love.graphics
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf(valueText or "", rect.x, rect.y + 1, rect.w, align or "center")
+end
 
-    graphics.setColor(0.09, 0.11, 0.15, 0.98)
-    graphics.rectangle("fill", self.sidePanel.x, self.sidePanel.y, self.sidePanel.w, self.sidePanel.h, 18, 18)
-    graphics.setColor(0.22, 0.28, 0.34, 1)
-    graphics.rectangle("line", self.sidePanel.x, self.sidePanel.y, self.sidePanel.w, self.sidePanel.h, 18, 18)
+function mapEditor:drawSequencerInlineField(rect, valueText, accentColor, active)
+    local graphics = love.graphics
+    local color = accentColor or { 0.48, 0.92, 0.62 }
+
+    graphics.setColor(0.06, 0.08, 0.1, 1)
+    graphics.rectangle("fill", rect.x, rect.y - 1, rect.w, rect.h + 2, 6, 6)
+    graphics.setLineWidth(active and 1.8 or 1)
+    graphics.setColor(color[1], color[2], color[3], 1)
+    graphics.rectangle("line", rect.x, rect.y - 1, rect.w, rect.h + 2, 6, 6)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(valueText or "", rect.x + 4, rect.y + 1, rect.w - 8, "center")
+end
+
+function mapEditor:drawSequencer(game)
+    local graphics = love.graphics
+    local layout = self:getSequencerLayout()
+    local mapDeadlineText = self:getActiveTextFieldValue("map", "map", "timeLimit", self.timeLimit and tostring(self.timeLimit) or "")
 
     love.graphics.setFont(game.fonts.title)
     graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.print("Map Editor", self.sidePanel.x + 18, self.sidePanel.y + 20)
+    graphics.print("Train Sequencer", layout.panelX, self.sidePanel.y + 20)
 
     love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.48, 0.92, 0.62, 1)
-    graphics.printf("Esc returns to the main menu", self.sidePanel.x + 18, self.sidePanel.y + 64, self.sidePanel.w - 36)
+    self:drawTextField(
+        "Map Deadline",
+        layout.mapDeadlineRect,
+        mapDeadlineText ~= "" and mapDeadlineText or "",
+        { 0.99, 0.78, 0.32 },
+        self.activeTextField and self.activeTextField.kind == "map"
+    )
+    self:drawPanelButton(layout.addRect, "Add Train", { 0.48, 0.92, 0.62 })
 
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.68, 0.74, 0.8, 1)
+    local header = self:getSequencerSummaryRects(layout.listHeaderRect)
+    graphics.printf("Start", header.start.x - 2, layout.listHeaderRect.y, header.start.w + 4, "center")
+    graphics.printf("Name", header.name.x - 2, layout.listHeaderRect.y, header.name.w + 4, "center")
+    graphics.printf("Line", header.lineChip.x - 6, layout.listHeaderRect.y, header.lineChip.w + 12, "center")
+    graphics.printf("Goal", header.goalChip.x - 6, layout.listHeaderRect.y, header.goalChip.w + 12, "center")
+    graphics.printf("Wagons", header.wagons.x - 4, layout.listHeaderRect.y, header.wagons.w + 8, "center")
+    graphics.printf("Deadline", header.deadline.x - 4, layout.listHeaderRect.y, header.deadline.w + 8, "center")
+
+    love.graphics.setScissor(layout.listRect.x, layout.listRect.y, layout.listRect.w, layout.listRect.h)
+    for _, row in ipairs(layout.rows) do
+        local entry = row.entry
+        local train = entry.train
+        local controls = self:getSequencerRowControlRects(row.rect)
+        local startText = self:getActiveTextFieldValue("train", train.id, "spawnTime", tostring(train.spawnTime or 0))
+        local wagonsText = self:getActiveTextFieldValue("train", train.id, "wagonCount", tostring(train.wagonCount or DEFAULT_TRAIN_WAGONS))
+        local deadlineText = self:getActiveTextFieldValue("train", train.id, "deadline", train.deadline and tostring(train.deadline) or "--")
+
+        graphics.setColor(0.06, 0.08, 0.1, 1)
+        graphics.rectangle("fill", row.rect.x, row.rect.y, row.rect.w, row.rect.h, 12, 12)
+        graphics.setLineWidth(1.1)
+        graphics.setColor(0.24, 0.32, 0.4, 1)
+        graphics.rectangle("line", row.rect.x, row.rect.y, row.rect.w, row.rect.h, 12, 12)
+
+        love.graphics.setFont(game.fonts.small)
+        self:drawSequencerInlineField(
+            controls.summary.start,
+            startText,
+            { 0.33, 0.8, 0.98 },
+            self.activeTextField and self.activeTextField.kind == "train" and self.activeTextField.targetId == train.id and self.activeTextField.fieldName == "spawnTime"
+        )
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.printf(entry.castName, controls.summary.name.x, controls.summary.name.y + 1, controls.summary.name.w, "left")
+        self:drawSequencerSummaryChip(controls.summary.lineChip, train.lineColor)
+        self:drawSequencerSummaryChip(controls.summary.goalChip, train.trainColor)
+        self:drawSequencerInlineField(
+            controls.summary.wagons,
+            wagonsText,
+            { 0.48, 0.92, 0.62 },
+            self.activeTextField and self.activeTextField.kind == "train" and self.activeTextField.targetId == train.id and self.activeTextField.fieldName == "wagonCount"
+        )
+        self:drawSequencerInlineField(
+            controls.summary.deadline,
+            deadlineText,
+            { 0.99, 0.78, 0.32 },
+            self.activeTextField and self.activeTextField.kind == "train" and self.activeTextField.targetId == train.id and self.activeTextField.fieldName == "deadline"
+        )
+
+        graphics.setLineWidth(1.1)
+        graphics.setColor(0.99, 0.78, 0.32, 1)
+        graphics.rectangle("line", controls.summary.remove.x, controls.summary.remove.y, controls.summary.remove.w, controls.summary.remove.h, 5, 5)
+        graphics.printf("X", controls.summary.remove.x, controls.summary.remove.y + 1, controls.summary.remove.w, "center")
+    end
+    love.graphics.setScissor()
+
+    if #layout.rows == 0 then
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        graphics.printf("No trains are authored yet. Add one to start sequencing this map.", layout.panelX, layout.listRect.y + 24, layout.panelWidth, "center")
+    end
+
+    if layout.scrollbar then
+        graphics.setColor(0.1, 0.12, 0.16, 1)
+        graphics.rectangle("fill", layout.scrollbar.track.x, layout.scrollbar.track.y, layout.scrollbar.track.w, layout.scrollbar.track.h, 4, 4)
+        graphics.setColor(0.24, 0.32, 0.4, 1)
+        graphics.rectangle("line", layout.scrollbar.track.x, layout.scrollbar.track.y, layout.scrollbar.track.w, layout.scrollbar.track.h, 4, 4)
+        graphics.setColor(0.33, 0.8, 0.98, 1)
+        graphics.rectangle("fill", layout.scrollbar.thumb.x, layout.scrollbar.thumb.y, layout.scrollbar.thumb.w, layout.scrollbar.thumb.h, 4, 4)
+    end
+
+    if self.statusText then
+        graphics.setColor(0.48, 0.92, 0.62, 1)
+        graphics.printf(self.statusText, layout.panelX, layout.backRect.y - 52, layout.panelWidth)
+    end
+
+    self:drawPanelButton(layout.backRect, "Back", { 0.99, 0.78, 0.32 })
+end
+
+function mapEditor:drawDefaultSidePanel(game)
+    local graphics = love.graphics
     local panelX = self.sidePanel.x + 18
     local panelWidth = self.sidePanel.w - 36
     local panelBottom = self:getSaveButtonRect().y - 16
@@ -2232,7 +3136,7 @@ function mapEditor:draw(game)
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(0.68, 0.74, 0.8, 1)
     graphics.printf(
-        string.format("Routes: %d  |  Intersections: %d", #self.routes, #self.intersections),
+        string.format("Routes: %d  |  Intersections: %d  |  Trains: %d", #self.routes, #self.intersections, #self.trains),
         panelX,
         currentY,
         panelWidth
@@ -2277,20 +3181,10 @@ function mapEditor:draw(game)
         local startColors = table.concat(lookupToSortedIds(startEndpoint and startEndpoint.colors or {}), ", ")
         local endColors = table.concat(lookupToSortedIds(endEndpoint and endEndpoint.colors or {}), ", ")
         graphics.setColor(selectedRoute.color[1], selectedRoute.color[2], selectedRoute.color[3], 1)
-        graphics.printf(
-            "Selected route: " .. (selectedRoute.label or selectedRoute.id),
-            panelX,
-            currentY,
-            panelWidth
-        )
+        graphics.printf("Selected route: " .. (selectedRoute.label or selectedRoute.id), panelX, currentY, panelWidth)
         currentY = currentY + 24
         graphics.setColor(0.84, 0.88, 0.92, 1)
-        graphics.printf(
-            "Start magnet: " .. startColors .. "\nExit magnet: " .. endColors,
-            panelX,
-            currentY,
-            panelWidth
-        )
+        graphics.printf("Start magnet: " .. startColors .. "\nExit magnet: " .. endColors, panelX, currentY, panelWidth)
     end
 
     if self.statusText then
@@ -2298,10 +3192,64 @@ function mapEditor:draw(game)
         graphics.printf(self.statusText, panelX, panelBottom - 42, panelWidth)
     end
 
+    love.graphics.setFont(game.fonts.small)
     self:drawPanelButton(self:getSaveButtonRect(), "Save Map (S)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getOpenButtonRect(), "Open Map (O)", { 0.33, 0.8, 0.98 })
-    self:drawPanelButton(self:getCopyButtonRect(), "Copy Export (C)", { 0.48, 0.92, 0.62 })
+    self:drawPanelButton(self:getSequencerButtonRect(), "Sequencer (C)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getResetButtonRect(), "Reset To Map (R)", { 0.99, 0.78, 0.32 })
+end
+
+function mapEditor:draw(game)
+    local graphics = love.graphics
+
+    graphics.setColor(0.05, 0.07, 0.09, 1)
+    graphics.rectangle("fill", 0, 0, self.viewport.w, self.viewport.h)
+
+    graphics.setColor(0.07, 0.09, 0.12, 1)
+    graphics.rectangle("fill", self.canvas.x, self.canvas.y, self.canvas.w, self.canvas.h, 18, 18)
+
+    graphics.setColor(0.1, 0.14, 0.18, 0.96)
+    graphics.rectangle("fill", self.canvas.x, self.canvas.y, self.canvas.w, self.spawnBandHeight, 18, 18)
+
+    graphics.setColor(0.25, 0.34, 0.42, 1)
+    graphics.setLineWidth(2)
+    graphics.rectangle("line", self.canvas.x, self.canvas.y, self.canvas.w, self.canvas.h, 18, 18)
+
+    graphics.setColor(0.16, 0.2, 0.24, 1)
+    graphics.line(
+        self.canvas.x + 16,
+        self.canvas.y + self.spawnBandHeight,
+        self.canvas.x + self.canvas.w - 16,
+        self.canvas.y + self.spawnBandHeight
+    )
+
+    for _, route in ipairs(self.routes) do
+        self:drawRoute(route, self.selectedRouteId)
+    end
+
+    for _, intersection in ipairs(self.intersections) do
+        self:drawIntersection(intersection)
+    end
+
+    graphics.setColor(0.09, 0.11, 0.15, 0.98)
+    graphics.rectangle("fill", self.sidePanel.x, self.sidePanel.y, self.sidePanel.w, self.sidePanel.h, 18, 18)
+    graphics.setColor(0.22, 0.28, 0.34, 1)
+    graphics.rectangle("line", self.sidePanel.x, self.sidePanel.y, self.sidePanel.w, self.sidePanel.h, 18, 18)
+
+    if self.sidePanelMode == "sequencer" then
+        self:drawSequencer(game)
+    else
+        love.graphics.setFont(game.fonts.title)
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print("Map Editor", self.sidePanel.x + 18, self.sidePanel.y + 20)
+
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.48, 0.92, 0.62, 1)
+        graphics.printf("Esc returns to the main menu", self.sidePanel.x + 18, self.sidePanel.y + 64, self.sidePanel.w - 36)
+        self:drawDefaultSidePanel(game)
+    end
+
+    self:drawColorPicker(game)
 
     graphics.setColor(0.7, 0.76, 0.82, 1)
     local sourceLabel
@@ -2313,12 +3261,7 @@ function mapEditor:draw(game)
         sourceLabel = "Current source: " .. (self.currentMapName or (self.level and self.level.title) or "Blank")
     end
     graphics.printf(sourceLabel, self.canvas.x + 18, self.canvas.y + 16, self.canvas.w - 36)
-    graphics.printf(
-        "Create starts from the top edge. Imported maps are editable immediately.",
-        self.canvas.x + 18,
-        self.canvas.y + self.spawnBandHeight - 24,
-        self.canvas.w - 36
-    )
+    graphics.printf("Create starts from the top edge. Imported maps are editable immediately.", self.canvas.x + 18, self.canvas.y + self.spawnBandHeight - 24, self.canvas.w - 36)
 
     self:drawDialog(game)
 end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -11,6 +11,7 @@ local function drawButton(rect, label, fillColor, strokeColor, font)
     local graphics = love.graphics
     graphics.setColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] or 1)
     graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 16, 16)
+    graphics.setLineWidth(1.5)
     graphics.setColor(strokeColor[1], strokeColor[2], strokeColor[3], strokeColor[4] or 1)
     graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 16, 16)
     love.graphics.setFont(font)
@@ -434,6 +435,18 @@ function ui.drawPlay(game)
         graphics.print(string.format("Time left: %.1fs", game.world.timeRemaining), 220, 172)
     end
 
+    local nextTrain = game.world:getNextQueuedTrain()
+    if nextTrain then
+        graphics.setColor(0.72, 0.78, 0.84, 1)
+        graphics.print(string.format("Next spawn: %s at %.1fs", game.world:getTrainSummary(nextTrain), nextTrain.spawnTime or 0), 42, 194)
+    end
+
+    local nextDeadline = game.world:getNearestPendingDeadline()
+    if nextDeadline then
+        graphics.setColor(0.99, 0.78, 0.32, 1)
+        graphics.print(string.format("Nearest deadline: %s by %.1fs", game.world:getTrainSummary(nextDeadline), nextDeadline.deadline), 360, 194)
+    end
+
     drawButton(
         { x = 1114, y = 28, w = 134, h = 38 },
         "Main Menu",
@@ -454,6 +467,24 @@ function ui.drawPlay(game)
             "Two trains overlapped because the routes were switched unsafely.",
             "Click, press Enter, Space, or R to retry this map",
             { 0.97, 0.36, 0.3 }
+        )
+    elseif game.failureReason == "wrong_destination" then
+        local failedTrain = game.world:getFailureTrain()
+        drawCenteredOverlay(
+            game,
+            "Wrong Destination",
+            string.format("%s left through the wrong output.", game.world:getTrainSummary(failedTrain) or "A train"),
+            "Retry the map and route this train to its matching color exit.",
+            { 0.97, 0.36, 0.3 }
+        )
+    elseif game.failureReason == "missed_deadline" then
+        local failedTrain = game.world:getFailureTrain()
+        drawCenteredOverlay(
+            game,
+            "Missed Deadline",
+            string.format("%s did not clear its goal in time.", game.world:getTrainSummary(failedTrain) or "A train"),
+            "Retry the map and route this train earlier.",
+            { 0.99, 0.78, 0.32 }
         )
     elseif game.failureReason == "timeout" then
         drawCenteredOverlay(

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -30,6 +30,13 @@ local function getWrappedLineCount(font, text, width)
     return 1
 end
 
+local function formatScore(value)
+    local formatted = string.format("%.2f", value or 0)
+    formatted = formatted:gsub("(%..-)0+$", "%1")
+    formatted = formatted:gsub("%.$", "")
+    return formatted
+end
+
 local function getMenuButtons(game)
     local centerX = game.viewport.w * 0.5 - 160
     return {
@@ -242,6 +249,30 @@ function ui.getPlayBackHit(_, x, y)
     })
 end
 
+local function getResultsButtonRects(game)
+    local panelX = game.viewport.w * 0.5 - 250
+    local buttonY = game.viewport.h - 72
+    return {
+        replay = { x = panelX, y = buttonY, w = 150, h = 42 },
+        editor = { x = panelX + 175, y = buttonY, w = 150, h = 42 },
+        menu = { x = panelX + 350, y = buttonY, w = 150, h = 42 },
+    }
+end
+
+function ui.getResultsHit(game, x, y)
+    local buttons = getResultsButtonRects(game)
+    if pointInRect(x, y, buttons.replay) then
+        return "replay"
+    end
+    if pointInRect(x, y, buttons.menu) then
+        return "menu"
+    end
+    if pointInRect(x, y, buttons.editor) then
+        return "editor"
+    end
+    return nil
+end
+
 function ui.drawMenu(game)
     local graphics = love.graphics
 
@@ -409,6 +440,7 @@ end
 function ui.drawPlay(game)
     local graphics = love.graphics
     local level = game.world:getLevel()
+    local runSummary = game.world:getRunSummary()
 
     graphics.setColor(0, 0, 0, 0.34)
     graphics.rectangle("fill", 22, 20, 620, 170, 18, 18)
@@ -429,6 +461,8 @@ function ui.drawPlay(game)
     local trainsText = string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #game.world.trains)
     graphics.setColor(0.84, 0.88, 0.92, 0.95)
     graphics.print(trainsText, 42, 172)
+    graphics.print(string.format("Interactions: %d", runSummary.interactionCount or 0), 42, 194)
+    graphics.print(string.format("Score: %s", formatScore(runSummary.finalScore or 0)), 220, 194)
 
     if game.world.timeRemaining then
         graphics.setColor(0.99, 0.83, 0.44, 1)
@@ -438,13 +472,13 @@ function ui.drawPlay(game)
     local nextTrain = game.world:getNextQueuedTrain()
     if nextTrain then
         graphics.setColor(0.72, 0.78, 0.84, 1)
-        graphics.print(string.format("Next spawn: %s at %.1fs", game.world:getTrainSummary(nextTrain), nextTrain.spawnTime or 0), 42, 194)
+        graphics.print(string.format("Next spawn: %s at %.1fs", game.world:getTrainSummary(nextTrain), nextTrain.spawnTime or 0), 42, 216)
     end
 
     local nextDeadline = game.world:getNearestPendingDeadline()
     if nextDeadline then
         graphics.setColor(0.99, 0.78, 0.32, 1)
-        graphics.print(string.format("Nearest deadline: %s by %.1fs", game.world:getTrainSummary(nextDeadline), nextDeadline.deadline), 360, 194)
+        graphics.print(string.format("Nearest deadline: %s by %.1fs", game.world:getTrainSummary(nextDeadline), nextDeadline.deadline), 360, 216)
     end
 
     drawButton(
@@ -459,50 +493,92 @@ function ui.drawPlay(game)
     graphics.printf(level.hint, 0, game.viewport.h - 66, game.viewport.w, "center")
     graphics.printf(level.footer, 0, game.viewport.h - 42, game.viewport.w, "center")
     graphics.printf("Press M for the main menu, E for the editor, or R to restart", 0, game.viewport.h - 90, game.viewport.w, "center")
+end
 
-    if game.failureReason == "collision" then
-        drawCenteredOverlay(
-            game,
-            "Signal Failure",
-            "Two trains overlapped because the routes were switched unsafely.",
-            "Click, press Enter, Space, or R to retry this map",
-            { 0.97, 0.36, 0.3 }
-        )
-    elseif game.failureReason == "wrong_destination" then
-        local failedTrain = game.world:getFailureTrain()
-        drawCenteredOverlay(
-            game,
-            "Wrong Destination",
-            string.format("%s left through the wrong output.", game.world:getTrainSummary(failedTrain) or "A train"),
-            "Retry the map and route this train to its matching color exit.",
-            { 0.97, 0.36, 0.3 }
-        )
-    elseif game.failureReason == "missed_deadline" then
-        local failedTrain = game.world:getFailureTrain()
-        drawCenteredOverlay(
-            game,
-            "Missed Deadline",
-            string.format("%s did not clear its goal in time.", game.world:getTrainSummary(failedTrain) or "A train"),
-            "Retry the map and route this train earlier.",
-            { 0.99, 0.78, 0.32 }
-        )
-    elseif game.failureReason == "timeout" then
-        drawCenteredOverlay(
-            game,
-            "Too Late",
-            "The timer expired before every train cleared its exit.",
-            "Retry the map and arm route changes earlier",
-            { 0.99, 0.83, 0.44 }
-        )
-    elseif game.levelComplete then
-        drawCenteredOverlay(
-            game,
-            "Level Clear",
-            "All trains cleared their exits.",
-            "Click, press Enter, Space, or R to replay. Press M for the main menu.",
-            { 0.48, 0.92, 0.62 }
-        )
+function ui.drawResults(game)
+    local graphics = love.graphics
+    local summary = game.resultsSummary or {}
+    local level = game.world and game.world:getLevel() or {}
+    local panel = {
+        x = game.viewport.w * 0.5 - 300,
+        y = 50,
+        w = 600,
+        h = 580,
+    }
+    local buttons = getResultsButtonRects(game)
+
+    graphics.setColor(0.05, 0.07, 0.1, 1)
+    graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    graphics.setColor(0, 0, 0, 0.22)
+    graphics.circle("fill", 190, 130, 170)
+    graphics.circle("fill", 1080, 560, 210)
+
+    graphics.setColor(0.09, 0.11, 0.15, 0.98)
+    graphics.rectangle("fill", panel.x, panel.y, panel.w, panel.h, 20, 20)
+    graphics.setColor(0.26, 0.34, 0.42, 1)
+    graphics.rectangle("line", panel.x, panel.y, panel.w, panel.h, 20, 20)
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    local title = "Level Clear"
+    local accent = { 0.48, 0.92, 0.62, 1 }
+    if summary.endReason == "collision" then
+        title = "Collision"
+        accent = { 0.97, 0.36, 0.3, 1 }
+    elseif summary.endReason == "timeout" then
+        title = "Time Up"
+        accent = { 0.99, 0.83, 0.44, 1 }
     end
+    graphics.printf(title, panel.x, panel.y + 24, panel.w, "center")
+
+    love.graphics.setFont(game.fonts.body)
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf(level.title or "Run Results", panel.x, panel.y + 74, panel.w, "center")
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(accent[1], accent[2], accent[3], 1)
+    graphics.printf(string.format("Score %s", formatScore(summary.finalScore or 0)), panel.x, panel.y + 108, panel.w, "center")
+
+    love.graphics.setFont(game.fonts.small)
+    local breakdownX = panel.x + 58
+    local valueX = panel.x + panel.w - 58
+    local lineY = panel.y + 192
+    local rows = {
+        { "On-time clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.onTimeClears) or 0)) },
+        { "Late clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.lateClears) or 0)) },
+        { "Time penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.timePenalty) or 0)) },
+        { "Interaction penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.interactionPenalty) or 0)) },
+        { "Distance penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.extraDistancePenalty) or 0)) },
+    }
+
+    for _, row in ipairs(rows) do
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        graphics.print(row[1], breakdownX, lineY)
+        graphics.printf(row[2], valueX - 140, lineY, 140, "right")
+        lineY = lineY + 28
+    end
+
+    lineY = lineY + 20
+    local stats = {
+        string.format("On-time trains: %d", summary.correctOnTimeCount or 0),
+        string.format("Late trains: %d", summary.correctLateCount or 0),
+        string.format("Wrong destinations: %d", summary.wrongDestinationCount or 0),
+        string.format("Elapsed time: %.1fs", summary.elapsedSeconds or 0),
+        string.format("Interactions: %d", summary.interactionCount or 0),
+        string.format("Driven distance: %.1fm", summary.actualDrivenDistance or 0),
+        string.format("Minimum distance: %.1fm", summary.minimumRequiredDistance or 0),
+        string.format("Extra distance: %.1fm", summary.extraDistance or 0),
+    }
+
+    for _, stat in ipairs(stats) do
+        graphics.setColor(0.72, 0.78, 0.84, 1)
+        graphics.print(stat, breakdownX, lineY)
+        lineY = lineY + 26
+    end
+
+    drawButton(buttons.replay, "Replay", { 0.1, 0.14, 0.18, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.small)
+    drawButton(buttons.editor, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
+    drawButton(buttons.menu, "Main Menu", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
 end
 
 return ui

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1,5 +1,13 @@
 local world = {}
 world.__index = world
+local COLOR_OPTIONS = {
+    { id = "blue", color = { 0.33, 0.8, 0.98 } },
+    { id = "yellow", color = { 0.98, 0.82, 0.34 } },
+    { id = "mint", color = { 0.4, 0.92, 0.76 } },
+    { id = "rose", color = { 0.98, 0.48, 0.62 } },
+    { id = "orange", color = { 0.98, 0.7, 0.28 } },
+    { id = "violet", color = { 0.82, 0.56, 0.98 } },
+}
 
 local function clamp(value, minValue, maxValue)
     if value < minValue then
@@ -53,6 +61,51 @@ local function darkerColor(color)
         color[2] * 0.42,
         color[3] * 0.42,
     }
+end
+
+local function nearestColorId(color)
+    if not color then
+        return COLOR_OPTIONS[1].id
+    end
+
+    local bestId = COLOR_OPTIONS[1].id
+    local bestDistance = math.huge
+    for _, option in ipairs(COLOR_OPTIONS) do
+        local dx = (color[1] or 0) - option.color[1]
+        local dy = (color[2] or 0) - option.color[2]
+        local dz = (color[3] or 0) - option.color[3]
+        local distance = dx * dx + dy * dy + dz * dz
+        if distance < bestDistance then
+            bestDistance = distance
+            bestId = option.id
+        end
+    end
+    return bestId
+end
+
+local function getColorById(colorId)
+    for _, option in ipairs(COLOR_OPTIONS) do
+        if option.id == colorId then
+            return copyColor(option.color)
+        end
+    end
+    return copyColor(COLOR_OPTIONS[1].color)
+end
+
+local function containsColorId(colors, colorId)
+    for _, candidate in ipairs(colors or {}) do
+        if candidate == colorId then
+            return true
+        end
+    end
+    return false
+end
+
+local function formatColorLabel(colorId)
+    if not colorId then
+        return "Unknown"
+    end
+    return colorId:sub(1, 1):upper() .. colorId:sub(2)
 end
 
 local function denormalizePoints(points, viewportW, viewportH)
@@ -189,6 +242,8 @@ function world.new(viewportW, viewportH, levelSource)
     self.collisionPoint = nil
     self.failureReason = nil
     self.timeRemaining = nil
+    self.elapsedTime = 0
+    self.failureTrain = nil
 
     self.level = self:normalizeLevel(levelSource or {})
 
@@ -253,12 +308,35 @@ function world:normalizeLevel(sourceLevel)
         end
 
         for _, trainDefinition in ipairs(sourceLevel.trains or {}) do
+            local speedScale = trainDefinition.speedScale or 1
+            local progress = trainDefinition.progress or 0
+            local spawnTime = trainDefinition.spawnTime
+            local startProgress = progress
+
+            if spawnTime == nil then
+                if progress < 0 then
+                    spawnTime = math.abs(progress) / math.max(1, self.trainSpeed * speedScale)
+                    startProgress = 0
+                else
+                    spawnTime = 0
+                end
+            end
+
+            local trainColor = trainDefinition.trainColor
+                or trainDefinition.goalColor
+                or nearestColorId(trainDefinition.color)
             normalized.trains[#normalized.trains + 1] = {
                 id = trainDefinition.id,
                 edgeId = trainDefinition.edgeId,
-                progress = trainDefinition.progress or 0,
+                lineColor = trainDefinition.lineColor,
+                progress = startProgress,
+                spawnTime = spawnTime,
                 speedScale = trainDefinition.speedScale or 1,
-                color = trainDefinition.color and copyColor(trainDefinition.color) or nil,
+                wagonCount = trainDefinition.wagonCount or self.carriageCount,
+                deadline = trainDefinition.deadline,
+                goalColor = trainDefinition.goalColor or trainColor,
+                trainColor = trainColor,
+                color = trainDefinition.color and copyColor(trainDefinition.color) or getColorById(trainColor),
             }
         end
 
@@ -372,12 +450,33 @@ function world:normalizeLevel(sourceLevel)
     for _, trainDefinition in ipairs(sourceLevel.trains or {}) do
         local junctionId = trainDefinition.junctionId
         local inputIndex = trainDefinition.inputIndex or trainDefinition.branchIndex or 1
+        local speedScale = trainDefinition.speedScale or 1
+        local progress = trainDefinition.progress or 0
+        local spawnTime = trainDefinition.spawnTime
+        local startProgress = progress
+        if spawnTime == nil then
+            if progress < 0 then
+                spawnTime = math.abs(progress) / math.max(1, self.trainSpeed * speedScale)
+                startProgress = 0
+            else
+                spawnTime = 0
+            end
+        end
+        local trainColor = trainDefinition.trainColor
+            or trainDefinition.goalColor
+            or nearestColorId(trainDefinition.color)
         normalized.trains[#normalized.trains + 1] = {
             id = trainDefinition.id,
             edgeId = string.format("%s_input_%d", junctionId or "junction", inputIndex),
-            progress = trainDefinition.progress or 0,
-            speedScale = trainDefinition.speedScale or 1,
-            color = trainDefinition.color and copyColor(trainDefinition.color) or nil,
+            lineColor = trainDefinition.lineColor,
+            progress = startProgress,
+            spawnTime = spawnTime,
+            speedScale = speedScale,
+            wagonCount = trainDefinition.wagonCount or self.carriageCount,
+            deadline = trainDefinition.deadline,
+            goalColor = trainDefinition.goalColor or trainColor,
+            trainColor = trainColor,
+            color = trainDefinition.color and copyColor(trainDefinition.color) or getColorById(trainColor),
         }
     end
 
@@ -464,53 +563,55 @@ function world:buildJunction(definition, existing)
 end
 
 function world:initializeLevel()
-    local previousJunctions = self.junctions
     self.junctions = {}
     self.junctionOrder = {}
     self.edges = {}
+    self.trains = {}
 
     for _, edgeDefinition in ipairs(self.level.edges or {}) do
         self.edges[edgeDefinition.id] = self:buildEdge(edgeDefinition)
     end
 
     for _, junctionDefinition in ipairs(self.level.junctions or {}) do
-        local existing = previousJunctions[junctionDefinition.id]
-        local junction = self:buildJunction(junctionDefinition, existing)
+        local junction = self:buildJunction(junctionDefinition, nil)
         self.junctions[junction.id] = junction
         self.junctionOrder[#self.junctionOrder + 1] = junction
     end
 
-    if #self.trains == 0 then
-        for _, trainDefinition in ipairs(self.level.trains or {}) do
-            local edge = self.edges[trainDefinition.edgeId]
-            if edge then
-                local baseColor = trainDefinition.color or edge.color
-
-                self.trains[#self.trains + 1] = {
-                    id = trainDefinition.id,
-                    edgeId = trainDefinition.edgeId,
-                    occupiedEdgeIds = { trainDefinition.edgeId },
-                    headDistance = trainDefinition.progress,
-                    speed = self.trainSpeed * (trainDefinition.speedScale or 1),
-                    currentSpeed = 0,
-                    color = copyColor(baseColor),
-                    darkColor = darkerColor(baseColor),
-                    completed = false,
-                }
-            end
-        end
-    else
-        for _, train in ipairs(self.trains) do
-            if self.edges[train.edgeId] then
-                train.occupiedEdgeIds = train.occupiedEdgeIds or { train.edgeId }
-                train.headDistance = train.headDistance or train.progress or 0
-            end
+    for _, trainDefinition in ipairs(self.level.trains or {}) do
+        local edge = self.edges[trainDefinition.edgeId]
+        if edge then
+            local baseColor = trainDefinition.color or edge.color
+            local spawned = (trainDefinition.spawnTime or 0) <= 0
+            self.trains[#self.trains + 1] = {
+                id = trainDefinition.id,
+                edgeId = trainDefinition.edgeId,
+                startEdgeId = trainDefinition.edgeId,
+                lineColor = trainDefinition.lineColor,
+                occupiedEdgeIds = spawned and { trainDefinition.edgeId } or {},
+                headDistance = spawned and (trainDefinition.progress or 0) or 0,
+                spawnProgress = trainDefinition.progress or 0,
+                speed = self.trainSpeed * (trainDefinition.speedScale or 1),
+                currentSpeed = 0,
+                color = copyColor(baseColor),
+                darkColor = darkerColor(baseColor),
+                goalColor = trainDefinition.goalColor or trainDefinition.trainColor or nearestColorId(baseColor),
+                trainColor = trainDefinition.trainColor or trainDefinition.goalColor or nearestColorId(baseColor),
+                wagonCount = trainDefinition.wagonCount or self.carriageCount,
+                spawnTime = trainDefinition.spawnTime or 0,
+                deadline = trainDefinition.deadline,
+                spawned = spawned,
+                completed = false,
+                completedAt = nil,
+            }
         end
     end
 
+    self.elapsedTime = 0
     self.timeRemaining = self.level.timeLimit
     self.collisionPoint = nil
     self.failureReason = nil
+    self.failureTrain = nil
 end
 
 function world:getOccupiedEdges(train)
@@ -522,6 +623,39 @@ function world:getOccupiedEdges(train)
         end
     end
     return occupiedEdges
+end
+
+function world:spawnTrain(train)
+    if train.spawned or train.completed or not self.edges[train.startEdgeId] then
+        return
+    end
+
+    train.spawned = true
+    train.edgeId = train.startEdgeId
+    train.occupiedEdgeIds = { train.startEdgeId }
+    train.headDistance = train.spawnProgress or 0
+    train.currentSpeed = 0
+end
+
+function world:completeTrain(train)
+    train.completed = true
+    train.currentSpeed = 0
+    train.completedAt = self.elapsedTime
+end
+
+function world:doesOutputAcceptTrain(train, junction, outputEdge)
+    if containsColorId(outputEdge.colors, train.goalColor) then
+        return true
+    end
+
+    if outputEdge.adoptInputColor then
+        local activeInput = junction.inputs[junction.activeInputIndex]
+        if activeInput and containsColorId(activeInput.colors, train.goalColor) then
+            return true
+        end
+    end
+
+    return containsColorId({ nearestColorId(outputEdge.color) }, train.goalColor)
 end
 
 function world:getCurrentEdge(train)
@@ -542,7 +676,7 @@ end
 
 function world:trimTrainOccupiedEdges(train, occupiedEdges)
     local edges = occupiedEdges or self:getOccupiedEdges(train)
-    local tailDistance = (train.headDistance or 0) - (self.carriageCount - 1) * (self.carriageLength + self.carriageGap)
+    local tailDistance = (train.headDistance or 0) - ((train.wagonCount or self.carriageCount) - 1) * (self.carriageLength + self.carriageGap)
 
     while #edges > 1 and tailDistance > edges[1].path.length do
         tailDistance = tailDistance - edges[1].path.length
@@ -730,17 +864,24 @@ end
 function world:advanceTrainToNextEdge(train, junction, overflow)
     local outputEdge = junction.outputs[clamp(junction.activeOutputIndex, 1, math.max(1, #junction.outputs))]
     if not outputEdge then
-        train.completed = true
-        return
+        self:completeTrain(train)
+        return false
+    end
+
+    if not self:doesOutputAcceptTrain(train, junction, outputEdge) then
+        self.failureReason = "wrong_destination"
+        self.failureTrain = train
+        return false
     end
 
     train.edgeId = outputEdge.id
     train.occupiedEdgeIds[#train.occupiedEdgeIds + 1] = outputEdge.id
     self:trimTrainOccupiedEdges(train)
+    return true
 end
 
 function world:updateTrain(train, dt)
-    if train.completed then
+    if train.completed or not train.spawned then
         return
     end
 
@@ -806,18 +947,19 @@ function world:updateTrain(train, dt)
                 train.currentSpeed = 0
                 break
             end
-            self:advanceTrainToNextEdge(train, junction, overflow)
+            if not self:advanceTrainToNextEdge(train, junction, overflow) then
+                break
+            end
         else
             break
         end
     end
 
     local occupiedEdges = self:getOccupiedEdges(train)
-    local tailDistance = (train.headDistance or 0) - (self.carriageCount - 1) * (self.carriageLength + self.carriageGap)
+    local tailDistance = (train.headDistance or 0) - ((train.wagonCount or self.carriageCount) - 1) * (self.carriageLength + self.carriageGap)
     local occupiedLength = self:getDistanceOnOccupiedEdges(occupiedEdges)
     if currentEdge and currentEdge.targetType == "exit" and tailDistance > occupiedLength + self.exitPadding then
-        train.completed = true
-        train.currentSpeed = 0
+        self:completeTrain(train)
     end
 end
 
@@ -826,11 +968,11 @@ function world:getTrainCarriagePositions(train)
     local carriageSpacing = self.carriageLength + self.carriageGap
     local occupiedEdges = self:getOccupiedEdges(train)
 
-    if train.completed or #occupiedEdges == 0 then
+    if train.completed or not train.spawned or #occupiedEdges == 0 then
         return positions
     end
 
-    for carriageIndex = 1, self.carriageCount do
+    for carriageIndex = 1, (train.wagonCount or self.carriageCount) do
         local carriageDistance = (train.headDistance or 0) - (carriageIndex - 1) * carriageSpacing
         local x, y, angle = self:pointOnOccupiedEdges(occupiedEdges, carriageDistance)
         positions[#positions + 1] = {
@@ -873,13 +1015,25 @@ function world:updateCollisionState()
     end
 end
 
+function world:updateDeadlineState()
+    for _, train in ipairs(self.trains) do
+        if not train.completed and train.deadline and self.elapsedTime > train.deadline then
+            self.failureReason = "missed_deadline"
+            self.failureTrain = train
+            return
+        end
+    end
+end
+
 function world:update(dt)
     if self.failureReason or self:isLevelComplete() then
         return
     end
 
-    if self.timeRemaining then
-        self.timeRemaining = math.max(0, self.timeRemaining - dt)
+    local previousElapsed = self.elapsedTime
+    self.elapsedTime = self.elapsedTime + dt
+    if self.level.timeLimit then
+        self.timeRemaining = math.max(0, self.level.timeLimit - self.elapsedTime)
     end
 
     for _, junction in ipairs(self.junctionOrder) do
@@ -887,10 +1041,25 @@ function world:update(dt)
     end
 
     for _, train in ipairs(self.trains) do
-        self:updateTrain(train, dt)
+        local trainDt = dt
+        if not train.spawned and not train.completed then
+            if self.elapsedTime >= (train.spawnTime or 0) then
+                self:spawnTrain(train)
+                trainDt = self.elapsedTime - math.max(previousElapsed, train.spawnTime or 0)
+            else
+                trainDt = nil
+            end
+        end
+
+        if trainDt and trainDt > 0 then
+            self:updateTrain(train, trainDt)
+        end
     end
 
     self:updateCollisionState()
+    if not self.failureReason then
+        self:updateDeadlineState()
+    end
 
     if not self.failureReason and self.timeRemaining and self.timeRemaining <= 0 and not self:isLevelComplete() then
         self.failureReason = "timeout"
@@ -899,6 +1068,10 @@ end
 
 function world:getFailureReason()
     return self.failureReason
+end
+
+function world:getFailureTrain()
+    return self.failureTrain
 end
 
 function world:isLevelComplete()
@@ -918,6 +1091,37 @@ function world:countCompletedTrains()
         end
     end
     return completedCount
+end
+
+function world:getNextQueuedTrain()
+    local bestTrain = nil
+    for _, train in ipairs(self.trains) do
+        if not train.spawned and not train.completed then
+            if not bestTrain or (train.spawnTime or 0) < (bestTrain.spawnTime or 0) then
+                bestTrain = train
+            end
+        end
+    end
+    return bestTrain
+end
+
+function world:getNearestPendingDeadline()
+    local bestTrain = nil
+    for _, train in ipairs(self.trains) do
+        if not train.completed and train.deadline then
+            if not bestTrain or train.deadline < bestTrain.deadline then
+                bestTrain = train
+            end
+        end
+    end
+    return bestTrain
+end
+
+function world:getTrainSummary(train)
+    if not train then
+        return nil
+    end
+    return string.format("%s train", formatColorLabel(train.goalColor or train.trainColor))
 end
 
 function world:getActiveRouteSummary()

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -226,6 +226,14 @@ local function combinePointLists(firstPoints, secondPoints)
     return combined
 end
 
+local function roundScoreValue(value)
+    return math.floor((value or 0) + 0.5)
+end
+
+local function getTailClearanceDistance(wagonCount, carriageLength, carriageGap)
+    return math.max(0, ((wagonCount or 1) - 1) * ((carriageLength or 0) + (carriageGap or 0)))
+end
+
 function world.new(viewportW, viewportH, levelSource)
     local self = setmetatable({}, world)
 
@@ -244,6 +252,7 @@ function world.new(viewportW, viewportH, levelSource)
     self.timeRemaining = nil
     self.elapsedTime = 0
     self.failureTrain = nil
+    self.interactionCount = 0
 
     self.level = self:normalizeLevel(levelSource or {})
 
@@ -262,6 +271,16 @@ end
 
 function world:getLevel()
     return self.level
+end
+
+function world:getScoringConstants()
+    return {
+        onTimeClear = 10,
+        lateClear = 5,
+        secondsPenalty = 0.25,
+        interactionPenalty = 1,
+        extraDistancePenalty = 1,
+    }
 end
 
 function world:normalizeLevel(sourceLevel)
@@ -562,6 +581,88 @@ function world:buildJunction(definition, existing)
     return junction
 end
 
+function world:registerInteraction()
+    self.interactionCount = (self.interactionCount or 0) + 1
+end
+
+function world:doesEdgeAcceptGoalColor(inputEdge, outputEdge, goalColor)
+    if containsColorId(outputEdge and outputEdge.colors, goalColor) then
+        return true
+    end
+
+    if outputEdge and outputEdge.adoptInputColor and containsColorId(inputEdge and inputEdge.colors, goalColor) then
+        return true
+    end
+
+    return outputEdge and nearestColorId(outputEdge.color) == goalColor or false
+end
+
+function world:buildMinimumDistanceLookup()
+    self.minimumDistanceByTrainId = {}
+
+    for _, train in ipairs(self.trains) do
+        local startEdge = self.edges[train.startEdgeId]
+        local goalColor = train.goalColor
+        local bestDistance = nil
+
+        if startEdge and startEdge.targetType == "junction" then
+            local queue = {
+                {
+                    edgeId = startEdge.id,
+                    distance = startEdge.path.length,
+                },
+            }
+            local bestByEdge = {
+                [startEdge.id] = startEdge.path.length,
+            }
+            local queueIndex = 1
+
+            while queueIndex <= #queue do
+                local current = queue[queueIndex]
+                queueIndex = queueIndex + 1
+
+                if bestDistance and current.distance >= bestDistance then
+                    goto continue_distance_search
+                end
+
+                local currentEdge = self.edges[current.edgeId]
+                if not currentEdge or currentEdge.targetType ~= "junction" then
+                    goto continue_distance_search
+                end
+
+                local junction = self.junctions[currentEdge.targetId]
+                for _, outputEdge in ipairs(junction and junction.outputs or {}) do
+                    if self:doesEdgeAcceptGoalColor(currentEdge, outputEdge, goalColor) then
+                        local nextDistance = current.distance + outputEdge.path.length
+                        if outputEdge.targetType == "exit" then
+                            if not bestDistance or nextDistance < bestDistance then
+                                bestDistance = nextDistance
+                            end
+                        elseif nextDistance < (bestByEdge[outputEdge.id] or math.huge) then
+                            bestByEdge[outputEdge.id] = nextDistance
+                            queue[#queue + 1] = {
+                                edgeId = outputEdge.id,
+                                distance = nextDistance,
+                            }
+                        end
+                    end
+                end
+
+                ::continue_distance_search::
+            end
+        end
+
+        if bestDistance then
+            bestDistance = bestDistance + self.exitPadding + getTailClearanceDistance(train.wagonCount, self.carriageLength, self.carriageGap)
+        else
+            bestDistance = 0
+        end
+
+        train.minimumDistance = bestDistance
+        self.minimumDistanceByTrainId[train.id or tostring(#self.minimumDistanceByTrainId + 1)] = bestDistance
+    end
+end
+
 function world:initializeLevel()
     self.junctions = {}
     self.junctionOrder = {}
@@ -603,15 +704,23 @@ function world:initializeLevel()
                 spawned = spawned,
                 completed = false,
                 completedAt = nil,
+                deliveredCorrectly = false,
+                deliveredLate = false,
+                failedWrongDestination = false,
+                actualDistance = 0,
+                minimumDistance = 0,
             }
         end
     end
+
+    self:buildMinimumDistanceLookup()
 
     self.elapsedTime = 0
     self.timeRemaining = self.level.timeLimit
     self.collisionPoint = nil
     self.failureReason = nil
     self.failureTrain = nil
+    self.interactionCount = 0
 end
 
 function world:getOccupiedEdges(train)
@@ -641,6 +750,8 @@ function world:completeTrain(train)
     train.completed = true
     train.currentSpeed = 0
     train.completedAt = self.elapsedTime
+    train.deliveredCorrectly = not train.failedWrongDestination
+    train.deliveredLate = train.deliveredCorrectly and train.deadline ~= nil and train.completedAt > train.deadline
 end
 
 function world:doesOutputAcceptTrain(train, junction, outputEdge)
@@ -727,19 +838,20 @@ end
 function world:cycleInput(junction)
     if #junction.inputs <= 1 then
         junction.activeInputIndex = 1
-        return
+        return false
     end
 
     junction.activeInputIndex = junction.activeInputIndex + 1
     if junction.activeInputIndex > #junction.inputs then
         junction.activeInputIndex = 1
     end
+    return true
 end
 
 function world:cycleOutput(junction, direction)
     if #junction.outputs <= 1 then
         junction.activeOutputIndex = 1
-        return
+        return false
     end
 
     junction.activeOutputIndex = junction.activeOutputIndex + direction
@@ -748,23 +860,24 @@ function world:cycleOutput(junction, direction)
     elseif junction.activeOutputIndex > #junction.outputs then
         junction.activeOutputIndex = 1
     end
+    return true
 end
 
 function world:activateControl(junction)
     local control = junction.control
 
     if control.type == "direct" then
-        self:cycleInput(junction)
-        return
+        return self:cycleInput(junction)
     end
 
     if control.type == "delayed" then
         control.armed = true
         control.remainingDelay = control.delay
-        return
+        return true
     end
 
     if control.type == "pump" then
+        local previousPumpCount = control.pumpCount
         control.pumpCount = math.min(control.target, control.pumpCount + 1)
         control.decayHold = control.decayDelay
         control.decayTimer = control.decayInterval
@@ -775,7 +888,10 @@ function world:activateControl(junction)
             control.decayHold = 0
             control.decayTimer = 0
         end
+        return control.pumpCount ~= previousPumpCount or control.target > 0
     end
+
+    return false
 end
 
 function world:isCrossingHit(junction, x, y)
@@ -794,16 +910,22 @@ end
 function world:handleClick(x, y, button)
     for _, junction in ipairs(self.junctionOrder) do
         if self:isOutputSelectorHit(junction, x, y) then
+            local changed
             if button == 2 then
-                self:cycleOutput(junction, -1)
+                changed = self:cycleOutput(junction, -1)
             else
-                self:cycleOutput(junction, 1)
+                changed = self:cycleOutput(junction, 1)
+            end
+            if changed then
+                self:registerInteraction()
             end
             return true
         end
 
         if button == 1 and self:isCrossingHit(junction, x, y) then
-            self:activateControl(junction)
+            if self:activateControl(junction) then
+                self:registerInteraction()
+            end
             return true
         end
     end
@@ -869,9 +991,7 @@ function world:advanceTrainToNextEdge(train, junction, overflow)
     end
 
     if not self:doesOutputAcceptTrain(train, junction, outputEdge) then
-        self.failureReason = "wrong_destination"
-        self.failureTrain = train
-        return false
+        train.failedWrongDestination = true
     end
 
     train.edgeId = outputEdge.id
@@ -920,6 +1040,8 @@ function world:updateTrain(train, dt)
         nextProgress = desiredStopDistance
         train.currentSpeed = 0
     end
+    local movedDistance = math.max(0, nextProgress - localProgress)
+    train.actualDistance = (train.actualDistance or 0) + movedDistance
 
     local previousLength = self:getDistanceOnOccupiedEdges(self:getOccupiedEdges(train)) - currentEdge.path.length
     train.headDistance = previousLength + nextProgress
@@ -1018,9 +1140,7 @@ end
 function world:updateDeadlineState()
     for _, train in ipairs(self.trains) do
         if not train.completed and train.deadline and self.elapsedTime > train.deadline then
-            self.failureReason = "missed_deadline"
             self.failureTrain = train
-            return
         end
     end
 end
@@ -1057,9 +1177,6 @@ function world:update(dt)
     end
 
     self:updateCollisionState()
-    if not self.failureReason then
-        self:updateDeadlineState()
-    end
 
     if not self.failureReason and self.timeRemaining and self.timeRemaining <= 0 and not self:isLevelComplete() then
         self.failureReason = "timeout"
@@ -1091,6 +1208,76 @@ function world:countCompletedTrains()
         end
     end
     return completedCount
+end
+
+function world:getRunEndReason()
+    if self.failureReason then
+        return self.failureReason
+    end
+    if self:isLevelComplete() then
+        return "level_clear"
+    end
+    return nil
+end
+
+function world:getRunSummary()
+    local scoring = self:getScoringConstants()
+    local summary = {
+        endReason = self:getRunEndReason(),
+        correctOnTimeCount = 0,
+        correctLateCount = 0,
+        wrongDestinationCount = 0,
+        elapsedSeconds = self.elapsedTime or 0,
+        interactionCount = self.interactionCount or 0,
+        actualDrivenDistance = 0,
+        minimumRequiredDistance = 0,
+        extraDistance = 0,
+        scoreBreakdown = {
+            onTimeClears = 0,
+            lateClears = 0,
+            timePenalty = 0,
+            interactionPenalty = 0,
+            extraDistancePenalty = 0,
+        },
+        finalScore = 0,
+    }
+
+    for _, train in ipairs(self.trains) do
+        summary.actualDrivenDistance = summary.actualDrivenDistance + (train.actualDistance or 0)
+
+        if train.completed and train.deliveredCorrectly then
+            local minimumDistance = train.minimumDistance or 0
+            local extraDistance = math.max(0, (train.actualDistance or 0) - minimumDistance)
+            summary.minimumRequiredDistance = summary.minimumRequiredDistance + minimumDistance
+            summary.extraDistance = summary.extraDistance + extraDistance
+
+            if train.deliveredLate then
+                summary.correctLateCount = summary.correctLateCount + 1
+                summary.scoreBreakdown.lateClears = summary.scoreBreakdown.lateClears + scoring.lateClear
+            else
+                summary.correctOnTimeCount = summary.correctOnTimeCount + 1
+                summary.scoreBreakdown.onTimeClears = summary.scoreBreakdown.onTimeClears + scoring.onTimeClear
+            end
+        elseif train.completed and train.failedWrongDestination then
+            summary.wrongDestinationCount = summary.wrongDestinationCount + 1
+        end
+    end
+
+    summary.scoreBreakdown.timePenalty = summary.elapsedSeconds * scoring.secondsPenalty
+    summary.scoreBreakdown.interactionPenalty = roundScoreValue(summary.interactionCount * scoring.interactionPenalty)
+    summary.scoreBreakdown.extraDistancePenalty = roundScoreValue(summary.extraDistance * scoring.extraDistancePenalty)
+
+    summary.finalScore = summary.scoreBreakdown.onTimeClears
+        + summary.scoreBreakdown.lateClears
+        - summary.scoreBreakdown.timePenalty
+        - summary.scoreBreakdown.interactionPenalty
+        - summary.scoreBreakdown.extraDistancePenalty
+
+    return summary
+end
+
+function world:getCurrentScore()
+    return self:getRunSummary().finalScore
 end
 
 function world:getNextQueuedTrain()


### PR DESCRIPTION
## Summary
- Add an editor train sequencer with explicit per-train scheduling, colors, wagon counts, and deadlines.
- Add runtime support for timed train spawns, per-train goals, distance tracking, interaction counting, and score-based results.
- Replace hard fail behavior with results flow where only collisions and map timer expiry end the run.
- Include validation for unreachable train goals from their source line, so impossible maps are flagged in the editor.

## Testing
- Not run (not requested)