### PR TITLE
Refactor level flow and in-run HUD into prep and play phases

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -79,6 +79,7 @@ function Game.new()
     self.levelSelectScroll = 0
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = nil
 
     self:updateRenderTransform()
     self:refreshMaps()
@@ -223,6 +224,7 @@ function Game:openMenu()
     self.levelSelectFilterHoverId = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = nil
     self:refreshMaps()
 end
 
@@ -233,6 +235,7 @@ function Game:openLevelSelect()
     self.levelSelectFilterHoverId = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = nil
     self:refreshMaps()
     local preferredMap = self.currentMapDescriptor
     if preferredMap then
@@ -254,6 +257,7 @@ function Game:openEditorBlank()
     self.levelSelectIssue = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = nil
     self.editor:resetFromMap(nil, nil)
 end
 
@@ -269,6 +273,7 @@ function Game:openEditorMap(mapDescriptor)
     self.levelSelectIssue = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = nil
     self.editor:resetFromMap(mapData, mapDescriptor)
     return true
 end
@@ -297,6 +302,7 @@ function Game:startMap(mapDescriptor)
     self.levelSelectIssue = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
+    self.playPhase = "prepare"
     self.world = world.new(self.viewport.w, self.viewport.h, mapData.level)
     self.screen = "play"
     return true
@@ -312,6 +318,19 @@ end
 
 function Game:isRunLocked()
     return self.levelComplete or self.failureReason ~= nil
+end
+
+function Game:isPreparingRun()
+    return self.screen == "play" and self.playPhase == "prepare"
+end
+
+function Game:startPlayPhase()
+    if not self.world or self.playPhase ~= "prepare" then
+        return false
+    end
+
+    self.playPhase = "play"
+    return true
 end
 
 function Game:openResults()
@@ -341,6 +360,10 @@ function Game:update(dt)
     end
 
     if self.screen == "results" or self:isRunLocked() then
+        return
+    end
+
+    if self.playPhase ~= "play" then
         return
     end
 
@@ -616,6 +639,11 @@ function Game:mousepressed(x, y, button)
 
     if ui.getPlayBackHit(self, viewportX, viewportY) then
         self:openMenu()
+        return
+    end
+
+    if button == 1 and ui.getPlayStartHit(self, viewportX, viewportY) then
+        self:startPlayPhase()
         return
     end
 

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -1216,6 +1216,8 @@ local function getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, h
     }
 end
 
+local PREP_TRAIN_ROW_SPACING = 8
+local PREP_TRAIN_ARROW_LENGTH = 19
 local getPrepTrainRowWidth
 
 local function getInputPrepCardRect(game, edge, trainCount)
@@ -1236,18 +1238,19 @@ local function getInputPrepCardRect(game, edge, trainCount)
     return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, height, 12)
 end
 
-local function getInputLiveCardRect(game, edge)
+local function getInputLiveCardRect(game, edge, train)
     local anchorX, anchorY, dirX, dirY = getTrackOuterAnchor(edge, false)
-    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, 244, 82, 12)
+    local width = math.max(140, getPrepTrainRowWidth(game, train) + 20)
+    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, 54, 12)
 end
 
-local function getOutputBadgeRect(game, edge)
+local function getOutputBadgeRect(game, edge, badge)
     local anchorX, anchorY, dirX, dirY = getTrackOuterAnchor(edge, true)
-    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, 132, 62, 12)
+    love.graphics.setFont(game.fonts.body)
+    local ratioText = string.format("%d / %d", badge.deliveredCount or 0, badge.expectedCount or 0)
+    local width = math.max(64, game.fonts.body:getWidth(ratioText) + PREP_TRAIN_ROW_SPACING * 2 + 16)
+    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, 44, 12)
 end
-
-local PREP_TRAIN_ROW_SPACING = 8
-local PREP_TRAIN_ARROW_LENGTH = 19
 
 local function formatSecondsLabel(value)
     return string.format("%ss", formatTimeValue(value))
@@ -1348,6 +1351,42 @@ local function drawPrepTrainPreview(game, x, centerY, train)
     graphics.setLineWidth(1)
 end
 
+local function drawTrainRow(game, rowRect, leadText, deadlineText, train)
+    local graphics = love.graphics
+    local centerY = rowRect.y + rowRect.h * 0.5
+
+    graphics.setColor(0.06, 0.08, 0.1, 0.96)
+    graphics.rectangle("fill", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
+    graphics.setColor(0.24, 0.32, 0.4, 1)
+    graphics.setLineWidth(1.1)
+    graphics.rectangle("line", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
+
+    love.graphics.setFont(game.fonts.small)
+    local leadWidth = game.fonts.small:getWidth(leadText)
+    local deadlineWidth = deadlineText and game.fonts.small:getWidth(deadlineText) or 0
+    local contentStartX = rowRect.x + PREP_TRAIN_ROW_SPACING
+
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.print(leadText, contentStartX, rowRect.y + 9)
+
+    local nextX = contentStartX + leadWidth + PREP_TRAIN_ROW_SPACING
+    if deadlineText then
+        local arrowStartX = nextX
+        local arrowEndX = arrowStartX + PREP_TRAIN_ARROW_LENGTH
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.setLineWidth(2)
+        graphics.line(arrowStartX, centerY, arrowEndX, centerY)
+        graphics.line(arrowEndX - 4, centerY - 3, arrowEndX, centerY)
+        graphics.line(arrowEndX - 4, centerY + 3, arrowEndX, centerY)
+        graphics.setLineWidth(1)
+        nextX = arrowEndX + PREP_TRAIN_ROW_SPACING
+        graphics.print(deadlineText, nextX, rowRect.y + 9)
+        nextX = nextX + deadlineWidth + PREP_TRAIN_ROW_SPACING
+    end
+
+    drawPrepTrainPreview(game, nextX, centerY, train)
+end
+
 local function drawInputPrepCard(game, group)
     local graphics = love.graphics
     local rect = getInputPrepCardRect(game, group.edge, #(group.trains or {}))
@@ -1374,93 +1413,43 @@ local function drawInputPrepCard(game, group)
             w = rowWidth,
             h = rowHeight,
         }
-        local centerY = rowRect.y + rowRect.h * 0.5
         local startText = formatSecondsLabel(train.spawnTime or 0)
         local deadlineText = train.deadline ~= nil and formatSecondsLabel(train.deadline) or nil
-
-        graphics.setColor(0.06, 0.08, 0.1, 0.96)
-        graphics.rectangle("fill", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
-        graphics.setColor(0.24, 0.32, 0.4, 1)
-        graphics.setLineWidth(1.1)
-        graphics.rectangle("line", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
-
-        love.graphics.setFont(game.fonts.small)
-        local startWidth = game.fonts.small:getWidth(startText)
-        local deadlineWidth = deadlineText and game.fonts.small:getWidth(deadlineText) or 0
-        local contentStartX = rowRect.x + PREP_TRAIN_ROW_SPACING
-
-        graphics.setColor(0.97, 0.98, 1, 1)
-        graphics.print(startText, contentStartX, rowRect.y + 9)
-
-        local nextX = contentStartX + startWidth + PREP_TRAIN_ROW_SPACING
-        if deadlineText then
-            local arrowStartX = nextX
-            local arrowEndX = arrowStartX + PREP_TRAIN_ARROW_LENGTH
-            graphics.setColor(0.97, 0.98, 1, 1)
-            graphics.setLineWidth(2)
-            graphics.line(arrowStartX, centerY, arrowEndX, centerY)
-            graphics.line(arrowEndX - 4, centerY - 3, arrowEndX, centerY)
-            graphics.line(arrowEndX - 4, centerY + 3, arrowEndX, centerY)
-            graphics.setLineWidth(1)
-            nextX = arrowEndX + PREP_TRAIN_ROW_SPACING
-            graphics.print(deadlineText, nextX, rowRect.y + 9)
-            nextX = nextX + deadlineWidth + PREP_TRAIN_ROW_SPACING
-        end
-
-        drawPrepTrainPreview(game, nextX, centerY, train)
+        drawTrainRow(game, rowRect, startText, deadlineText, train)
         rowY = rowY + rowHeight + rowGap
     end
 end
 
 local function drawInputLiveCard(game, edge, train)
     local graphics = love.graphics
-    local rect = getInputLiveCardRect(game, edge)
+    local rect = getInputLiveCardRect(game, edge, train)
     local remainingSeconds = math.max(0, (train.spawnTime or 0) - (game.world.elapsedTime or 0))
 
     drawMetalPanel(rect, 0.96)
-
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf(edge.label or edge.id, rect.x + 12, rect.y + 10, rect.w - 24, "left")
-
-    graphics.setColor(0.84, 0.88, 0.92, 1)
-    graphics.printf(tostring(train.id or "--"), rect.x + 12, rect.y + 31, rect.w - 24, "left")
-    graphics.printf(
-        string.format("Line %s -> Goal %s", getColorLabel(train.lineColor), getColorLabel(train.goalColor or train.trainColor)),
-        rect.x + 12,
-        rect.y + 49,
-        rect.w - 24,
-        "left"
-    )
-    graphics.setColor(0.99, 0.78, 0.32, 1)
-    graphics.printf(
-        string.format("Arrives in %ss | Deadline %s", formatTimeValue(remainingSeconds), formatTimeValue(train.deadline)),
-        rect.x + 12,
-        rect.y + 65,
-        rect.w - 24,
-        "left"
+    drawTrainRow(
+        game,
+        {
+            x = math.floor(rect.x + 10),
+            y = math.floor(rect.y + 10),
+            w = rect.w - 20,
+            h = 34,
+        },
+        formatSecondsLabel(remainingSeconds),
+        train.deadline ~= nil and formatSecondsLabel(train.deadline) or nil,
+        train
     )
 end
 
 local function drawOutputBadge(game, badge)
     local graphics = love.graphics
-    local rect = getOutputBadgeRect(game, badge.edge)
+    local rect = getOutputBadgeRect(game, badge.edge, badge)
+    local ratioText = string.format("%d / %d", badge.deliveredCount or 0, badge.expectedCount or 0)
 
     drawMetalPanel(rect, 0.96)
 
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf(badge.edge.label or badge.edge.id, rect.x + 10, rect.y + 10, rect.w - 20, "center")
-
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.48, 0.92, 0.62, 1)
-    graphics.printf(
-        string.format("%d / %d", badge.deliveredCount or 0, badge.expectedCount or 0),
-        rect.x,
-        rect.y + 28,
-        rect.w,
-        "center"
-    )
+    graphics.printf(ratioText, rect.x, rect.y + math.floor((rect.h - game.fonts.body:getHeight()) * 0.5 + 0.5), rect.w, "center")
 end
 
 function ui.getPlayBackHit(_, x, y)

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -82,6 +82,37 @@ local function lerp(a, b, t)
     return a + ((b - a) * t)
 end
 
+local function clamp(value, minValue, maxValue)
+    if value < minValue then
+        return minValue
+    end
+    if value > maxValue then
+        return maxValue
+    end
+    return value
+end
+
+local function angleBetweenPoints(a, b)
+    local dx = (b and b.x or 0) - (a and a.x or 0)
+    local dy = (b and b.y or 0) - (a and a.y or 0)
+    if math.atan2 then
+        return math.atan2(dy, dx)
+    end
+
+    if dx == 0 then
+        if dy >= 0 then
+            return math.pi * 0.5
+        end
+        return -math.pi * 0.5
+    end
+
+    local angle = math.atan(dy / dx)
+    if dx < 0 then
+        angle = angle + math.pi
+    end
+    return angle
+end
+
 local function drawButton(rect, label, fillColor, strokeColor, font)
     local graphics = love.graphics
     graphics.setColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] or 1)
@@ -240,16 +271,22 @@ local function getTrainStatusText(worldState, train)
 end
 
 local function buildPlayHelpSections(game)
+    local controlLines = {
+        "Left click a junction to activate its control.",
+        "Left click the selector below a junction to cycle outputs forward.",
+        "Right click the selector below a junction to cycle outputs backward.",
+        "M opens the menu. E opens the editor. R restarts the run.",
+        "F2 closes this help panel. F3 opens the debug panel.",
+    }
+
+    if game.playPhase == "prepare" then
+        controlLines[#controlLines + 1] = "Use the Start button when your routes are set."
+    end
+
     local sections = {
         {
             title = "Controls",
-            lines = {
-                "Left click a junction to activate its control.",
-                "Left click the selector below a junction to cycle outputs forward.",
-                "Right click the selector below a junction to cycle outputs backward.",
-                "M opens the menu. E opens the editor. R restarts the run.",
-                "F2 closes this help panel. F3 opens the debug panel.",
-            },
+            lines = controlLines,
         },
         {
             title = "Junctions",
@@ -266,7 +303,35 @@ local function buildPlayHelpSections(game)
 end
 
 local function buildPlayDebugSections(game)
+    local runSummary = game.world:getRunSummary()
+    local nextTrain = game.world:getNextQueuedTrain()
+    local nextDeadline = game.world:getNearestPendingDeadline()
     local sections = {
+        {
+            title = "Run Stats",
+            lines = {
+                string.format("Phase: %s", game.playPhase == "prepare" and "Preparation" or "Play"),
+                string.format("Elapsed: %.1fs", game.world.elapsedTime or 0),
+                game.world.timeRemaining and string.format("Time left: %.1fs", game.world.timeRemaining) or "Time left: Unlimited",
+                string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #game.world.trains),
+                string.format("Interactions: %d", runSummary.interactionCount or 0),
+                string.format("Score: %s", formatScore(runSummary.finalScore or 0)),
+                nextTrain and string.format(
+                    "Next spawn: %s at %.1fs",
+                    game.world:getTrainSummary(nextTrain),
+                    nextTrain.spawnTime or 0
+                ) or "Next spawn: none",
+                nextDeadline and string.format(
+                    "Nearest deadline: %s by %.1fs",
+                    game.world:getTrainSummary(nextDeadline),
+                    nextDeadline.deadline or 0
+                ) or "Nearest deadline: none",
+            },
+        },
+        {
+            title = "Active Routes",
+            lines = { game.world:getActiveRouteSummary() },
+        },
         {
             title = "Junction State",
             lines = {},
@@ -277,44 +342,21 @@ local function buildPlayDebugSections(game)
         },
     }
     local worldState = game.world
-    local queueGroups = {}
-    local orderedGroups = {}
 
     for _, junction in ipairs(worldState.junctionOrder or {}) do
-        sections[1].lines[#sections[1].lines + 1] = string.format("%s | %s", junction.label, getJunctionRouteText(junction))
-        sections[1].lines[#sections[1].lines + 1] = getJunctionStateText(junction)
+        sections[3].lines[#sections[3].lines + 1] = string.format("%s | %s", junction.label, getJunctionRouteText(junction))
+        sections[3].lines[#sections[3].lines + 1] = getJunctionStateText(junction)
     end
 
-    for _, train in ipairs(worldState.trains or {}) do
-        local startEdgeId = train.startEdgeId or train.edgeId
-        local startEdge = worldState.edges[startEdgeId]
-        if not queueGroups[startEdgeId] then
-            queueGroups[startEdgeId] = {
-                label = startEdge and startEdge.label or startEdgeId,
-                trains = {},
-            }
-            orderedGroups[#orderedGroups + 1] = queueGroups[startEdgeId]
-        end
-        queueGroups[startEdgeId].trains[#queueGroups[startEdgeId].trains + 1] = train
-    end
-
-    table.sort(orderedGroups, function(firstGroup, secondGroup)
-        return firstGroup.label < secondGroup.label
-    end)
-
-    for _, group in ipairs(orderedGroups) do
-        table.sort(group.trains, function(firstTrain, secondTrain)
-            return (firstTrain.startProgress or 0) > (secondTrain.startProgress or 0)
-        end)
-
-        sections[2].lines[#sections[2].lines + 1] = string.format("%s queue", group.label)
+    for _, group in ipairs(worldState:getInputEdgeGroups()) do
+        sections[4].lines[#sections[4].lines + 1] = string.format("%s queue", group.edge.label or group.edge.id)
         for index, train in ipairs(group.trains) do
-            sections[2].lines[#sections[2].lines + 1] = string.format(
+            sections[4].lines[#sections[4].lines + 1] = string.format(
                 "%d. %s | start %.0f | %.2fx | %s",
                 index,
                 train.id,
-                train.startProgress or 0,
-                train.speedScale or 1,
+                train.spawnTime or 0,
+                train.speed / math.max(1, worldState.trainSpeed),
                 getTrainStatusText(worldState, train)
             )
         end
@@ -1085,13 +1127,352 @@ function ui.getLevelSelectFilterHoverId(game, x, y)
     return nil
 end
 
-function ui.getPlayBackHit(_, x, y)
-    return pointInRect(x, y, {
+local function getPlayBackRect()
+    return {
         x = 1114,
         y = 28,
         w = 134,
         h = 38,
-    })
+    }
+end
+
+local function getPlayStartRect()
+    return {
+        x = 1048,
+        y = 74,
+        w = 200,
+        h = 46,
+    }
+end
+
+local function formatTimeValue(value)
+    if value == nil then
+        return "--"
+    end
+    return string.format("%.1f", value)
+end
+
+local function getColorLabel(colorId)
+    if not colorId then
+        return "--"
+    end
+    return colorId:sub(1, 1):upper() .. colorId:sub(2)
+end
+
+local function getTrackOuterAnchor(track, isOutput)
+    local points = track and track.path and track.path.points or {}
+    if #points == 0 then
+        return 0, 0, 0, -1
+    end
+
+    local outerPoint
+    local innerPoint
+    if isOutput then
+        outerPoint = points[#points]
+        innerPoint = points[#points - 1] or outerPoint
+    else
+        outerPoint = points[1]
+        innerPoint = points[2] or outerPoint
+    end
+
+    local angle = angleBetweenPoints(outerPoint, innerPoint)
+    local dirX = math.cos(angle)
+    local dirY = math.sin(angle)
+    if not isOutput then
+        dirX = -dirX
+        dirY = -dirY
+    end
+
+    return outerPoint.x, outerPoint.y, dirX, dirY
+end
+
+local function getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, height, offset)
+    local push = offset or 18
+    local targetX = anchorX + dirX * push
+    local targetY = anchorY + dirY * push
+    local rectX = targetX - width * 0.5
+    local rectY
+
+    if math.abs(dirX) > math.abs(dirY) then
+        if dirX < 0 then
+            rectX = targetX - width - 10
+        else
+            rectX = targetX + 10
+        end
+        rectY = targetY - height * 0.5
+    else
+        if dirY < 0 then
+            rectY = targetY - height - 10
+        else
+            rectY = targetY + 10
+        end
+    end
+
+    return {
+        x = clamp(rectX, 18, game.viewport.w - width - 18),
+        y = clamp(rectY or (targetY - height * 0.5), 82, game.viewport.h - height - 70),
+        w = width,
+        h = height,
+    }
+end
+
+local getPrepTrainRowWidth
+
+local function getInputPrepCardRect(game, edge, trainCount)
+    local rowCount = math.max(1, trainCount or 0)
+    local height = 20 + rowCount * 44
+    local width = 140
+
+    for _, group in ipairs(game.world:getInputEdgeGroups()) do
+        if group.edge.id == edge.id then
+            for _, train in ipairs(group.trains or {}) do
+                width = math.max(width, getPrepTrainRowWidth(game, train) + 20)
+            end
+            break
+        end
+    end
+
+    local anchorX, anchorY, dirX, dirY = getTrackOuterAnchor(edge, false)
+    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, width, height, 12)
+end
+
+local function getInputLiveCardRect(game, edge)
+    local anchorX, anchorY, dirX, dirY = getTrackOuterAnchor(edge, false)
+    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, 244, 82, 12)
+end
+
+local function getOutputBadgeRect(game, edge)
+    local anchorX, anchorY, dirX, dirY = getTrackOuterAnchor(edge, true)
+    return getAnchoredPanelRect(game, anchorX, anchorY, dirX, dirY, 132, 62, 12)
+end
+
+local PREP_TRAIN_ROW_SPACING = 8
+local PREP_TRAIN_ARROW_LENGTH = 19
+
+local function formatSecondsLabel(value)
+    return string.format("%ss", formatTimeValue(value))
+end
+
+local function getPrepTrainPreviewMetrics(game, train)
+    local wagonCount = math.max(1, train.wagonCount or 1)
+    local gap = 4
+    local carriageWidth = 16
+    local carriageHeight = 16
+    local countText = nil
+    local totalWidth
+    local iconCount = math.min(wagonCount, 5)
+
+    if wagonCount > 5 then
+        love.graphics.setFont(game.fonts.small)
+        countText = string.format("%dx", wagonCount)
+        totalWidth = game.fonts.small:getWidth(countText) + gap + carriageWidth
+        iconCount = 1
+    else
+        totalWidth = iconCount * carriageWidth + (iconCount - 1) * gap
+    end
+
+    return {
+        gap = gap,
+        wagonCount = wagonCount,
+        iconCount = iconCount,
+        countText = countText,
+        carriageWidth = carriageWidth,
+        carriageHeight = carriageHeight,
+        totalWidth = totalWidth,
+    }
+end
+
+local function getPrepTrainRowContentWidth(game, train)
+    love.graphics.setFont(game.fonts.small)
+
+    local startText = formatSecondsLabel(train.spawnTime or 0)
+    local deadlineText = train.deadline ~= nil and formatSecondsLabel(train.deadline) or nil
+    local startWidth = game.fonts.small:getWidth(startText)
+    local deadlineWidth = deadlineText and game.fonts.small:getWidth(deadlineText) or 0
+    local trainMetrics = getPrepTrainPreviewMetrics(game, train)
+
+    if deadlineText then
+        return startWidth
+            + PREP_TRAIN_ROW_SPACING
+            + PREP_TRAIN_ARROW_LENGTH
+            + PREP_TRAIN_ROW_SPACING
+            + deadlineWidth
+            + PREP_TRAIN_ROW_SPACING
+            + trainMetrics.totalWidth
+    end
+
+    return startWidth + PREP_TRAIN_ROW_SPACING + trainMetrics.totalWidth
+end
+
+getPrepTrainRowWidth = function(game, train)
+    return getPrepTrainRowContentWidth(game, train) + PREP_TRAIN_ROW_SPACING * 2
+end
+
+local function drawPrepTrainPreview(game, x, centerY, train)
+    local graphics = love.graphics
+    local metrics = getPrepTrainPreviewMetrics(game, train)
+    local startX = x
+    local carriageY = math.floor(centerY - metrics.carriageHeight * 0.5 + 0.5)
+    local bodyColor = train.color or { 0.84, 0.88, 0.92 }
+    local darkColor = train.darkColor or { bodyColor[1] * 0.42, bodyColor[2] * 0.42, bodyColor[3] * 0.42 }
+
+    if metrics.countText then
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print(metrics.countText, startX, math.floor(centerY - game.fonts.small:getHeight() * 0.5 + 0.5))
+        startX = startX + game.fonts.small:getWidth(metrics.countText) + metrics.gap
+    end
+
+    for carriageIndex = 1, metrics.iconCount do
+        local carriageX = startX + (carriageIndex - 1) * (metrics.carriageWidth + metrics.gap)
+        graphics.setColor(darkColor[1], darkColor[2], darkColor[3], 0.96)
+        graphics.rectangle("fill", carriageX, carriageY, metrics.carriageWidth, metrics.carriageHeight, 4, 4)
+        graphics.setColor(bodyColor[1], bodyColor[2], bodyColor[3], 1)
+        graphics.setLineWidth(1.4)
+        graphics.rectangle("line", carriageX, carriageY, metrics.carriageWidth, metrics.carriageHeight, 4, 4)
+
+        local windowWidth = math.max(3, metrics.carriageWidth - 8)
+        local windowHeight = math.max(4, metrics.carriageHeight - 8)
+        graphics.setColor(0.95, 0.97, 1, 0.9)
+        graphics.rectangle(
+            "fill",
+            carriageX + math.floor((metrics.carriageWidth - windowWidth) * 0.5 + 0.5),
+            carriageY + math.floor((metrics.carriageHeight - windowHeight) * 0.5 + 0.5),
+            windowWidth,
+            windowHeight,
+            2,
+            2
+        )
+    end
+
+    graphics.setLineWidth(1)
+end
+
+local function drawInputPrepCard(game, group)
+    local graphics = love.graphics
+    local rect = getInputPrepCardRect(game, group.edge, #(group.trains or {}))
+    local rowHeight = 34
+    local rowGap = 10
+    local rowCount = #(group.trains or {})
+    local totalRowsHeight = rowCount > 0 and (rowCount * rowHeight) + ((rowCount - 1) * rowGap) or 0
+    local rowY = rect.y + math.floor((rect.h - totalRowsHeight) * 0.5 + 0.5)
+
+    drawMetalPanel(rect, 0.96)
+
+    if rowCount == 0 then
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        graphics.printf("No scheduled trains.", rect.x + 16, rect.y + 14, rect.w - 32, "center")
+        return
+    end
+
+    for _, train in ipairs(group.trains or {}) do
+        local rowWidth = getPrepTrainRowWidth(game, train)
+        local rowRect = {
+            x = math.floor(rect.x + (rect.w - rowWidth) * 0.5 + 0.5),
+            y = rowY,
+            w = rowWidth,
+            h = rowHeight,
+        }
+        local centerY = rowRect.y + rowRect.h * 0.5
+        local startText = formatSecondsLabel(train.spawnTime or 0)
+        local deadlineText = train.deadline ~= nil and formatSecondsLabel(train.deadline) or nil
+
+        graphics.setColor(0.06, 0.08, 0.1, 0.96)
+        graphics.rectangle("fill", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
+        graphics.setColor(0.24, 0.32, 0.4, 1)
+        graphics.setLineWidth(1.1)
+        graphics.rectangle("line", rowRect.x, rowRect.y, rowRect.w, rowRect.h, 10, 10)
+
+        love.graphics.setFont(game.fonts.small)
+        local startWidth = game.fonts.small:getWidth(startText)
+        local deadlineWidth = deadlineText and game.fonts.small:getWidth(deadlineText) or 0
+        local contentStartX = rowRect.x + PREP_TRAIN_ROW_SPACING
+
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print(startText, contentStartX, rowRect.y + 9)
+
+        local nextX = contentStartX + startWidth + PREP_TRAIN_ROW_SPACING
+        if deadlineText then
+            local arrowStartX = nextX
+            local arrowEndX = arrowStartX + PREP_TRAIN_ARROW_LENGTH
+            graphics.setColor(0.97, 0.98, 1, 1)
+            graphics.setLineWidth(2)
+            graphics.line(arrowStartX, centerY, arrowEndX, centerY)
+            graphics.line(arrowEndX - 4, centerY - 3, arrowEndX, centerY)
+            graphics.line(arrowEndX - 4, centerY + 3, arrowEndX, centerY)
+            graphics.setLineWidth(1)
+            nextX = arrowEndX + PREP_TRAIN_ROW_SPACING
+            graphics.print(deadlineText, nextX, rowRect.y + 9)
+            nextX = nextX + deadlineWidth + PREP_TRAIN_ROW_SPACING
+        end
+
+        drawPrepTrainPreview(game, nextX, centerY, train)
+        rowY = rowY + rowHeight + rowGap
+    end
+end
+
+local function drawInputLiveCard(game, edge, train)
+    local graphics = love.graphics
+    local rect = getInputLiveCardRect(game, edge)
+    local remainingSeconds = math.max(0, (train.spawnTime or 0) - (game.world.elapsedTime or 0))
+
+    drawMetalPanel(rect, 0.96)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(edge.label or edge.id, rect.x + 12, rect.y + 10, rect.w - 24, "left")
+
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf(tostring(train.id or "--"), rect.x + 12, rect.y + 31, rect.w - 24, "left")
+    graphics.printf(
+        string.format("Line %s -> Goal %s", getColorLabel(train.lineColor), getColorLabel(train.goalColor or train.trainColor)),
+        rect.x + 12,
+        rect.y + 49,
+        rect.w - 24,
+        "left"
+    )
+    graphics.setColor(0.99, 0.78, 0.32, 1)
+    graphics.printf(
+        string.format("Arrives in %ss | Deadline %s", formatTimeValue(remainingSeconds), formatTimeValue(train.deadline)),
+        rect.x + 12,
+        rect.y + 65,
+        rect.w - 24,
+        "left"
+    )
+end
+
+local function drawOutputBadge(game, badge)
+    local graphics = love.graphics
+    local rect = getOutputBadgeRect(game, badge.edge)
+
+    drawMetalPanel(rect, 0.96)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(badge.edge.label or badge.edge.id, rect.x + 10, rect.y + 10, rect.w - 20, "center")
+
+    love.graphics.setFont(game.fonts.body)
+    graphics.setColor(0.48, 0.92, 0.62, 1)
+    graphics.printf(
+        string.format("%d / %d", badge.deliveredCount or 0, badge.expectedCount or 0),
+        rect.x,
+        rect.y + 28,
+        rect.w,
+        "center"
+    )
+end
+
+function ui.getPlayBackHit(_, x, y)
+    return pointInRect(x, y, getPlayBackRect())
+end
+
+function ui.getPlayStartHit(game, x, y)
+    if game.playPhase ~= "prepare" then
+        return false
+    end
+
+    return pointInRect(x, y, getPlayStartRect())
 end
 
 local function getResultsButtonRects(game)
@@ -1289,94 +1670,47 @@ end
 
 function ui.drawPlay(game)
     local graphics = love.graphics
-    local level = game.world:getLevel()
-    local runSummary = game.world:getRunSummary()
-    local gameTitleText = "Out of Signal"
-    local levelTitleText = level.title or ""
-    local titleFont = game.fonts.title
-    local levelFont = game.fonts.body
-    local timerFont = game.fonts.small
-    local timerText = game.world.timeRemaining and string.format("Time left: %.1fs", game.world.timeRemaining) or nil
-    local titleRowWidth = titleFont:getWidth(gameTitleText)
-    local levelRowWidth = 0
-    local timerRowWidth = timerText and timerFont:getWidth(timerText) or 0
-    local titleRowHeight = math.max(titleFont:getHeight(), levelFont:getHeight())
-    local headerHeight = titleRowHeight + PLAY_HEADER.paddingY * 2
+    local inputGroups = game.world:getInputEdgeGroups()
+    local outputGroups = game.world:getOutputBadgeGroups()
 
-    if levelTitleText ~= "" then
-        levelRowWidth = PLAY_HEADER.titleGap + levelFont:getWidth(levelTitleText)
+    for _, badge in ipairs(outputGroups) do
+        drawOutputBadge(game, badge)
     end
 
-    if timerText then
-        headerHeight = headerHeight + PLAY_HEADER.rowGap + timerFont:getHeight()
+    if game.playPhase == "prepare" then
+        for _, group in ipairs(inputGroups) do
+            drawInputPrepCard(game, group)
+        end
+    else
+        for _, group in ipairs(inputGroups) do
+            local nextTrain = game.world:getNextPendingTrainForInputEdge(group.edge.id)
+            if nextTrain then
+                drawInputLiveCard(game, group.edge, nextTrain)
+            end
+        end
     end
 
-    local playHeaderRect = {
-        x = PLAY_HEADER.x,
-        y = PLAY_HEADER.y,
-        w = math.max(titleRowWidth + levelRowWidth, timerRowWidth) + PLAY_HEADER.paddingX * 2,
-        h = headerHeight,
-    }
-    local titleRowY = playHeaderRect.y + PLAY_HEADER.paddingY
-    local textX = playHeaderRect.x + PLAY_HEADER.paddingX
+    drawButton(getPlayBackRect(), "Main Menu", { 0.09, 0.11, 0.15, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
 
-    graphics.setColor(0, 0, 0, 0.34)
-    graphics.rectangle("fill", playHeaderRect.x, playHeaderRect.y, playHeaderRect.w, playHeaderRect.h, PLAY_HEADER.radius, PLAY_HEADER.radius)
-
-    love.graphics.setFont(titleFont)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.print(gameTitleText, textX, titleRowY)
-
-    if levelTitleText ~= "" then
-        love.graphics.setFont(levelFont)
+    if game.playPhase == "prepare" then
+        drawButton(getPlayStartRect(), "Start Run", { 0.12, 0.17, 0.2, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
+        love.graphics.setFont(game.fonts.small)
         graphics.setColor(0.84, 0.88, 0.92, 1)
-        graphics.print(
-            levelTitleText,
-            textX + titleRowWidth + PLAY_HEADER.titleGap,
-            titleRowY + math.floor((titleRowHeight - levelFont:getHeight()) * 0.5 + 0.5)
-        )
+        graphics.printf("Preparation Phase: set your routes, then start the clock.", 0, 34, game.viewport.w, "center")
     end
-
-    if timerText then
-        love.graphics.setFont(timerFont)
-        graphics.setColor(0.99, 0.83, 0.44, 1)
-        graphics.print(timerText, textX, titleRowY + titleRowHeight + PLAY_HEADER.rowGap)
-    end
-
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.48, 0.92, 0.62, 1)
-    graphics.print(game.world:getActiveRouteSummary(), 42, 152)
-
-    local trainsText = string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #game.world.trains)
-    graphics.setColor(0.84, 0.88, 0.92, 0.95)
-    graphics.print(trainsText, 42, 174)
-    graphics.print(string.format("Interactions: %d", runSummary.interactionCount or 0), 42, 196)
-    graphics.print(string.format("Score: %s", formatScore(runSummary.finalScore or 0)), 220, 196)
-
-    local nextTrain = game.world:getNextQueuedTrain()
-    if nextTrain then
-        graphics.setColor(0.72, 0.78, 0.84, 1)
-        graphics.print(string.format("Next spawn: %s at %.1fs", game.world:getTrainSummary(nextTrain), nextTrain.spawnTime or 0), 42, 220)
-    end
-
-    local nextDeadline = game.world:getNearestPendingDeadline()
-    if nextDeadline then
-        graphics.setColor(0.99, 0.78, 0.32, 1)
-        graphics.print(string.format("Nearest deadline: %s by %.1fs", game.world:getTrainSummary(nextDeadline), nextDeadline.deadline), 360, 220)
-    end
-
-    drawButton(
-        { x = 1114, y = 28, w = 134, h = 38 },
-        "Main Menu",
-        { 0.09, 0.11, 0.15, 0.98 },
-        { 0.3, 0.36, 0.42, 1 },
-        game.fonts.small
-    )
 
     graphics.setColor(0, 0, 0, 0.3)
     graphics.rectangle("fill", game.viewport.w - 286, game.viewport.h - 54, 250, 30, 15, 15)
     graphics.setColor(0.8, 0.84, 0.9, 0.82)
-    graphics.printf("Press F2 for help, F3 for debug, M for menu, E for editor, or R to restart", 0, game.viewport.h - 42, game.viewport.w, "center")
+    graphics.printf(
+        game.playPhase == "prepare"
+            and "Press F2 for help, F3 for debug, M for menu, E for editor, or R to reset prep"
+            or "Press F2 for help, F3 for debug, M for menu, E for editor, or R to restart",
+        0,
+        game.viewport.h - 42,
+        game.viewport.w,
+        "center"
+    )
 
     drawPlayInfoOverlay(game)
 end

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -132,6 +132,23 @@ local function formatColorLabel(colorId)
     return colorId:sub(1, 1):upper() .. colorId:sub(2)
 end
 
+local function appendUnique(list, lookup, value)
+    if value and not lookup[value] then
+        lookup[value] = true
+        list[#list + 1] = value
+    end
+end
+
+local function compareScheduledTrains(firstTrain, secondTrain)
+    local firstSpawn = firstTrain.spawnTime or 0
+    local secondSpawn = secondTrain.spawnTime or 0
+    if math.abs(firstSpawn - secondSpawn) > 0.0001 then
+        return firstSpawn < secondSpawn
+    end
+
+    return tostring(firstTrain.id or "") < tostring(secondTrain.id or "")
+end
+
 local function denormalizePoints(points, viewportW, viewportH)
     local denormalized = {}
 
@@ -808,6 +825,7 @@ function world:initializeLevel()
                 completed = false,
                 completedAt = nil,
                 clearedAt = nil,
+                clearingExitEdgeId = nil,
                 deliveredCorrectly = false,
                 deliveredLate = false,
                 failedWrongDestination = false,
@@ -853,6 +871,7 @@ function world:spawnTrain(train)
     train.exiting = false
     train.exitFadeRemaining = 0
     train.clearedAt = nil
+    train.clearingExitEdgeId = nil
 end
 
 function world:isTrainCleared(train)
@@ -876,6 +895,7 @@ function world:beginTrainExit(train)
     train.exiting = true
     train.exitFadeRemaining = self.exitFadeDuration
     train.clearedAt = self.elapsedTime
+    train.clearingExitEdgeId = train.clearingExitEdgeId or (currentEdge and currentEdge.id or nil)
 end
 
 function world:completeTrain(train)
@@ -1260,6 +1280,9 @@ function world:advanceTrainToNextEdge(train, junction, overflow)
     train.edgeId = outputEdge.id
     train.occupiedEdgeIds[#train.occupiedEdgeIds + 1] = outputEdge.id
     self:trimTrainOccupiedEdges(train)
+    if outputEdge.targetType == "exit" then
+        train.clearingExitEdgeId = outputEdge.id
+    end
 
     if junction.control.type == "trip" and junction.control.remainingTrips > 0 and not junction.control.pendingResetTrainId then
         junction.control.pendingResetTrainId = train.id
@@ -1549,6 +1572,111 @@ end
 
 function world:getCurrentScore()
     return self:getRunSummary().finalScore
+end
+
+function world:getInputEdgeGroups()
+    local groupsByEdgeId = {}
+    local orderedGroups = {}
+
+    for _, junction in ipairs(self.junctionOrder or {}) do
+        for _, inputEdge in ipairs(junction.inputs or {}) do
+            if not groupsByEdgeId[inputEdge.id] then
+                groupsByEdgeId[inputEdge.id] = {
+                    edge = inputEdge,
+                    trains = {},
+                }
+                orderedGroups[#orderedGroups + 1] = groupsByEdgeId[inputEdge.id]
+            end
+        end
+    end
+
+    for _, train in ipairs(self.trains or {}) do
+        local inputEdgeId = train.startEdgeId or train.edgeId
+        local group = groupsByEdgeId[inputEdgeId]
+        if group then
+            group.trains[#group.trains + 1] = train
+        end
+    end
+
+    for _, group in ipairs(orderedGroups) do
+        table.sort(group.trains, compareScheduledTrains)
+    end
+
+    return orderedGroups
+end
+
+function world:getNextPendingTrainForInputEdge(edgeId)
+    local nextTrain = nil
+
+    for _, train in ipairs(self.trains or {}) do
+        local inputEdgeId = train.startEdgeId or train.edgeId
+        if inputEdgeId == edgeId and not train.spawned and not self:isTrainCleared(train) then
+            if not nextTrain or compareScheduledTrains(train, nextTrain) then
+                nextTrain = train
+            end
+        end
+    end
+
+    return nextTrain
+end
+
+function world:getOutputAcceptedGoalColors(outputEdge)
+    local colors = {}
+    local lookup = {}
+
+    for _, colorId in ipairs(outputEdge and outputEdge.colors or {}) do
+        appendUnique(colors, lookup, colorId)
+    end
+
+    if outputEdge and outputEdge.adoptInputColor then
+        local sourceJunction = self.junctions[outputEdge.sourceId]
+        for _, inputEdge in ipairs(sourceJunction and sourceJunction.inputs or {}) do
+            for _, colorId in ipairs(inputEdge.colors or {}) do
+                appendUnique(colors, lookup, colorId)
+            end
+        end
+    end
+
+    if #colors == 0 and outputEdge then
+        appendUnique(colors, lookup, nearestColorId(outputEdge.color))
+    end
+
+    return colors
+end
+
+function world:getOutputBadgeGroups()
+    local orderedGroups = {}
+
+    for _, junction in ipairs(self.junctionOrder or {}) do
+        for _, outputEdge in ipairs(junction.outputs or {}) do
+            local acceptedColors = self:getOutputAcceptedGoalColors(outputEdge)
+            local acceptedLookup = {}
+            for _, colorId in ipairs(acceptedColors) do
+                acceptedLookup[colorId] = true
+            end
+
+            local expectedCount = 0
+            local deliveredCount = 0
+            for _, train in ipairs(self.trains or {}) do
+                local goalColor = train.goalColor or train.trainColor
+                if acceptedLookup[goalColor] then
+                    expectedCount = expectedCount + 1
+                end
+                if train.clearingExitEdgeId == outputEdge.id and self:isTrainCleared(train) then
+                    deliveredCount = deliveredCount + 1
+                end
+            end
+
+            orderedGroups[#orderedGroups + 1] = {
+                edge = outputEdge,
+                expectedCount = expectedCount,
+                deliveredCount = deliveredCount,
+                acceptedColors = acceptedColors,
+            }
+        end
+    end
+
+    return orderedGroups
 end
 
 function world:getNextQueuedTrain()


### PR DESCRIPTION
## Requested Behavior
- Redesign level entry and play flow so maps open into a preparation phase before simulation starts.
- Remove the old top-left play header and move run stats into the Route Debug overlay.
- Replace the left-side HUD with endpoint-attached train cards and output progress badges.
- Restyle the prep train rows and output badges to be tighter, more compact, and easier to read.

## Summary
- Added an explicit `prepare` phase with a Start action before trains begin moving.
- Moved run metrics and queue details into the F3 debug overlay.
- Added input prep cards, live next-train cards, and exit progress badges anchored to track geometry.
- Tightened the prep row layout and wagon rendering for more compact information density.

## Testing
- `git diff --check`
- Smoke-launched the project with `love.exe`
- Not run (not requested)