### PR TITLE
Fix shared outpoint merge validation and rendering

### DIFF
--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -396,7 +396,27 @@ local function buildLegacyAuthoredTrains(startEdgeRecords)
 end
 
 local function edgeSupportsGoalColor(edge, goalColor)
-    return containsValue(edge and edge.colors or {}, goalColor)
+    if containsValue(edge and edge.colors or {}, goalColor) then
+        return true
+    end
+
+    if edge and edge.adoptInputColor and containsValue(edge.inputColors or {}, goalColor) then
+        return true
+    end
+
+    return false
+end
+
+local function addOutputColors(outputColorLookup, edge, sourceEndpoint, targetEndpoint)
+    for _, colorId in ipairs(targetEndpoint and (targetEndpoint.colors or {}) or edge and edge.colors or {}) do
+        outputColorLookup[colorId] = true
+    end
+
+    if edge and edge.adoptInputColor then
+        for _, colorId in ipairs(sourceEndpoint and (sourceEndpoint.colors or {}) or edge.inputColors or {}) do
+            outputColorLookup[colorId] = true
+        end
+    end
 end
 
 local function canReachGoalColor(startEdgeId, goalColor, edgeById, junctionLookup)
@@ -439,8 +459,8 @@ end
 function authoredMap.validateEditorMap(mapName, editorData)
     local errors = {}
 
-    if not editorData or #(editorData.junctions or {}) == 0 then
-        errors[#errors + 1] = "Add at least one lever intersection before starting this map."
+    if not editorData or #(editorData.routes or {}) == 0 then
+        errors[#errors + 1] = "Draw at least one route before starting this map."
         return nil, errors, errors[1]
     end
 
@@ -485,9 +505,11 @@ function authoredMap.validateEditorMap(mapName, editorData)
 
     for _, route in ipairs(editorData.routes or {}) do
         local routeHits = routeJunctions[route.id] or {}
-        if #routeHits == 0 then
-            errors[#errors + 1] = string.format("Route '%s' is not attached to a playable junction.", route.label or route.id)
-            goto continue_route
+        local validRouteHits = {}
+        local routeTotalLength = 0
+
+        for pointIndex = 1, #(route.points or {}) - 1 do
+            routeTotalLength = routeTotalLength + segmentLength(route.points[pointIndex], route.points[pointIndex + 1])
         end
 
         for _, hit in ipairs(routeHits) do
@@ -496,18 +518,17 @@ function authoredMap.validateEditorMap(mapName, editorData)
                 errors[#errors + 1] = string.format("Route '%s' did not actually reach a detected junction.", route.label or route.id)
                 goto continue_route
             end
-            hit.distance = distanceAlongRoute
-            hit.point = snappedPoint
+
+            if distanceAlongRoute > 0.0001 and distanceAlongRoute < routeTotalLength - 0.0001 then
+                hit.distance = distanceAlongRoute
+                hit.point = snappedPoint
+                validRouteHits[#validRouteHits + 1] = hit
+            end
         end
 
-        table.sort(routeHits, function(first, second)
+        table.sort(validRouteHits, function(first, second)
             return first.distance < second.distance
         end)
-
-        local routeTotalLength = 0
-        for pointIndex = 1, #(route.points or {}) - 1 do
-            routeTotalLength = routeTotalLength + segmentLength(route.points[pointIndex], route.points[pointIndex + 1])
-        end
 
         local nodes = {
             {
@@ -518,7 +539,7 @@ function authoredMap.validateEditorMap(mapName, editorData)
             },
         }
 
-        for _, hit in ipairs(routeHits) do
+        for _, hit in ipairs(validRouteHits) do
             nodes[#nodes + 1] = {
                 kind = "junction",
                 id = hit.junctionId,
@@ -554,6 +575,7 @@ function authoredMap.validateEditorMap(mapName, editorData)
                 color = getColor(route.color),
                 darkColor = darkerColor(getColor(route.color)),
                 colors = targetEndpoint and (targetEndpoint.colors or {}) or sourceEndpoint and (sourceEndpoint.colors or {}) or {},
+                inputColors = sourceEndpoint and (sourceEndpoint.colors or {}) or {},
                 adoptInputColor = targetEndpoint and #(targetEndpoint.colors or {}) > 1 or false,
                 sourceType = sourceNode.kind,
                 sourceId = sourceNode.id,
@@ -581,7 +603,7 @@ function authoredMap.validateEditorMap(mapName, editorData)
                 local targetJunction = junctionLookup[targetNode.id]
                 targetJunction.inputEdgeIds[#targetJunction.inputEdgeIds + 1] = edge.id
             end
-            if sourceNode.kind == "start" and targetNode.kind == "junction" then
+            if sourceNode.kind == "start" then
                 startEdgeRecords[edge.id] = startEdgeRecords[edge.id] or {
                     edgeId = edge.id,
                     colors = {},
@@ -597,10 +619,10 @@ function authoredMap.validateEditorMap(mapName, editorData)
                         lineColorToEdgeId[colorId] = edge.id
                     end
                 end
-            elseif targetNode.kind == "exit" then
-                for _, colorId in ipairs(targetEndpoint and (targetEndpoint.colors or {}) or {}) do
-                    outputColorLookup[colorId] = true
-                end
+            end
+
+            if targetNode.kind == "exit" then
+                addOutputColors(outputColorLookup, edge, sourceEndpoint, targetEndpoint)
             end
         end
 
@@ -620,6 +642,7 @@ function authoredMap.validateEditorMap(mapName, editorData)
         edgeById[edge.id] = edge
     end
 
+    local playableJunctions = {}
     for _, junction in ipairs(orderedJunctions) do
         local inputEdges = {}
         local outputEdges = {}
@@ -642,6 +665,10 @@ function authoredMap.validateEditorMap(mapName, editorData)
         sortEdgesByStart(inputEdges)
         sortEdgesByEnd(outputEdges)
 
+        if #inputEdges == 0 and #outputEdges == 0 then
+            goto continue_junction
+        end
+
         if #inputEdges > 5 or #outputEdges > 5 then
             errors[#errors + 1] = "A junction exceeds the current limit of five inputs or five outputs."
         end
@@ -660,6 +687,9 @@ function authoredMap.validateEditorMap(mapName, editorData)
         end
         junction.activeInputIndex = math.min(junction.activeInputIndex, math.max(1, #junction.inputEdgeIds))
         junction.activeOutputIndex = math.min(junction.activeOutputIndex, math.max(1, #junction.outputEdgeIds))
+        playableJunctions[#playableJunctions + 1] = junction
+
+        ::continue_junction::
     end
 
     local authoredTrains = editorData.trains
@@ -722,13 +752,19 @@ function authoredMap.validateEditorMap(mapName, editorData)
         return nil, errors, table.concat(errors, " ")
     end
 
+    local hasPlayableJunctions = #playableJunctions > 0
+
     return {
         title = mapName,
         description = "Custom map loaded from the editor.",
-        hint = "Click the junction center to switch inputs. Use the bottom selector to switch outputs.",
-        footer = "Sequence trains from the editor pane and clear every goal on time.",
+        hint = hasPlayableJunctions
+            and "Click the junction center to switch inputs. Use the bottom selector to switch outputs."
+            or "Shared endpoints are not junctions. Only one train can safely occupy a line end at a time.",
+        footer = hasPlayableJunctions
+            and "Sequence trains from the editor pane and clear every goal on time."
+            or "Shared line ends stay contested even without a junction, so spacing still matters.",
         timeLimit = timeLimit,
-        junctions = orderedJunctions,
+        junctions = playableJunctions,
         edges = edges,
         trains = trains,
     }, {}, nil

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -1958,6 +1958,45 @@ function mapEditor:sortRouteIdsByMagnet(routeIds, magnetKind)
     end)
 end
 
+function mapEditor:isSharedEndpointIntersection(groupedIntersection)
+    local sharedStartEndpointId = nil
+    local sharedEndEndpointId = nil
+    local allAtSharedStart = true
+    local allAtSharedEnd = true
+    local toleranceSquared = 12 * 12
+
+    for _, routeId in ipairs(groupedIntersection.routeIds or {}) do
+        local route = self:getRouteById(routeId)
+        if not route or not route.points or #route.points < 2 then
+            return false
+        end
+
+        local startPoint = route.points[1]
+        local endPoint = route.points[#route.points]
+        local touchesStart = distanceSquared(startPoint.x, startPoint.y, groupedIntersection.x, groupedIntersection.y) <= toleranceSquared
+        local touchesEnd = distanceSquared(endPoint.x, endPoint.y, groupedIntersection.x, groupedIntersection.y) <= toleranceSquared
+
+        if not touchesStart then
+            allAtSharedStart = false
+        elseif sharedStartEndpointId and sharedStartEndpointId ~= route.startEndpointId then
+            allAtSharedStart = false
+        else
+            sharedStartEndpointId = route.startEndpointId
+        end
+
+        if not touchesEnd then
+            allAtSharedEnd = false
+        elseif sharedEndEndpointId and sharedEndEndpointId ~= route.endEndpointId then
+            allAtSharedEnd = false
+        else
+            sharedEndEndpointId = route.endEndpointId
+        end
+    end
+
+    return (allAtSharedStart and sharedStartEndpointId ~= nil)
+        or (allAtSharedEnd and sharedEndEndpointId ~= nil)
+end
+
 function mapEditor:rebuildIntersections()
     local previousIntersections = self.intersections or {}
     local grouped = {}
@@ -2010,6 +2049,10 @@ function mapEditor:rebuildIntersections()
     self.intersections = {}
 
     for _, groupedIntersection in pairs(grouped) do
+        if self:isSharedEndpointIntersection(groupedIntersection) then
+            goto continue_intersection
+        end
+
         table.sort(groupedIntersection.routeIds)
         local routeKey = table.concat(groupedIntersection.routeIds, "|")
         local inputEndpointIds = {}
@@ -2058,6 +2101,8 @@ function mapEditor:rebuildIntersections()
         intersection.activeInputIndex = math.min((state and state.activeInputIndex) or 1, math.max(1, #inputRouteIds))
         intersection.activeOutputIndex = math.min((state and state.activeOutputIndex) or 1, math.max(1, #outputEndpointIds))
         self.intersections[#self.intersections + 1] = intersection
+
+        ::continue_intersection::
     end
 
     table.sort(self.intersections, function(a, b)

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -710,7 +710,7 @@ function world:buildMinimumDistanceLookup()
         local goalColor = train.goalColor
         local bestDistance = nil
 
-        if startEdge and startEdge.targetType == "junction" then
+        if startEdge then
             local queue = {
                 {
                     edgeId = startEdge.id,
@@ -731,7 +731,20 @@ function world:buildMinimumDistanceLookup()
                 end
 
                 local currentEdge = self.edges[current.edgeId]
-                if not currentEdge or currentEdge.targetType ~= "junction" then
+                if not currentEdge then
+                    goto continue_distance_search
+                end
+
+                if currentEdge.targetType == "exit" then
+                    if containsColorId(currentEdge.colors, goalColor) or nearestColorId(currentEdge.color) == goalColor then
+                        if not bestDistance or current.distance < bestDistance then
+                            bestDistance = current.distance
+                        end
+                    end
+                    goto continue_distance_search
+                end
+
+                if currentEdge.targetType ~= "junction" then
                     goto continue_distance_search
                 end
 
@@ -1380,12 +1393,12 @@ function world:updateCollisionState()
 
     for firstIndex = 1, #self.trains - 1 do
         local firstTrain = self.trains[firstIndex]
-        if not self:isTrainCleared(firstTrain) then
+        if firstTrain.spawned and not firstTrain.completed then
             local firstCars = self:getTrainCarriagePositions(firstTrain)
 
             for secondIndex = firstIndex + 1, #self.trains do
                 local secondTrain = self.trains[secondIndex]
-                if not self:isTrainCleared(secondTrain) then
+                if secondTrain.spawned and not secondTrain.completed then
                     local secondCars = self:getTrainCarriagePositions(secondTrain)
 
                     for _, firstCar in ipairs(firstCars) do
@@ -1709,6 +1722,35 @@ function world:drawInputTrack(track, isActive)
     local trackColor = isActive and track.color or track.darkColor
     local trackAlpha = isActive and 0.96 or 0.72
     local stripeColors = buildTrackStripeColors(track.colors, isActive)
+    local renderedPoints = self:getRenderedTrackPoints(track)
+    if #renderedPoints < 2 then
+        return
+    end
+
+    local points = flattenPoints(renderedPoints)
+
+    graphics.setLineStyle("rough")
+    graphics.setColor(0.17, 0.21, 0.24, 0.95)
+    graphics.setLineWidth(self.trackWidth + 10)
+    graphics.line(points)
+
+    if stripeColors then
+        self:drawStripedTrack(points, self.trackWidth, stripeColors, trackAlpha)
+    else
+        self:drawTrackLine(points, self.trackWidth, trackColor, trackAlpha)
+    end
+end
+
+function world:drawStandaloneTrack(track, isActive)
+    local graphics = love.graphics
+    local trackColor = isActive and track.color or track.darkColor
+    local trackAlpha = isActive and 0.96 or 0.72
+    local stripeColors = nil
+
+    if not track.adoptInputColor then
+        stripeColors = buildTrackStripeColors(track.colors, isActive)
+    end
+
     local renderedPoints = self:getRenderedTrackPoints(track)
     if #renderedPoints < 2 then
         return
@@ -2065,6 +2107,7 @@ function world:drawTrain(train)
     local carriages = self:getTrainCarriagePositions(train)
     local width = self.carriageLength
     local height = 18
+    local outlineWidth = 2
     local alpha = 1
 
     if train.exiting and self.exitFadeDuration > 0 then
@@ -2084,6 +2127,7 @@ function world:drawTrain(train)
         graphics.setColor(train.darkColor[1], train.darkColor[2], train.darkColor[3], 0.95 * alpha)
         graphics.rectangle("fill", -width * 0.5, -height * 0.5, width, height, 5, 5)
         graphics.setColor(train.color[1], train.color[2], train.color[3], alpha)
+        graphics.setLineWidth(outlineWidth)
         graphics.rectangle("line", -width * 0.5, -height * 0.5, width, height, 5, 5)
         graphics.setColor(0.94, 0.96, 0.98, 0.9 * alpha)
         graphics.rectangle("fill", -width * 0.22, -height * 0.28, width * 0.44, height * 0.56, 3, 3)
@@ -2110,6 +2154,7 @@ end
 function world:draw()
     local graphics = love.graphics
     local highlightedEdgeIds = self:getHighlightedEdgeIds()
+    local drawnEdgeIds = {}
 
     graphics.setColor(0.08, 0.1, 0.12, 1)
     graphics.rectangle("fill", 0, 0, self.viewport.w, self.viewport.h)
@@ -2118,17 +2163,29 @@ function world:draw()
         for outputIndex = 1, #junction.outputs do
             local outputTrack = junction.outputs[outputIndex]
             self:drawOutputTrack(junction, outputIndex, outputTrack and highlightedEdgeIds[outputTrack.id] == true)
+            if outputTrack then
+                drawnEdgeIds[outputTrack.id] = true
+            end
         end
 
         for inputIndex = 1, #junction.inputs do
             local inputTrack = junction.inputs[inputIndex]
             self:drawInputTrack(inputTrack, inputTrack and highlightedEdgeIds[inputTrack.id] == true)
+            if inputTrack then
+                drawnEdgeIds[inputTrack.id] = true
+            end
         end
 
         self:drawCrossing(junction)
 
         for inputIndex = 1, #junction.inputs do
             self:drawTrackSignal(junction, inputIndex)
+        end
+    end
+
+    for _, track in pairs(self.edges or {}) do
+        if track and not drawnEdgeIds[track.id] then
+            self:drawStandaloneTrack(track, highlightedEdgeIds[track.id] == true)
         end
     end
 


### PR DESCRIPTION
## Requested Behavior
- When two routes merge into a single outpoint, treat it as a shared endpoint rather than a junction.
- Do not create zero-length junction segments or validation errors for that merge.
- Allow trains targeting each merged color to validate and score normally.
- Keep the in-game rendering consistent with existing track and train visuals.

## Summary
- Treat shared endpoint merges as direct endpoint convergence instead of junctions in the editor and playable map build.
- Preserve output color availability for merged outpoints, including adopted input colors.
- Allow direct `start -> exit` edges in runtime pathing and collision handling so trains can converge at the same endpoint safely.
- Render standalone edges through the normal track pipeline and keep train wagon outlines at a fixed width so shared-endpoint maps match the standard look.

## Testing
- Not run (not requested)