### PR TITLE
Shiirroo/add marketplace maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_KEY=replace-with-your-backend-api-key
+API_BASE_URL=https://signal-leaderboard.just2dev-signal.workers.dev

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ luac.out
 
 # Local tooling metadata
 .codex/
+.env
 
 *claude
 
@@ -52,3 +53,4 @@ settings.json
 /AGENTS.md
 .idea
 *idea/
+.env

--- a/API_REQUESTS.md
+++ b/API_REQUESTS.md
@@ -1,0 +1,262 @@
+# API Requests
+
+All requests require the header `x-api-key`.
+
+If `HMAC_SECRET` is configured, all `POST` requests also require the header `x-signature` with the format `sha256=<signature>`.
+
+All `POST` requests use JSON request bodies.
+
+Base URL example:
+
+```text
+https://signal-leaderboard.just2dev-signal.workers.dev
+```
+
+## Common Headers
+
+```http
+x-api-key: YOUR_API_KEY
+content-type: application/json
+```
+
+## POST Requests
+
+### POST /api/maps
+
+This creates or updates a user map.
+
+The client sends its own local `map_uuid` for the map.
+
+If the same `creator_uuid` sends the same `map_uuid` again, the existing map is updated instead of creating a new one. The backend keeps the same `internal_identifier`.
+
+```http
+POST /api/maps
+```
+
+Request body:
+
+```json
+{
+  "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+  "map_name": "Arena Alpha",
+  "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "map": {
+    "tiles": [],
+    "spawn": {
+      "x": 1,
+      "y": 2
+    }
+  }
+}
+```
+
+Response example:
+
+```json
+{
+  "created_at": "2026-04-19T12:00:00.000Z",
+  "creator_display_name": "Patrick",
+  "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "favorite_count": 0,
+  "internal_identifier": "aB3kQ9",
+  "map": {
+    "tiles": [],
+    "spawn": {
+      "x": 1,
+      "y": 2
+    }
+  },
+  "map_category": "users",
+  "map_name": "Arena Alpha",
+  "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+  "updated_at": "2026-04-19T12:00:00.000Z"
+}
+```
+
+### POST /api/maps/{map_uuid}/favorites
+
+This adds one favorite vote for one user on one map. A user can vote only once per map.
+
+```http
+POST /api/maps/8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5/favorites
+```
+
+Request body:
+
+```json
+{
+  "voter_uuid": "223e4567-e89b-12d3-a456-426614174111"
+}
+```
+
+You can also send `player_uuid` instead of `voter_uuid`.
+
+Response example:
+
+```json
+{
+  "accepted": true,
+  "favorite_count": 1,
+  "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+  "ok": true,
+  "voter_uuid": "223e4567-e89b-12d3-a456-426614174111"
+}
+```
+
+## GET Requests
+
+### GET /api/maps/id/{map_uuid}
+
+This loads one map by its full `map_uuid`.
+
+```http
+GET /api/maps/id/8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5
+```
+
+Response example:
+
+```json
+{
+  "created_at": "2026-04-19T12:00:00.000Z",
+  "creator_display_name": "Patrick",
+  "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "favorite_count": 1,
+  "internal_identifier": "aB3kQ9",
+  "map": {
+    "tiles": [],
+    "spawn": {
+      "x": 1,
+      "y": 2
+    }
+  },
+  "map_category": "users",
+  "map_name": "Arena Alpha",
+  "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+  "updated_at": "2026-04-19T12:00:00.000Z"
+}
+```
+
+### GET /api/maps/code/{internal_identifier}
+
+This loads one map by its internal identifier.
+
+```http
+GET /api/maps/code/aB3kQ9
+```
+
+Response example:
+
+```json
+{
+  "created_at": "2026-04-19T12:00:00.000Z",
+  "creator_display_name": "Patrick",
+  "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "favorite_count": 1,
+  "internal_identifier": "aB3kQ9",
+  "map": {
+    "tiles": [],
+    "spawn": {
+      "x": 1,
+      "y": 2
+    }
+  },
+  "map_category": "users",
+  "map_name": "Arena Alpha",
+  "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+  "updated_at": "2026-04-19T12:00:00.000Z"
+}
+```
+
+### GET /api/maps/favorites
+
+This returns the favorite maps ordered by `favorite_count` descending.
+
+```http
+GET /api/maps/favorites
+GET /api/maps/favorites?limit=10
+```
+
+Response example:
+
+```json
+{
+  "entries": [
+    {
+      "created_at": "2026-04-19T12:00:00.000Z",
+      "creator_display_name": "Patrick",
+      "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+      "favorite_count": 12,
+      "internal_identifier": "aB3kQ9",
+      "map": {
+        "tiles": []
+      },
+      "map_category": "users",
+      "map_name": "Arena Alpha",
+      "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+      "updated_at": "2026-04-19T12:00:00.000Z"
+    }
+  ],
+  "limit": 10
+}
+```
+
+### GET /api/maps/search
+
+This searches maps by partial `map_uuid`, partial `map_name`, partial `internal_identifier`, partial `creator_uuid`, or partial creator username.
+
+```http
+GET /api/maps/search?q=arena
+GET /api/maps/search?query=aB3
+GET /api/maps/search?q=8c9d4c8b&limit=10
+```
+
+Response example:
+
+```json
+{
+  "entries": [
+    {
+      "created_at": "2026-04-19T12:00:00.000Z",
+      "creator_display_name": "Patrick",
+      "creator_uuid": "123e4567-e89b-12d3-a456-426614174000",
+      "favorite_count": 12,
+      "internal_identifier": "aB3kQ9",
+      "map": {
+        "tiles": []
+      },
+      "map_category": "users",
+      "map_name": "Arena Alpha",
+      "map_uuid": "8c9d4c8b-8a53-49c8-9d4d-6deec824d1b5",
+      "updated_at": "2026-04-19T12:00:00.000Z"
+    }
+  ],
+  "limit": 10,
+  "query": "arena"
+}
+```
+
+## Common Error Responses
+
+Unauthorized:
+
+```json
+{
+  "error": "Unauthorized"
+}
+```
+
+Not found:
+
+```json
+{
+  "error": "Map not found"
+}
+```
+
+Invalid input example:
+
+```json
+{
+  "error": "Invalid map_uuid"
+}
+```

--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -1,4 +1,5 @@
 local authoredMap = {}
+local roadTypes = require("src.game.road_types")
 
 local COLOR_LOOKUP = {
     blue = { 0.33, 0.80, 0.98 },
@@ -208,6 +209,89 @@ local function getRouteById(editorData, routeId)
     return nil
 end
 
+local function getRouteSegmentRoadTypes(route)
+    local routePoints = (route and route.points) or {}
+    local segmentCount = math.max(0, #routePoints - 1)
+    local fallbackRoadType = roadTypes.normalizeRoadType(route and route.roadType)
+    local segmentRoadTypes = {}
+
+    for segmentIndex = 1, segmentCount do
+        local roadTypeId = route
+            and route.segmentRoadTypes
+            and route.segmentRoadTypes[segmentIndex]
+            or fallbackRoadType
+        segmentRoadTypes[segmentIndex] = roadTypes.normalizeRoadType(roadTypeId)
+    end
+
+    return segmentRoadTypes
+end
+
+local function buildRouteStyleSections(route, startDistance, endDistance)
+    local styleSections = {}
+    local routePoints = route.points or {}
+    local segmentRoadTypes = getRouteSegmentRoadTypes(route)
+    local traversedDistance = 0
+    local epsilon = 0.0000001
+    local totalSectionLength = math.max(endDistance - startDistance, epsilon)
+
+    for pointIndex = 1, #routePoints - 1 do
+        local pointA = routePoints[pointIndex]
+        local pointB = routePoints[pointIndex + 1]
+        local length = segmentLength(pointA, pointB)
+        local segmentStartDistance = traversedDistance
+        local segmentEndDistance = traversedDistance + length
+        local overlapStartDistance = math.max(startDistance, segmentStartDistance)
+        local overlapEndDistance = math.min(endDistance, segmentEndDistance)
+
+        if overlapEndDistance - overlapStartDistance > epsilon then
+            local roadTypeId = segmentRoadTypes[pointIndex]
+            local previousSection = styleSections[#styleSections]
+            local localStartRatio = (overlapStartDistance - startDistance) / totalSectionLength
+            local localEndRatio = (overlapEndDistance - startDistance) / totalSectionLength
+
+            if previousSection
+                and previousSection.roadType == roadTypeId
+                and math.abs(previousSection.endRatio - localStartRatio) <= epsilon then
+                previousSection.endRatio = localEndRatio
+            else
+                styleSections[#styleSections + 1] = {
+                    roadType = roadTypeId,
+                    speedScale = roadTypes.getConfig(roadTypeId).speedScale,
+                    startRatio = localStartRatio,
+                    endRatio = localEndRatio,
+                }
+            end
+        end
+
+        traversedDistance = segmentEndDistance
+    end
+
+    return styleSections
+end
+
+local function styleSectionsRoughlyMatch(firstSections, secondSections, tolerance)
+    if #firstSections ~= #secondSections then
+        return false
+    end
+
+    local epsilon = tolerance or 0.001
+    for sectionIndex = 1, #firstSections do
+        local firstSection = firstSections[sectionIndex]
+        local secondSection = secondSections[sectionIndex]
+        if firstSection.roadType ~= secondSection.roadType then
+            return false
+        end
+        if math.abs(firstSection.startRatio - secondSection.startRatio) > epsilon then
+            return false
+        end
+        if math.abs(firstSection.endRatio - secondSection.endRatio) > epsilon then
+            return false
+        end
+    end
+
+    return true
+end
+
 local function sortRouteIdsByMagnet(editorData, routeIds, magnetKind)
     table.sort(routeIds, function(firstRouteId, secondRouteId)
         local firstRoute = getRouteById(editorData, firstRouteId)
@@ -411,10 +495,15 @@ function authoredMap.validateEditorMap(mapName, editorData)
 
             local targetEndpoint = targetNode.kind == "exit" and getEndpointById(editorData, targetNode.id) or nil
             local sourceEndpoint = sourceNode.kind == "start" and getEndpointById(editorData, sourceNode.id) or nil
+            local styleSections = buildRouteStyleSections(route, sourceNode.distance, targetNode.distance)
+            local primaryRoadType = styleSections[1] and styleSections[1].roadType or roadTypes.DEFAULT_ID
             local edge = {
                 id = string.format("%s_segment_%d", route.id, nodeIndex),
                 label = string.format("%s Segment %d", route.label or route.id, nodeIndex),
                 routeId = route.id,
+                roadType = primaryRoadType,
+                speedScale = roadTypes.getConfig(primaryRoadType).speedScale,
+                styleSections = styleSections,
                 points = points,
                 color = getColor(route.color),
                 darkColor = darkerColor(getColor(route.color)),
@@ -431,6 +520,10 @@ function authoredMap.validateEditorMap(mapName, editorData)
             if existingEdge then
                 if not pointsRoughlyMatch(existingEdge.points, edge.points) then
                     errors[#errors + 1] = "Merged tracks must share the same path between their nodes."
+                    goto continue_route
+                end
+                if not styleSectionsRoughlyMatch(existingEdge.styleSections or {}, edge.styleSections or {}) then
+                    errors[#errors + 1] = "Merged tracks must use the same road style profile."
                     goto continue_route
                 end
                 edge = existingEdge

--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -827,8 +827,12 @@ function authoredMap.validateEditorMap(mapName, editorData)
     }, {}, nil
 end
 
-function authoredMap.buildPlayableLevel(mapName, editorData)
+function authoredMap.buildPlayableLevel(mapName, editorData, mapUuid)
     local level, errors, errorText = authoredMap.validateEditorMap(mapName, editorData)
+    if level then
+        level.id = mapUuid or level.id
+        level.mapUuid = mapUuid or level.mapUuid
+    end
     return level, errorText, errors
 end
 

--- a/src/game/env_loader.lua
+++ b/src/game/env_loader.lua
@@ -9,6 +9,7 @@ local REQUIRED_KEYS = {
 }
 local OPTIONAL_KEYS = {
     "API_BASE_URL",
+    "HMAC_SECRET",
 }
 local SOURCE_WORKING_DIRECTORY = "working directory .env"
 local SOURCE_LOVE_FILESYSTEM = "project .env"
@@ -154,6 +155,7 @@ function envLoader.load()
 
     local apiKey = values.API_KEY or ""
     local apiBaseUrl = values.API_BASE_URL or DEFAULT_API_BASE_URL
+    local hmacSecret = values.HMAC_SECRET or ""
 
     if apiBaseUrl == DEFAULT_API_BASE_URL and not sourceByKey.API_BASE_URL then
         sourceByKey.API_BASE_URL = SOURCE_DEFAULT
@@ -167,6 +169,7 @@ function envLoader.load()
         values = values,
         apiKey = apiKey,
         apiBaseUrl = apiBaseUrl,
+        hmacSecret = hmacSecret,
         sourceByKey = sourceByKey,
         isConfigured = #errors == 0,
         errors = errors,

--- a/src/game/env_loader.lua
+++ b/src/game/env_loader.lua
@@ -1,6 +1,20 @@
 local envLoader = {}
 
 local ENV_FILE = ".env"
+local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
+local MIN_QUOTED_LENGTH = 2
+local DIRECTORY_SEPARATOR = package.config:sub(1, 1)
+local REQUIRED_KEYS = {
+    "API_KEY",
+}
+local OPTIONAL_KEYS = {
+    "API_BASE_URL",
+}
+local SOURCE_WORKING_DIRECTORY = "working directory .env"
+local SOURCE_LOVE_FILESYSTEM = "project .env"
+local SOURCE_SAVE_DIRECTORY = "save directory .env"
+local SOURCE_PROCESS_ENVIRONMENT = "process environment"
+local SOURCE_DEFAULT = "built-in default"
 
 local function trim(value)
     return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
@@ -10,20 +24,16 @@ local function stripQuotes(value)
     local trimmed = trim(value)
     local firstChar = trimmed:sub(1, 1)
     local lastChar = trimmed:sub(-1)
-    if (#trimmed >= 2) and ((firstChar == '"' and lastChar == '"') or (firstChar == "'" and lastChar == "'")) then
+    if (#trimmed >= MIN_QUOTED_LENGTH) and ((firstChar == '"' and lastChar == '"') or (firstChar == "'" and lastChar == "'")) then
         return trimmed:sub(2, -2)
     end
     return trimmed
 end
 
-local function readEnvFile()
-    if love and love.filesystem and love.filesystem.getInfo and love.filesystem.getInfo(ENV_FILE, "file") then
-        return love.filesystem.read(ENV_FILE)
-    end
-
-    local handle = io.open(ENV_FILE, "rb")
+local function readFile(path)
+    local handle = io.open(path, "rb")
     if not handle then
-        return nil, string.format("%s could not be read.", ENV_FILE)
+        return nil
     end
 
     local content = handle:read("*a")
@@ -31,39 +41,133 @@ local function readEnvFile()
     return content
 end
 
-function envLoader.load()
-    local content, readError = readEnvFile()
+local function parseEnvContent(content)
     local values = {}
-    local errors = {}
 
     if not content then
-        errors[#errors + 1] = readError or string.format("%s is missing.", ENV_FILE)
-    else
-        for line in content:gmatch("[^\r\n]+") do
-            local trimmedLine = trim(line)
-            if trimmedLine ~= "" and trimmedLine:sub(1, 1) ~= "#" then
-                local key, value = trimmedLine:match("^([%w_]+)%s*=%s*(.*)$")
-                if key then
-                    values[key] = stripQuotes(value)
-                end
+        return values
+    end
+
+    for line in content:gmatch("[^\r\n]+") do
+        local trimmedLine = trim(line)
+        if trimmedLine ~= "" and trimmedLine:sub(1, 1) ~= "#" then
+            local key, value = trimmedLine:match("^([%w_]+)%s*=%s*(.*)$")
+            if key then
+                values[key] = stripQuotes(value)
             end
         end
     end
 
+    return values
+end
+
+local function setValue(target, sourceByKey, key, value, sourceName, shouldOverride)
+    local canAssign = shouldOverride or target[key] == nil or target[key] == ""
+    if canAssign then
+        target[key] = value
+        sourceByKey[key] = sourceName
+    end
+end
+
+local function mergeValues(target, sourceByKey, source, sourceName)
+    for key, value in pairs(source or {}) do
+        setValue(target, sourceByKey, key, value, sourceName, false)
+    end
+end
+
+local function readLoveEnvFile()
+    if not (love and love.filesystem and love.filesystem.getInfo) then
+        return nil
+    end
+
+    if not love.filesystem.getInfo(ENV_FILE, "file") then
+        return nil
+    end
+
+    return love.filesystem.read(ENV_FILE)
+end
+
+local function readSaveDirectoryEnvFile()
+    if not (love and love.filesystem and love.filesystem.getSaveDirectory) then
+        return nil
+    end
+
+    local saveDirectory = love.filesystem.getSaveDirectory()
+    if not saveDirectory or saveDirectory == "" then
+        return nil
+    end
+
+    return readFile(saveDirectory .. DIRECTORY_SEPARATOR .. ENV_FILE)
+end
+
+local function readEnvValues()
+    local values = {}
+    local sourceByKey = {}
+    local loadedSourceCount = 0
+
+    local loveContent = readLoveEnvFile()
+    if loveContent then
+        mergeValues(values, sourceByKey, parseEnvContent(loveContent), SOURCE_LOVE_FILESYSTEM)
+        loadedSourceCount = loadedSourceCount + 1
+    end
+
+    local workingDirectoryContent = readFile(ENV_FILE)
+    if workingDirectoryContent then
+        mergeValues(values, sourceByKey, parseEnvContent(workingDirectoryContent), SOURCE_WORKING_DIRECTORY)
+        loadedSourceCount = loadedSourceCount + 1
+    end
+
+    local saveDirectoryContent = readSaveDirectoryEnvFile()
+    if saveDirectoryContent then
+        mergeValues(values, sourceByKey, parseEnvContent(saveDirectoryContent), SOURCE_SAVE_DIRECTORY)
+        loadedSourceCount = loadedSourceCount + 1
+    end
+
+    return values, sourceByKey, loadedSourceCount
+end
+
+local function applyProcessEnvironment(values, sourceByKey)
+    for _, key in ipairs(REQUIRED_KEYS) do
+        local environmentValue = os.getenv(key)
+        if environmentValue and trim(environmentValue) ~= "" then
+            setValue(values, sourceByKey, key, stripQuotes(environmentValue), SOURCE_PROCESS_ENVIRONMENT, true)
+        end
+    end
+
+    for _, key in ipairs(OPTIONAL_KEYS) do
+        local environmentValue = os.getenv(key)
+        if environmentValue and trim(environmentValue) ~= "" then
+            setValue(values, sourceByKey, key, stripQuotes(environmentValue), SOURCE_PROCESS_ENVIRONMENT, true)
+        end
+    end
+end
+
+function envLoader.load()
+    local values, sourceByKey, loadedSourceCount = readEnvValues()
+    local errors = {}
+
+    applyProcessEnvironment(values, sourceByKey)
+
+    if loadedSourceCount == 0 and not os.getenv("API_KEY") and not os.getenv("API_BASE_URL") then
+        errors[#errors + 1] = string.format("%s was not found. Set API_KEY in process environment variables or a local %s file.", ENV_FILE, ENV_FILE)
+    end
+
     local apiKey = values.API_KEY or ""
-    local leaderboardId = values.LEADERBOARD_ID or ""
+    local apiBaseUrl = values.API_BASE_URL or DEFAULT_API_BASE_URL
+
+    if apiBaseUrl == DEFAULT_API_BASE_URL and not sourceByKey.API_BASE_URL then
+        sourceByKey.API_BASE_URL = SOURCE_DEFAULT
+    end
 
     if apiKey == "" then
-        errors[#errors + 1] = "API_KEY is missing in .env."
-    end
-    if leaderboardId == "" then
-        errors[#errors + 1] = "LEADERBOARD_ID is missing in .env."
+        errors[#errors + 1] = "API_KEY is missing. Set it in the process environment or in .env."
     end
 
     return {
         values = values,
         apiKey = apiKey,
-        leaderboardId = leaderboardId,
+        apiBaseUrl = apiBaseUrl,
+        sourceByKey = sourceByKey,
         isConfigured = #errors == 0,
         errors = errors,
     }

--- a/src/game/env_loader.lua
+++ b/src/game/env_loader.lua
@@ -1,0 +1,73 @@
+local envLoader = {}
+
+local ENV_FILE = ".env"
+
+local function trim(value)
+    return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function stripQuotes(value)
+    local trimmed = trim(value)
+    local firstChar = trimmed:sub(1, 1)
+    local lastChar = trimmed:sub(-1)
+    if (#trimmed >= 2) and ((firstChar == '"' and lastChar == '"') or (firstChar == "'" and lastChar == "'")) then
+        return trimmed:sub(2, -2)
+    end
+    return trimmed
+end
+
+local function readEnvFile()
+    if love and love.filesystem and love.filesystem.getInfo and love.filesystem.getInfo(ENV_FILE, "file") then
+        return love.filesystem.read(ENV_FILE)
+    end
+
+    local handle = io.open(ENV_FILE, "rb")
+    if not handle then
+        return nil, string.format("%s could not be read.", ENV_FILE)
+    end
+
+    local content = handle:read("*a")
+    handle:close()
+    return content
+end
+
+function envLoader.load()
+    local content, readError = readEnvFile()
+    local values = {}
+    local errors = {}
+
+    if not content then
+        errors[#errors + 1] = readError or string.format("%s is missing.", ENV_FILE)
+    else
+        for line in content:gmatch("[^\r\n]+") do
+            local trimmedLine = trim(line)
+            if trimmedLine ~= "" and trimmedLine:sub(1, 1) ~= "#" then
+                local key, value = trimmedLine:match("^([%w_]+)%s*=%s*(.*)$")
+                if key then
+                    values[key] = stripQuotes(value)
+                end
+            end
+        end
+    end
+
+    local apiKey = values.API_KEY or ""
+    local leaderboardId = values.LEADERBOARD_ID or ""
+
+    if apiKey == "" then
+        errors[#errors + 1] = "API_KEY is missing in .env."
+    end
+    if leaderboardId == "" then
+        errors[#errors + 1] = "LEADERBOARD_ID is missing in .env."
+    end
+
+    return {
+        values = values,
+        apiKey = apiKey,
+        leaderboardId = leaderboardId,
+        isConfigured = #errors == 0,
+        errors = errors,
+    }
+end
+
+return envLoader
+

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -3,6 +3,7 @@ local mapEditor = require("src.game.map_editor")
 local mapStorage = require("src.game.map_storage")
 local profileStorage = require("src.game.profile_storage")
 local leaderboardClient = require("src.game.leaderboard_client")
+local leaderboardPreviewCache = require("src.game.leaderboard_preview_cache")
 local world = require("src.game.world")
 local ui = require("src.game.ui")
 local json = require("src.game.json")
@@ -29,6 +30,16 @@ local LEADERBOARD_MESSAGE_EMPTY = "No entries were found for this leaderboard ye
 local LEADERBOARD_MESSAGE_FETCH_FAILED = "The leaderboard could not be loaded."
 local LEADERBOARD_MESSAGE_NO_DATA = "No data right now."
 local LEADERBOARD_MAP_NAME_UNKNOWN = "Unknown Map"
+local LEVEL_SELECT_PREVIEW_ENTRY_LIMIT = 5
+local LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS = 60
+local LEVEL_SELECT_PREVIEW_FETCH_TIMEOUT_SECONDS = 5
+local LEVEL_SELECT_PREVIEW_STATUS_IDLE = "idle"
+local LEVEL_SELECT_PREVIEW_STATUS_LOADING = "loading"
+local LEVEL_SELECT_PREVIEW_STATUS_READY = "ready"
+local LEVEL_SELECT_PREVIEW_STATUS_ERROR = "error"
+local LEVEL_SELECT_PREVIEW_MESSAGE_LOADING = "Loading leaderboard..."
+local LEVEL_SELECT_PREVIEW_MESSAGE_EMPTY = "No scores yet."
+local LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA = "No local leaderboard data."
 
 local function getNowSeconds()
     if love and love.timer and love.timer.getTime then
@@ -36,6 +47,14 @@ local function getNowSeconds()
     end
 
     return os.clock()
+end
+
+local function getNowUnixSeconds()
+    if os and os.time then
+        return os.time()
+    end
+
+    return math.floor(getNowSeconds())
 end
 
 local function drainChannel(channel)
@@ -94,6 +113,22 @@ local function trimLastUtf8Character(value)
     return (value or ""):gsub("[%z\1-\127\194-\244][\128-\191]*$", "")
 end
 
+local function normalizeLeaderboardEntry(entry, fallbackMapUuid, fallbackRank)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    return {
+        playerDisplayName = entry.display_name or entry.playerDisplayName or "Unknown",
+        playerUuid = entry.player_uuid or entry.playerUuid or "",
+        mapCount = tonumber(entry.map_count) or 0,
+        score = tonumber(entry.score or 0) or 0,
+        rank = tonumber(entry.rank) or fallbackRank or 0,
+        mapUuid = entry.map_uuid or entry.last_map_uuid or fallbackMapUuid,
+        updatedAt = entry.updated_at or entry.updatedAt,
+    }
+end
+
 local function normalizeLeaderboardEntries(payload)
     local normalized = {}
 
@@ -107,16 +142,11 @@ local function normalizeLeaderboardEntries(payload)
         return normalized
     end
 
-    for _, entry in ipairs(sourceEntries) do
-        normalized[#normalized + 1] = {
-            playerDisplayName = entry.display_name or entry.playerDisplayName or "Unknown",
-            playerUuid = entry.player_uuid or entry.playerUuid or "",
-            mapCount = tonumber(entry.map_count) or 0,
-            score = tonumber(entry.score or 0) or 0,
-            rank = tonumber(entry.rank) or (#normalized + 1),
-            mapUuid = entry.map_uuid or entry.last_map_uuid or fallbackMapUuid,
-            updatedAt = entry.updated_at or entry.updatedAt,
-        }
+    for index, entry in ipairs(sourceEntries) do
+        local normalizedEntry = normalizeLeaderboardEntry(entry, fallbackMapUuid, index)
+        if normalizedEntry then
+            normalized[#normalized + 1] = normalizedEntry
+        end
     end
 
     return normalized
@@ -191,6 +221,18 @@ function Game.new()
     self.levelSelectFilterHoverId = nil
     self.levelSelectVisualIndex = nil
     self.levelSelectScroll = 0
+    self.levelSelectLeaderboardFlipMapUuid = nil
+    self.levelSelectPreviewCacheByMap = leaderboardPreviewCache.load()
+    self.levelSelectPreviewNextFetchAtByMap = {}
+    self.levelSelectPreviewState = {
+        mapUuid = nil,
+        status = LEVEL_SELECT_PREVIEW_STATUS_IDLE,
+        message = nil,
+    }
+    self.levelSelectPreviewRequestSequence = 0
+    self.activeLevelSelectPreviewRequestId = nil
+    self.activeLevelSelectPreviewRequestStartedAt = nil
+    self.activeLevelSelectPreviewRequestMapUuid = nil
     self.resultsSummary = nil
     self.resultsOnlineState = nil
     self.profileSetupNameBuffer = profile.playerDisplayName or ""
@@ -302,6 +344,190 @@ function Game:getActiveOnlineConfig()
     return resolvedConfig
 end
 
+function Game:setLevelSelectPreviewState(mapUuid, status, message)
+    self.levelSelectPreviewState = {
+        mapUuid = mapUuid,
+        status = status or LEVEL_SELECT_PREVIEW_STATUS_IDLE,
+        message = message,
+    }
+end
+
+function Game:getLevelSelectPreviewCacheEntry(mapUuid)
+    if not mapUuid or mapUuid == "" then
+        return nil
+    end
+
+    local entry = self.levelSelectPreviewCacheByMap[mapUuid]
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    return entry
+end
+
+function Game:setLevelSelectPreviewCacheEntry(mapUuid, entry)
+    if not mapUuid or mapUuid == "" then
+        return
+    end
+
+    if type(entry) == "table" then
+        self.levelSelectPreviewCacheByMap[mapUuid] = entry
+    else
+        self.levelSelectPreviewCacheByMap[mapUuid] = nil
+    end
+
+    leaderboardPreviewCache.save(self.levelSelectPreviewCacheByMap)
+end
+
+function Game:isLevelSelectPreviewCacheFresh(mapUuid)
+    local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    local fetchedAt = cacheEntry and tonumber(cacheEntry.fetched_at) or nil
+    if not fetchedAt then
+        return false
+    end
+
+    return (getNowUnixSeconds() - fetchedAt) < LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+end
+
+function Game:isLevelSelectPreviewFetchAllowed(mapUuid)
+    if not mapUuid or mapUuid == "" then
+        return false
+    end
+
+    return getNowUnixSeconds() >= (self.levelSelectPreviewNextFetchAtByMap[mapUuid] or 0)
+end
+
+function Game:getActiveLevelSelectPreviewMapUuid()
+    if self.screen ~= "level_select" then
+        return nil
+    end
+
+    local selectedMap = self:getSelectedLevelMap()
+    local mapUuid = selectedMap and selectedMap.mapUuid or nil
+    if mapUuid and mapUuid ~= "" and self.levelSelectLeaderboardFlipMapUuid == mapUuid then
+        return mapUuid
+    end
+
+    return nil
+end
+
+function Game:clearLevelSelectLeaderboardFlip()
+    self.levelSelectLeaderboardFlipMapUuid = nil
+    self:setLevelSelectPreviewState(nil, LEVEL_SELECT_PREVIEW_STATUS_IDLE, nil)
+end
+
+function Game:getLevelSelectPreviewDisplayState(mapUuid)
+    local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    local topEntries = normalizeLeaderboardEntries({
+        entries = cacheEntry and cacheEntry.top_entries or {},
+        map_uuid = mapUuid,
+    })
+    local playerEntry = normalizeLeaderboardEntry(cacheEntry and cacheEntry.player_entry or nil, mapUuid)
+
+    for _, entry in ipairs(topEntries) do
+        entry.mapName = self:getMapNameByUuid(entry.mapUuid)
+    end
+    if playerEntry then
+        playerEntry.mapName = self:getMapNameByUuid(playerEntry.mapUuid)
+    end
+
+    local pinnedPlayerEntry = nil
+    if playerEntry then
+        local isAlreadyVisible = false
+        for _, entry in ipairs(topEntries) do
+            if entry.playerUuid == playerEntry.playerUuid then
+                isAlreadyVisible = true
+                break
+            end
+        end
+
+        if not isAlreadyVisible then
+            pinnedPlayerEntry = playerEntry
+        end
+    end
+
+    local previewState = self.levelSelectPreviewState or {}
+    local hasCache = cacheEntry ~= nil
+    local hasVisibleEntries = #topEntries > 0 or pinnedPlayerEntry ~= nil
+    local isLoading = self.activeLevelSelectPreviewRequestId ~= nil and self.activeLevelSelectPreviewRequestMapUuid == mapUuid
+    local shouldShowSpinner = isLoading or (previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_LOADING and not hasCache)
+    local message = nil
+
+    if shouldShowSpinner and not hasCache then
+        message = LEVEL_SELECT_PREVIEW_MESSAGE_LOADING
+    elseif hasCache and not hasVisibleEntries and not playerEntry then
+        message = LEVEL_SELECT_PREVIEW_MESSAGE_EMPTY
+    elseif previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_ERROR and not hasCache then
+        message = previewState.message or LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA
+    end
+
+    return {
+        topEntries = topEntries,
+        pinnedPlayerEntry = pinnedPlayerEntry,
+        hasCache = hasCache,
+        isLoading = shouldShowSpinner,
+        message = message,
+    }
+end
+
+function Game:updateLevelSelectPreviewCacheFromSubmit(response)
+    if type(response) ~= "table" then
+        return
+    end
+
+    local mapUuid = tostring(response.map_uuid or (self.resultsSummary and self.resultsSummary.mapUuid) or "")
+    if mapUuid == "" then
+        return
+    end
+
+    local submittedEntry = {
+        display_name = response.display_name or self.profile.playerDisplayName or "Unknown",
+        map_uuid = mapUuid,
+        player_uuid = response.player_uuid or self.profile.playerId or "",
+        rank = tonumber(response.rank) or nil,
+        score = tonumber(response.score or 0) or 0,
+        updated_at = response.updated_at,
+    }
+
+    local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid) or {
+        map_uuid = mapUuid,
+        top_entries = {},
+        player_entry = nil,
+        target_rank = nil,
+        fetched_at = getNowUnixSeconds(),
+    }
+
+    local topEntries = {}
+    for _, entry in ipairs(cacheEntry.top_entries or {}) do
+        if type(entry) == "table" and tostring(entry.player_uuid or entry.playerUuid or "") ~= submittedEntry.player_uuid then
+            topEntries[#topEntries + 1] = entry
+        end
+    end
+
+    if submittedEntry.rank and submittedEntry.rank <= LEVEL_SELECT_PREVIEW_ENTRY_LIMIT then
+        topEntries[#topEntries + 1] = submittedEntry
+        table.sort(topEntries, function(a, b)
+            local aRank = tonumber(a.rank) or math.huge
+            local bRank = tonumber(b.rank) or math.huge
+            if aRank ~= bRank then
+                return aRank < bRank
+            end
+
+            return tostring(a.player_uuid or "") < tostring(b.player_uuid or "")
+        end)
+
+        while #topEntries > LEVEL_SELECT_PREVIEW_ENTRY_LIMIT do
+            table.remove(topEntries)
+        end
+    end
+
+    cacheEntry.top_entries = topEntries
+    cacheEntry.player_entry = submittedEntry
+    cacheEntry.target_rank = submittedEntry.rank
+    cacheEntry.fetched_at = getNowUnixSeconds()
+    self:setLevelSelectPreviewCacheEntry(mapUuid, cacheEntry)
+end
+
 function Game:ensureLeaderboardWorker()
     local existingThread = self.leaderboardWorkerThread
     if existingThread and existingThread:isRunning() and not existingThread:getError() then
@@ -345,6 +571,30 @@ function Game:beginLeaderboardFetch(onlineConfig)
     }))
 end
 
+function Game:beginLevelSelectPreviewFetch(onlineConfig, mapUuid)
+    if self.activeLevelSelectPreviewRequestId ~= nil or not mapUuid or mapUuid == "" then
+        return
+    end
+
+    self:ensureLeaderboardWorker()
+    self.levelSelectPreviewRequestSequence = self.levelSelectPreviewRequestSequence + 1
+    self.activeLevelSelectPreviewRequestId = self.levelSelectPreviewRequestSequence
+    self.activeLevelSelectPreviewRequestStartedAt = getNowSeconds()
+    self.activeLevelSelectPreviewRequestMapUuid = mapUuid
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil)
+    self.leaderboardRequestChannel:push(json.encode({
+        kind = "preview",
+        requestId = self.activeLevelSelectPreviewRequestId,
+        config = {
+            apiKey = onlineConfig.apiKey,
+            apiBaseUrl = onlineConfig.apiBaseUrl,
+            limit = LEVEL_SELECT_PREVIEW_ENTRY_LIMIT,
+            mapUuid = mapUuid,
+            playerUuid = self.profile and self.profile.playerId or nil,
+        },
+    }))
+end
+
 function Game:applyLeaderboardFetchResult(response)
     local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
     local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
@@ -370,25 +620,73 @@ function Game:applyLeaderboardFetchResult(response)
     end
 end
 
+function Game:applyLevelSelectPreviewFetchResult(response, mapUuid)
+    if not mapUuid or mapUuid == "" then
+        return
+    end
+
+    local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    if response.ok and type(response.payload) == "table" then
+        local fetchedAt = getNowUnixSeconds()
+        self:setLevelSelectPreviewCacheEntry(mapUuid, {
+            map_uuid = mapUuid,
+            top_entries = type(response.payload.top_entries) == "table" and response.payload.top_entries or {},
+            player_entry = type(response.payload.player_entry) == "table" and response.payload.player_entry or nil,
+            target_rank = tonumber(response.payload.target_rank) or nil,
+            fetched_at = fetchedAt,
+        })
+        self.levelSelectPreviewNextFetchAtByMap[mapUuid] = fetchedAt + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+        return
+    end
+
+    self.levelSelectPreviewNextFetchAtByMap[mapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+    if cacheEntry then
+        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+        return
+    end
+
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+end
+
 function Game:updateLeaderboardFetchState()
     local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
     local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
+    local activePreviewMapUuid = self.activeLevelSelectPreviewRequestMapUuid
+    local previewCacheEntry = self:getLevelSelectPreviewCacheEntry(activePreviewMapUuid)
 
-    if self.leaderboardWorkerThread and self.activeLeaderboardRequestId ~= nil then
+    if self.leaderboardWorkerThread and (self.activeLeaderboardRequestId ~= nil or self.activeLevelSelectPreviewRequestId ~= nil) then
         local threadError = self.leaderboardWorkerThread:getError()
         if threadError then
-            self.activeLeaderboardRequestId = nil
-            self.activeLeaderboardRequestStartedAt = nil
-            self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
-            if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
-                self.leaderboardState = self:buildLeaderboardState(
-                    LEADERBOARD_STATUS_ERROR,
-                    threadError,
-                    cacheEntry.payload,
-                    cacheEntry.fetchedAt
-                )
+            if self.activeLeaderboardRequestId ~= nil then
+                self.activeLeaderboardRequestId = nil
+                self.activeLeaderboardRequestStartedAt = nil
+                self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
+                if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
+                    self.leaderboardState = self:buildLeaderboardState(
+                        LEADERBOARD_STATUS_ERROR,
+                        threadError,
+                        cacheEntry.payload,
+                        cacheEntry.fetchedAt
+                    )
+                end
+                self.activeLeaderboardRequestScopeKey = nil
             end
-            self.activeLeaderboardRequestScopeKey = nil
+
+            if self.activeLevelSelectPreviewRequestId ~= nil then
+                self.activeLevelSelectPreviewRequestId = nil
+                self.activeLevelSelectPreviewRequestStartedAt = nil
+                if activePreviewMapUuid and activePreviewMapUuid ~= "" then
+                    self.levelSelectPreviewNextFetchAtByMap[activePreviewMapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+                    if previewCacheEntry then
+                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+                    else
+                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+                    end
+                end
+                self.activeLevelSelectPreviewRequestMapUuid = nil
+            end
+
             self.leaderboardWorkerThread = nil
             return
         end
@@ -414,6 +712,24 @@ function Game:updateLeaderboardFetchState()
         end
     end
 
+    if self.activeLevelSelectPreviewRequestId ~= nil and self.activeLevelSelectPreviewRequestStartedAt ~= nil then
+        local elapsedSeconds = getNowSeconds() - self.activeLevelSelectPreviewRequestStartedAt
+        if elapsedSeconds >= LEVEL_SELECT_PREVIEW_FETCH_TIMEOUT_SECONDS then
+            local previewMapUuid = self.activeLevelSelectPreviewRequestMapUuid
+            self.activeLevelSelectPreviewRequestId = nil
+            self.activeLevelSelectPreviewRequestStartedAt = nil
+            if previewMapUuid and previewMapUuid ~= "" then
+                self.levelSelectPreviewNextFetchAtByMap[previewMapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+                if self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
+                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+                else
+                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+                end
+            end
+            self.activeLevelSelectPreviewRequestMapUuid = nil
+        end
+    end
+
     while true do
         local encodedResponse = self.leaderboardResponseChannel:pop()
         if not encodedResponse then
@@ -421,11 +737,17 @@ function Game:updateLeaderboardFetchState()
         end
 
         local decodedResponse = json.decode(encodedResponse)
-        if type(decodedResponse) == "table" and decodedResponse.requestId == self.activeLeaderboardRequestId then
+        if type(decodedResponse) == "table" and decodedResponse.kind == "fetch" and decodedResponse.requestId == self.activeLeaderboardRequestId then
             self.activeLeaderboardRequestId = nil
             self.activeLeaderboardRequestStartedAt = nil
             self:applyLeaderboardFetchResult(decodedResponse)
             self.activeLeaderboardRequestScopeKey = nil
+        elseif type(decodedResponse) == "table" and decodedResponse.kind == "preview" and decodedResponse.requestId == self.activeLevelSelectPreviewRequestId then
+            local previewMapUuid = self.activeLevelSelectPreviewRequestMapUuid
+            self.activeLevelSelectPreviewRequestId = nil
+            self.activeLevelSelectPreviewRequestStartedAt = nil
+            self.activeLevelSelectPreviewRequestMapUuid = nil
+            self:applyLevelSelectPreviewFetchResult(decodedResponse, previewMapUuid)
         end
     end
 
@@ -442,6 +764,18 @@ function Game:updateLeaderboardFetchState()
         end
 
         self:beginLeaderboardFetch(onlineConfig)
+    end
+
+    local previewMapUuid = self:getActiveLevelSelectPreviewMapUuid()
+    if previewMapUuid and self.activeLevelSelectPreviewRequestId == nil and not self:isLevelSelectPreviewCacheFresh(previewMapUuid) and self:isLevelSelectPreviewFetchAllowed(previewMapUuid) then
+        local onlineConfig = self:getActiveOnlineConfig()
+        if onlineConfig.isConfigured then
+            self:beginLevelSelectPreviewFetch(onlineConfig, previewMapUuid)
+        elseif self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
+            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+        else
+            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+        end
     end
 end
 
@@ -558,6 +892,7 @@ function Game:submitResultsScore()
             and "Score was valid, but your online best for this map is already higher."
             or "Score uploaded successfully.",
     }
+    self:updateLevelSelectPreviewCacheFromSubmit(response)
 end
 
 function Game:refreshLeaderboard()
@@ -728,6 +1063,7 @@ end
 function Game:setLevelSelectSelection(mapDescriptor)
     self.levelSelectSelectedId = mapDescriptor and mapDescriptor.id or nil
     self.levelSelectScroll = 0
+    self:clearLevelSelectLeaderboardFlip()
 end
 
 function Game:resetLevelSelectVisualIndex()
@@ -741,6 +1077,7 @@ function Game:setLevelSelectFilter(filterId)
     self:getSelectedLevelMap()
     self:resetLevelSelectVisualIndex()
     self.levelSelectScroll = 0
+    self:clearLevelSelectLeaderboardFlip()
 end
 
 function Game:updateLevelSelectAnimation(dt)
@@ -770,6 +1107,7 @@ function Game:moveLevelSelectSelection(direction)
     if #maps == 0 then
         self.levelSelectSelectedId = nil
         self.levelSelectScroll = 0
+        self:clearLevelSelectLeaderboardFlip()
         return nil
     end
 
@@ -789,6 +1127,7 @@ function Game:moveLevelSelectSelection(direction)
     end
 
     self.levelSelectSelectedId = maps[nextIndex].id
+    self:clearLevelSelectLeaderboardFlip()
     return maps[nextIndex]
 end
 
@@ -802,6 +1141,23 @@ function Game:scrollLevelSelect(delta)
     for _ = 1, steps do
         self:moveLevelSelectSelection(direction)
     end
+end
+
+function Game:toggleLevelSelectLeaderboardFlip(mapDescriptor)
+    local mapUuid = mapDescriptor and mapDescriptor.mapUuid or nil
+    if not mapUuid or mapUuid == "" then
+        return
+    end
+
+    if self.levelSelectLeaderboardFlipMapUuid == mapUuid then
+        self:clearLevelSelectLeaderboardFlip()
+        return
+    end
+
+    self.levelSelectSelectedId = mapDescriptor.id
+    self.levelSelectScroll = 0
+    self.levelSelectLeaderboardFlipMapUuid = mapUuid
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil)
 end
 
 function Game:getBuiltinShortcutMap(index)
@@ -836,6 +1192,7 @@ function Game:openLevelSelect()
     self.levelSelectIssue = nil
     self.levelSelectFilter = "all"
     self.levelSelectFilterHoverId = nil
+    self:clearLevelSelectLeaderboardFlip()
     self.resultsSummary = nil
     self.playOverlayMode = nil
     self:refreshMaps()
@@ -1253,7 +1610,7 @@ function Game:mousepressed(x, y, button)
     end
 
     if self.screen == "level_select" then
-        local hit = ui.getLevelSelectHit(self, viewportX, viewportY)
+        local hit = ui.getLevelSelectHit(self, viewportX, viewportY, button)
         if not hit then
             return
         end
@@ -1270,6 +1627,8 @@ function Game:mousepressed(x, y, button)
             return
         elseif hit.kind == "select_map" then
             self:setLevelSelectSelection(hit.map)
+        elseif hit.kind == "toggle_leaderboard_card" then
+            self:toggleLevelSelectLeaderboardFlip(hit.map)
         elseif hit.kind == "open_map" then
             self:setLevelSelectSelection(hit.map)
             local ok, startError, mapData = self:startMap(hit.map)

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -1,8 +1,11 @@
 local input = require("src.game.input")
 local mapEditor = require("src.game.map_editor")
 local mapStorage = require("src.game.map_storage")
+local profileStorage = require("src.game.profile_storage")
+local simpleboardsClient = require("src.game.simpleboards_client")
 local world = require("src.game.world")
 local ui = require("src.game.ui")
+local json = require("src.game.json")
 
 local Game = {}
 Game.__index = Game
@@ -46,8 +49,73 @@ local function closestWrappedIndex(currentValue, targetIndex, count)
     return bestValue
 end
 
+local function trim(value)
+    return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function trimLastUtf8Character(value)
+    return (value or ""):gsub("[%z\1-\127\194-\244][\128-\191]*$", "")
+end
+
+local function extractMapUuidFromMetadata(metadata)
+    if type(metadata) ~= "string" then
+        return nil
+    end
+
+    local trimmedMetadata = trim(metadata)
+    if trimmedMetadata == "" then
+        return nil
+    end
+
+    if trimmedMetadata:sub(1, 1) == "{" then
+        local decoded = json.decode(trimmedMetadata)
+        if type(decoded) == "table" then
+            return decoded.mapUuid
+        end
+    end
+
+    return trimmedMetadata
+end
+
+local function normalizeLeaderboardEntries(entries, mapUuid)
+    local normalized = {}
+
+    if type(entries) ~= "table" then
+        return normalized
+    end
+
+    local sourceEntries = entries.entries or entries
+    if type(sourceEntries) ~= "table" then
+        return normalized
+    end
+
+    for _, entry in ipairs(sourceEntries) do
+        local entryMapUuid = extractMapUuidFromMetadata(entry.metadata)
+        if not mapUuid or entryMapUuid == mapUuid then
+            normalized[#normalized + 1] = {
+                playerDisplayName = entry.playerDisplayName or entry.playerName or "Unknown",
+                playerId = entry.playerId,
+                score = tonumber(entry.score or 0) or 0,
+                metadata = entry.metadata,
+                mapUuid = entryMapUuid,
+                createdAt = entry.createdAt or entry.created_at,
+            }
+        end
+    end
+
+    table.sort(normalized, function(firstEntry, secondEntry)
+        if firstEntry.score == secondEntry.score then
+            return tostring(firstEntry.playerDisplayName or "") < tostring(secondEntry.playerDisplayName or "")
+        end
+        return firstEntry.score > secondEntry.score
+    end)
+
+    return normalized
+end
+
 function Game.new()
     local self = setmetatable({}, Game)
+    local profile = profileStorage.load()
 
     self.viewport = {
         w = 1280,
@@ -64,7 +132,9 @@ function Game.new()
         small = love.graphics.newFont(14),
     }
 
-    self.screen = "menu"
+    self.profile = profile
+    self.onlineConfig = simpleboardsClient.getConfig()
+    self.screen = trim(profile.playerDisplayName) ~= "" and "menu" or "profile_setup"
     self.levelComplete = false
     self.failureReason = nil
     self.world = nil
@@ -79,12 +149,199 @@ function Game.new()
     self.levelSelectVisualIndex = nil
     self.levelSelectScroll = 0
     self.resultsSummary = nil
+    self.resultsOnlineState = nil
+    self.profileSetupNameBuffer = profile.playerDisplayName or ""
+    self.profileSetupError = nil
     self.playOverlayMode = nil
+    self.leaderboardState = {
+        status = "idle",
+        message = nil,
+        entries = {},
+        totalEntries = 0,
+    }
+    self.leaderboardReturnScreen = "menu"
+    self.leaderboardMapUuid = nil
+    self.leaderboardTitle = "Online Leaderboard"
 
     self:updateRenderTransform()
     self:refreshMaps()
 
     return self
+end
+
+function Game:reloadOnlineConfig()
+    self.onlineConfig = simpleboardsClient.getConfig()
+    return self.onlineConfig
+end
+
+function Game:isProfileComplete()
+    return trim(self.profile and self.profile.playerDisplayName or "") ~= ""
+end
+
+function Game:isDebugModeEnabled()
+    return self.profile and self.profile.debugMode == true
+end
+
+function Game:saveProfile()
+    local savedProfile, saveError = profileStorage.save(self.profile or {})
+    if savedProfile then
+        self.profile = savedProfile
+        return true
+    end
+    return false, saveError
+end
+
+function Game:toggleDebugMode()
+    self.profile.debugMode = not self:isDebugModeEnabled()
+    local ok = self:saveProfile()
+    if not ok then
+        self.profile.debugMode = not self.profile.debugMode
+    end
+end
+
+function Game:appendProfileNameInput(text)
+    local cleanText = text:gsub("[%c\r\n\t]", "")
+    if cleanText == "" then
+        return
+    end
+
+    local nextValue = self.profileSetupNameBuffer .. cleanText
+    if #nextValue <= 24 then
+        self.profileSetupNameBuffer = nextValue
+        self.profileSetupError = nil
+    end
+end
+
+function Game:backspaceProfileName()
+    self.profileSetupNameBuffer = trimLastUtf8Character(self.profileSetupNameBuffer)
+    self.profileSetupError = nil
+end
+
+function Game:confirmProfileSetup()
+    local trimmedName = trim(self.profileSetupNameBuffer)
+    if trimmedName == "" then
+        self.profileSetupError = "Enter a username before continuing."
+        return false, self.profileSetupError
+    end
+
+    self.profile.playerDisplayName = trimmedName
+    self.profileSetupNameBuffer = trimmedName
+    local ok, saveError = self:saveProfile()
+    if not ok then
+        self.profileSetupError = saveError or "The profile could not be saved."
+        return false, self.profileSetupError
+    end
+
+    self.profileSetupError = nil
+    self:openMenu()
+    return true
+end
+
+function Game:submitResultsScore()
+    self.resultsOnlineState = nil
+
+    local onlineConfig = self:reloadOnlineConfig()
+    if not onlineConfig.isConfigured then
+        self.resultsOnlineState = {
+            status = "disabled",
+            message = table.concat(onlineConfig.errors or { "SimpleBoards is not configured." }, " "),
+        }
+        return
+    end
+
+    if not self.levelComplete then
+        self.resultsOnlineState = {
+            status = "skipped",
+            message = "Scores are uploaded only after a successful level clear.",
+        }
+        return
+    end
+
+    if self:isDebugModeEnabled() then
+        self.resultsOnlineState = {
+            status = "skipped",
+            message = "Debug mode is enabled, so the online score upload was skipped.",
+        }
+        return
+    end
+
+    local summary = self.resultsSummary or {}
+    local _, submitError = simpleboardsClient.submitScore({
+        playerId = self.profile.playerId,
+        playerDisplayName = self.profile.playerDisplayName,
+        score = tostring(summary.finalScore or 0),
+        metadata = summary.mapUuid or "",
+    }, onlineConfig)
+
+    if submitError then
+        self.resultsOnlineState = {
+            status = "error",
+            message = submitError,
+        }
+        return
+    end
+
+    self.resultsOnlineState = {
+        status = "submitted",
+        message = "Score uploaded successfully.",
+    }
+end
+
+function Game:refreshLeaderboard()
+    self.leaderboardState = {
+        status = "loading",
+        message = "Loading leaderboard...",
+        entries = {},
+        totalEntries = 0,
+    }
+
+    local onlineConfig = self:reloadOnlineConfig()
+    if not onlineConfig.isConfigured then
+        self.leaderboardState = {
+            status = "disabled",
+            message = table.concat(onlineConfig.errors or { "SimpleBoards is not configured." }, " "),
+            entries = {},
+            totalEntries = 0,
+        }
+        return
+    end
+
+    local entries, fetchError = simpleboardsClient.fetchLeaderboard(onlineConfig)
+    if not entries then
+        self.leaderboardState = {
+            status = "error",
+            message = fetchError or "The leaderboard could not be loaded.",
+            entries = {},
+            totalEntries = 0,
+        }
+        return
+    end
+
+    local filteredEntries = normalizeLeaderboardEntries(entries, self.leaderboardMapUuid)
+    self.leaderboardState = {
+        status = "ready",
+        message = #filteredEntries > 0 and nil or "No entries were found for this leaderboard yet.",
+        entries = filteredEntries,
+        totalEntries = #filteredEntries,
+    }
+end
+
+function Game:openLeaderboard(options)
+    local openOptions = options or {}
+    self.screen = "leaderboard"
+    self.leaderboardReturnScreen = openOptions.returnScreen or "menu"
+    self.leaderboardMapUuid = openOptions.mapUuid
+    self.leaderboardTitle = openOptions.title or (self.leaderboardMapUuid and "Map Leaderboard" or "Online Leaderboard")
+    self:refreshLeaderboard()
+end
+
+function Game:returnFromLeaderboard()
+    if self.leaderboardReturnScreen == "results" and self.resultsSummary then
+        self.screen = "results"
+        return
+    end
+
+    self:openMenu()
 end
 
 function Game:updateRenderTransform()
@@ -219,6 +476,11 @@ function Game:getBuiltinShortcutMap(index)
 end
 
 function Game:openMenu()
+    if not self:isProfileComplete() then
+        self.screen = "profile_setup"
+        return
+    end
+
     self.screen = "menu"
     self.levelSelectIssue = nil
     self.levelSelectFilterHoverId = nil
@@ -299,6 +561,7 @@ function Game:startMap(mapDescriptor, options)
     self.currentRunOrigin = startOptions.origin
     self.levelSelectIssue = nil
     self.resultsSummary = nil
+    self.resultsOnlineState = nil
     self.playOverlayMode = nil
     self.world = world.new(self.viewport.w, self.viewport.h, mapData.level)
     self.screen = "play"
@@ -349,6 +612,7 @@ function Game:openResults()
     self.failureReason = self.resultsSummary.endReason == "level_clear" and nil or self.resultsSummary.endReason
     self.levelComplete = self.resultsSummary.endReason == "level_clear"
     self.screen = "results"
+    self:submitResultsScore()
 end
 
 function Game:update(dt)
@@ -388,8 +652,12 @@ function Game:draw()
 
     if self.screen == "menu" then
         ui.drawMenu(self)
+    elseif self.screen == "profile_setup" then
+        ui.drawProfileSetup(self)
     elseif self.screen == "level_select" then
         ui.drawLevelSelect(self)
+    elseif self.screen == "leaderboard" then
+        ui.drawLeaderboard(self)
     elseif self.screen == "editor" then
         self.editor:draw(self)
     elseif self.screen == "results" then
@@ -410,8 +678,10 @@ end
 
 function Game:keypressed(key)
     if key == "escape" then
-        if self.screen == "menu" then
+        if self.screen == "profile_setup" or self.screen == "menu" then
             love.event.quit()
+        elseif self.screen == "leaderboard" then
+            self:returnFromLeaderboard()
         elseif self.screen == "level_select" and self.levelSelectIssue then
             self.levelSelectIssue = nil
         elseif self.screen == "editor" then
@@ -426,11 +696,33 @@ function Game:keypressed(key)
         return
     end
 
+    if self.screen == "profile_setup" then
+        if key == "backspace" then
+            self:backspaceProfileName()
+        elseif key == "return" then
+            self:confirmProfileSetup()
+        end
+        return
+    end
+
     if self.screen == "menu" then
         if key == "return" or key == "space" then
             self:openLevelSelect()
         elseif key == "e" then
             self:openEditorBlank()
+        elseif key == "d" then
+            self:toggleDebugMode()
+        elseif key == "l" then
+            self:openLeaderboard({ returnScreen = "menu", title = "Online Leaderboard" })
+        end
+        return
+    end
+
+    if self.screen == "leaderboard" then
+        if key == "r" then
+            self:refreshLeaderboard()
+        elseif key == "m" then
+            self:returnFromLeaderboard()
         end
         return
     end
@@ -503,6 +795,14 @@ function Game:keypressed(key)
             self:navigateBackFromRun()
             return
         end
+        if key == "l" then
+            self:openLeaderboard({
+                returnScreen = "results",
+                mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
+                title = "Current Map Leaderboard",
+            })
+            return
+        end
         if (key == "e" or key == "tab") and self.currentMapDescriptor then
             self:openEditorMap(self.currentMapDescriptor)
             return
@@ -558,7 +858,9 @@ function Game:keypressed(key)
 end
 
 function Game:textinput(text)
-    if self.screen == "editor" then
+    if self.screen == "profile_setup" then
+        self:appendProfileNameInput(text)
+    elseif self.screen == "editor" then
         self.editor:textinput(text)
     end
 end
@@ -566,14 +868,36 @@ end
 function Game:mousepressed(x, y, button)
     local viewportX, viewportY = self:toViewportPosition(x, y)
 
+    if self.screen == "profile_setup" then
+        local action = ui.getProfileSetupActionAt(self, viewportX, viewportY)
+        if action == "confirm" then
+            self:confirmProfileSetup()
+        end
+        return
+    end
+
     if self.screen == "menu" then
         local action = ui.getMenuActionAt(self, viewportX, viewportY)
         if action == "play" then
             self:openLevelSelect()
+        elseif action == "leaderboard" then
+            self:openLeaderboard({ returnScreen = "menu", title = "Online Leaderboard" })
         elseif action == "editor" then
             self:openEditorBlank()
+        elseif action == "debug" then
+            self:toggleDebugMode()
         elseif action == "quit" then
             love.event.quit()
+        end
+        return
+    end
+
+    if self.screen == "leaderboard" then
+        local action = ui.getLeaderboardActionAt(self, viewportX, viewportY)
+        if action == "back" then
+            self:returnFromLeaderboard()
+        elseif action == "refresh" then
+            self:refreshLeaderboard()
         end
         return
     end
@@ -627,6 +951,12 @@ function Game:mousepressed(x, y, button)
 
         if hit == "replay" then
             self:restart()
+        elseif hit == "leaderboard" then
+            self:openLeaderboard({
+                returnScreen = "results",
+                mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
+                title = "Current Map Leaderboard",
+            })
         elseif hit == "menu" then
             self:openMenu()
         elseif hit == "editor" and self.currentMapDescriptor then

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -2,13 +2,50 @@ local input = require("src.game.input")
 local mapEditor = require("src.game.map_editor")
 local mapStorage = require("src.game.map_storage")
 local profileStorage = require("src.game.profile_storage")
-local simpleboardsClient = require("src.game.simpleboards_client")
+local leaderboardClient = require("src.game.leaderboard_client")
 local world = require("src.game.world")
 local ui = require("src.game.ui")
 local json = require("src.game.json")
 
 local Game = {}
 Game.__index = Game
+local ONLINE_CONFIG_LOG_PREFIX = "[Leaderboard]"
+local LEADERBOARD_CACHE_DURATION_SECONDS = 60
+local LEADERBOARD_FETCH_TIMEOUT_SECONDS = 5
+local LEADERBOARD_ENTRY_LIMIT = 50
+local LEADERBOARD_THREAD_FILE = "src/game/leaderboard_fetch_thread.lua"
+local LEADERBOARD_REQUEST_CHANNEL_NAME = "signal_leaderboard_request"
+local LEADERBOARD_RESPONSE_CHANNEL_NAME = "signal_leaderboard_response"
+local LEADERBOARD_SCOPE_GLOBAL = "global"
+local LEADERBOARD_SCOPE_MAP_PREFIX = "map:"
+local LEADERBOARD_STATUS_IDLE = "idle"
+local LEADERBOARD_STATUS_LOADING = "loading"
+local LEADERBOARD_STATUS_READY = "ready"
+local LEADERBOARD_STATUS_ERROR = "error"
+local LEADERBOARD_STATUS_DISABLED = "disabled"
+local LEADERBOARD_SCOPE_MAP = "map"
+local LEADERBOARD_MESSAGE_LOADING = "Loading leaderboard..."
+local LEADERBOARD_MESSAGE_EMPTY = "No entries were found for this leaderboard yet."
+local LEADERBOARD_MESSAGE_FETCH_FAILED = "The leaderboard could not be loaded."
+local LEADERBOARD_MESSAGE_NO_DATA = "No data right now."
+local LEADERBOARD_MAP_NAME_UNKNOWN = "Unknown Map"
+
+local function getNowSeconds()
+    if love and love.timer and love.timer.getTime then
+        return love.timer.getTime()
+    end
+
+    return os.clock()
+end
+
+local function drainChannel(channel)
+    if not channel then
+        return
+    end
+
+    while channel:pop() ~= nil do
+    end
+end
 
 local function findLevelSelectIndex(game, maps)
     local fallbackIndex = #maps > 0 and 1 or nil
@@ -57,60 +94,64 @@ local function trimLastUtf8Character(value)
     return (value or ""):gsub("[%z\1-\127\194-\244][\128-\191]*$", "")
 end
 
-local function extractMapUuidFromMetadata(metadata)
-    if type(metadata) ~= "string" then
-        return nil
-    end
-
-    local trimmedMetadata = trim(metadata)
-    if trimmedMetadata == "" then
-        return nil
-    end
-
-    if trimmedMetadata:sub(1, 1) == "{" then
-        local decoded = json.decode(trimmedMetadata)
-        if type(decoded) == "table" then
-            return decoded.mapUuid
-        end
-    end
-
-    return trimmedMetadata
-end
-
-local function normalizeLeaderboardEntries(entries, mapUuid)
+local function normalizeLeaderboardEntries(payload)
     local normalized = {}
 
-    if type(entries) ~= "table" then
+    if type(payload) ~= "table" then
         return normalized
     end
 
-    local sourceEntries = entries.entries or entries
+    local sourceEntries = payload.entries or payload
+    local fallbackMapUuid = payload.map_uuid
     if type(sourceEntries) ~= "table" then
         return normalized
     end
 
     for _, entry in ipairs(sourceEntries) do
-        local entryMapUuid = extractMapUuidFromMetadata(entry.metadata)
-        if not mapUuid or entryMapUuid == mapUuid then
-            normalized[#normalized + 1] = {
-                playerDisplayName = entry.playerDisplayName or entry.playerName or "Unknown",
-                playerId = entry.playerId,
-                score = tonumber(entry.score or 0) or 0,
-                metadata = entry.metadata,
-                mapUuid = entryMapUuid,
-                createdAt = entry.createdAt or entry.created_at,
-            }
-        end
+        normalized[#normalized + 1] = {
+            playerDisplayName = entry.display_name or entry.playerDisplayName or "Unknown",
+            playerUuid = entry.player_uuid or entry.playerUuid or "",
+            mapCount = tonumber(entry.map_count) or 0,
+            score = tonumber(entry.score or 0) or 0,
+            rank = tonumber(entry.rank) or (#normalized + 1),
+            mapUuid = entry.map_uuid or entry.last_map_uuid or fallbackMapUuid,
+            updatedAt = entry.updated_at or entry.updatedAt,
+        }
     end
 
-    table.sort(normalized, function(firstEntry, secondEntry)
-        if firstEntry.score == secondEntry.score then
-            return tostring(firstEntry.playerDisplayName or "") < tostring(secondEntry.playerDisplayName or "")
-        end
-        return firstEntry.score > secondEntry.score
-    end)
-
     return normalized
+end
+
+local function getLeaderboardScopeKey(mapUuid)
+    if mapUuid and mapUuid ~= "" then
+        return LEADERBOARD_SCOPE_MAP_PREFIX .. mapUuid
+    end
+
+    return LEADERBOARD_SCOPE_GLOBAL
+end
+
+local function describeConfigSource(onlineConfig, key)
+    local sourceByKey = onlineConfig and onlineConfig.sourceByKey or {}
+    return sourceByKey[key] or "missing"
+end
+
+local function logOnlineConfig(onlineConfig)
+    local config = onlineConfig or {}
+    local statusText = config.isConfigured and "ready" or "incomplete"
+    local apiKeySource = describeConfigSource(config, "API_KEY")
+    local apiBaseUrlSource = describeConfigSource(config, "API_BASE_URL")
+
+    print(string.format(
+        "%s startup status=%s apiKeySource=%s apiBaseUrlSource=%s",
+        ONLINE_CONFIG_LOG_PREFIX,
+        statusText,
+        apiKeySource,
+        apiBaseUrlSource
+    ))
+
+    for _, errorMessage in ipairs(config.errors or {}) do
+        print(string.format("%s config error: %s", ONLINE_CONFIG_LOG_PREFIX, errorMessage))
+    end
 end
 
 function Game.new()
@@ -133,13 +174,15 @@ function Game.new()
     }
 
     self.profile = profile
-    self.onlineConfig = simpleboardsClient.getConfig()
+    self.onlineConfig = leaderboardClient.getConfig()
+    logOnlineConfig(self.onlineConfig)
     self.screen = trim(profile.playerDisplayName) ~= "" and "menu" or "profile_setup"
     self.levelComplete = false
     self.failureReason = nil
     self.world = nil
     self.editor = mapEditor.new(self.viewport.w, self.viewport.h, nil)
     self.availableMaps = {}
+    self.mapNameByUuid = {}
     self.currentMapDescriptor = nil
     self.currentRunOrigin = nil
     self.levelSelectIssue = nil
@@ -154,14 +197,27 @@ function Game.new()
     self.profileSetupError = nil
     self.playOverlayMode = nil
     self.leaderboardState = {
-        status = "idle",
+        status = LEADERBOARD_STATUS_IDLE,
         message = nil,
         entries = {},
         totalEntries = 0,
+        fetchedAt = nil,
     }
     self.leaderboardReturnScreen = "menu"
     self.leaderboardMapUuid = nil
     self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardHoverInfo = nil
+    self.leaderboardCacheByScope = {}
+    self.leaderboardNextFetchAtByScope = {}
+    self.leaderboardRequestSequence = 0
+    self.activeLeaderboardRequestId = nil
+    self.activeLeaderboardRequestStartedAt = nil
+    self.activeLeaderboardRequestScopeKey = nil
+    self.leaderboardWorkerThread = nil
+    self.leaderboardRequestChannel = love.thread.getChannel(LEADERBOARD_REQUEST_CHANNEL_NAME)
+    self.leaderboardResponseChannel = love.thread.getChannel(LEADERBOARD_RESPONSE_CHANNEL_NAME)
+    drainChannel(self.leaderboardRequestChannel)
+    drainChannel(self.leaderboardResponseChannel)
 
     self:updateRenderTransform()
     self:refreshMaps()
@@ -170,8 +226,223 @@ function Game.new()
 end
 
 function Game:reloadOnlineConfig()
-    self.onlineConfig = simpleboardsClient.getConfig()
+    local loadedConfig = leaderboardClient.getConfig()
+    if loadedConfig.isConfigured or not (self.onlineConfig and self.onlineConfig.isConfigured) then
+        self.onlineConfig = loadedConfig
+    end
     return self.onlineConfig
+end
+
+function Game:getLeaderboardCacheEntry(scopeKey)
+    local resolvedScopeKey = scopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
+    return self.leaderboardCacheByScope[resolvedScopeKey] or {
+        payload = nil,
+        fetchedAt = nil,
+    }
+end
+
+function Game:setLeaderboardCacheEntry(scopeKey, payload, fetchedAt)
+    self.leaderboardCacheByScope[scopeKey] = {
+        payload = payload,
+        fetchedAt = fetchedAt,
+    }
+end
+
+function Game:getFilteredLeaderboardEntries(payload)
+    local normalizedEntries = normalizeLeaderboardEntries(payload)
+
+    for _, entry in ipairs(normalizedEntries) do
+        entry.mapName = self:getMapNameByUuid(entry.mapUuid)
+    end
+
+    return normalizedEntries
+end
+
+function Game:buildLeaderboardState(status, message, rawEntries, fetchedAt)
+    local filteredEntries = self:getFilteredLeaderboardEntries(rawEntries)
+    local resolvedMessage = message
+
+    if status == LEADERBOARD_STATUS_READY and #filteredEntries == 0 then
+        resolvedMessage = LEADERBOARD_MESSAGE_EMPTY
+    end
+
+    return {
+        status = status,
+        message = resolvedMessage,
+        entries = filteredEntries,
+        totalEntries = #filteredEntries,
+        fetchedAt = fetchedAt,
+        scope = type(rawEntries) == "table" and rawEntries.scope or (self.leaderboardMapUuid and LEADERBOARD_SCOPE_MAP or LEADERBOARD_SCOPE_GLOBAL),
+    }
+end
+
+function Game:isLeaderboardCacheFresh()
+    local cacheEntry = self:getLeaderboardCacheEntry()
+    if not cacheEntry.payload or not cacheEntry.fetchedAt then
+        return false
+    end
+
+    return (getNowSeconds() - cacheEntry.fetchedAt) < LEADERBOARD_CACHE_DURATION_SECONDS
+end
+
+function Game:isLeaderboardFetchAllowed()
+    return getNowSeconds() >= (self.leaderboardNextFetchAtByScope[getLeaderboardScopeKey(self.leaderboardMapUuid)] or 0)
+end
+
+function Game:getActiveOnlineConfig()
+    local resolvedConfig = self:reloadOnlineConfig()
+    if resolvedConfig and resolvedConfig.isConfigured then
+        return resolvedConfig
+    end
+
+    if self.onlineConfig and self.onlineConfig.isConfigured then
+        return self.onlineConfig
+    end
+
+    return resolvedConfig
+end
+
+function Game:ensureLeaderboardWorker()
+    local existingThread = self.leaderboardWorkerThread
+    if existingThread and existingThread:isRunning() and not existingThread:getError() then
+        return true
+    end
+
+    self.leaderboardWorkerThread = love.thread.newThread(LEADERBOARD_THREAD_FILE)
+    self.leaderboardWorkerThread:start()
+    return true
+end
+
+function Game:beginLeaderboardFetch(onlineConfig)
+    if self.activeLeaderboardRequestId ~= nil then
+        return
+    end
+
+    self:ensureLeaderboardWorker()
+    local requestScopeKey = getLeaderboardScopeKey(self.leaderboardMapUuid)
+    local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
+
+    self.leaderboardState = self:buildLeaderboardState(
+        LEADERBOARD_STATUS_LOADING,
+        LEADERBOARD_MESSAGE_LOADING,
+        cacheEntry.payload,
+        cacheEntry.fetchedAt
+    )
+
+    self.leaderboardRequestSequence = self.leaderboardRequestSequence + 1
+    self.activeLeaderboardRequestId = self.leaderboardRequestSequence
+    self.activeLeaderboardRequestStartedAt = getNowSeconds()
+    self.activeLeaderboardRequestScopeKey = requestScopeKey
+    self.leaderboardRequestChannel:push(json.encode({
+        kind = "fetch",
+        requestId = self.activeLeaderboardRequestId,
+        config = {
+            apiKey = onlineConfig.apiKey,
+            apiBaseUrl = onlineConfig.apiBaseUrl,
+            limit = LEADERBOARD_ENTRY_LIMIT,
+            mapUuid = self.leaderboardMapUuid,
+        },
+    }))
+end
+
+function Game:applyLeaderboardFetchResult(response)
+    local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
+    local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
+    if response.ok and type(response.payload) == "table" then
+        local fetchedAt = getNowSeconds()
+        self:setLeaderboardCacheEntry(requestScopeKey, response.payload, fetchedAt)
+        self.leaderboardNextFetchAtByScope[requestScopeKey] = fetchedAt + LEADERBOARD_CACHE_DURATION_SECONDS
+        if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
+            self.leaderboardState = self:buildLeaderboardState(LEADERBOARD_STATUS_READY, nil, response.payload, fetchedAt)
+        end
+        return
+    end
+
+    self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
+    local fetchMessage = response.error or LEADERBOARD_MESSAGE_FETCH_FAILED
+    if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
+        self.leaderboardState = self:buildLeaderboardState(
+            LEADERBOARD_STATUS_ERROR,
+            fetchMessage,
+            cacheEntry.payload,
+            cacheEntry.fetchedAt
+        )
+    end
+end
+
+function Game:updateLeaderboardFetchState()
+    local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
+    local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
+
+    if self.leaderboardWorkerThread and self.activeLeaderboardRequestId ~= nil then
+        local threadError = self.leaderboardWorkerThread:getError()
+        if threadError then
+            self.activeLeaderboardRequestId = nil
+            self.activeLeaderboardRequestStartedAt = nil
+            self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
+            if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
+                self.leaderboardState = self:buildLeaderboardState(
+                    LEADERBOARD_STATUS_ERROR,
+                    threadError,
+                    cacheEntry.payload,
+                    cacheEntry.fetchedAt
+                )
+            end
+            self.activeLeaderboardRequestScopeKey = nil
+            self.leaderboardWorkerThread = nil
+            return
+        end
+    end
+
+    if self.activeLeaderboardRequestId ~= nil and self.activeLeaderboardRequestStartedAt ~= nil then
+        local elapsedSeconds = getNowSeconds() - self.activeLeaderboardRequestStartedAt
+        if elapsedSeconds >= LEADERBOARD_FETCH_TIMEOUT_SECONDS then
+            self.activeLeaderboardRequestId = nil
+            self.activeLeaderboardRequestStartedAt = nil
+            self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
+            local hasCachedEntries = cacheEntry.payload ~= nil
+            if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
+                self.leaderboardState = self:buildLeaderboardState(
+                    hasCachedEntries and LEADERBOARD_STATUS_READY or LEADERBOARD_STATUS_ERROR,
+                    hasCachedEntries and nil or LEADERBOARD_MESSAGE_NO_DATA,
+                    cacheEntry.payload,
+                    cacheEntry.fetchedAt
+                )
+            end
+            self.activeLeaderboardRequestScopeKey = nil
+            return
+        end
+    end
+
+    while true do
+        local encodedResponse = self.leaderboardResponseChannel:pop()
+        if not encodedResponse then
+            break
+        end
+
+        local decodedResponse = json.decode(encodedResponse)
+        if type(decodedResponse) == "table" and decodedResponse.requestId == self.activeLeaderboardRequestId then
+            self.activeLeaderboardRequestId = nil
+            self.activeLeaderboardRequestStartedAt = nil
+            self:applyLeaderboardFetchResult(decodedResponse)
+            self.activeLeaderboardRequestScopeKey = nil
+        end
+    end
+
+    if self.screen == "leaderboard" and self.activeLeaderboardRequestId == nil and not self:isLeaderboardCacheFresh() and self:isLeaderboardFetchAllowed() then
+        local onlineConfig = self:getActiveOnlineConfig()
+        if not onlineConfig.isConfigured then
+            self.leaderboardState = self:buildLeaderboardState(
+                LEADERBOARD_STATUS_DISABLED,
+                table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
+                cacheEntry.payload,
+                cacheEntry.fetchedAt
+            )
+            return
+        end
+
+        self:beginLeaderboardFetch(onlineConfig)
+    end
 end
 
 function Game:isProfileComplete()
@@ -244,7 +515,7 @@ function Game:submitResultsScore()
     if not onlineConfig.isConfigured then
         self.resultsOnlineState = {
             status = "disabled",
-            message = table.concat(onlineConfig.errors or { "SimpleBoards is not configured." }, " "),
+            message = table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
         }
         return
     end
@@ -266,11 +537,11 @@ function Game:submitResultsScore()
     end
 
     local summary = self.resultsSummary or {}
-    local _, submitError = simpleboardsClient.submitScore({
-        playerId = self.profile.playerId,
+    local response, submitError, statusCode = leaderboardClient.submitScore({
+        playerUuid = self.profile.playerId,
         playerDisplayName = self.profile.playerDisplayName,
-        score = tostring(summary.finalScore or 0),
-        metadata = summary.mapUuid or "",
+        score = summary.finalScore or 0,
+        mapUuid = summary.mapUuid,
     }, onlineConfig)
 
     if submitError then
@@ -282,48 +553,48 @@ function Game:submitResultsScore()
     end
 
     self.resultsOnlineState = {
-        status = "submitted",
-        message = "Score uploaded successfully.",
+        status = statusCode == 202 and "kept" or "submitted",
+        message = statusCode == 202
+            and "Score was valid, but your online best for this map is already higher."
+            or "Score uploaded successfully.",
     }
 end
 
 function Game:refreshLeaderboard()
-    self.leaderboardState = {
-        status = "loading",
-        message = "Loading leaderboard...",
-        entries = {},
-        totalEntries = 0,
-    }
-
-    local onlineConfig = self:reloadOnlineConfig()
+    local onlineConfig = self:getActiveOnlineConfig()
+    local cacheEntry = self:getLeaderboardCacheEntry()
     if not onlineConfig.isConfigured then
-        self.leaderboardState = {
-            status = "disabled",
-            message = table.concat(onlineConfig.errors or { "SimpleBoards is not configured." }, " "),
-            entries = {},
-            totalEntries = 0,
-        }
+        self.leaderboardState = self:buildLeaderboardState(
+            LEADERBOARD_STATUS_DISABLED,
+            table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
+            cacheEntry.payload,
+            cacheEntry.fetchedAt
+        )
         return
     end
 
-    local entries, fetchError = simpleboardsClient.fetchLeaderboard(onlineConfig)
-    if not entries then
-        self.leaderboardState = {
-            status = "error",
-            message = fetchError or "The leaderboard could not be loaded.",
-            entries = {},
-            totalEntries = 0,
-        }
+    if self:isLeaderboardCacheFresh() then
+        self.leaderboardState = self:buildLeaderboardState(
+            LEADERBOARD_STATUS_READY,
+            nil,
+            cacheEntry.payload,
+            cacheEntry.fetchedAt
+        )
         return
     end
 
-    local filteredEntries = normalizeLeaderboardEntries(entries, self.leaderboardMapUuid)
-    self.leaderboardState = {
-        status = "ready",
-        message = #filteredEntries > 0 and nil or "No entries were found for this leaderboard yet.",
-        entries = filteredEntries,
-        totalEntries = #filteredEntries,
-    }
+    if not self:isLeaderboardFetchAllowed() then
+        local fallbackMessage = cacheEntry.payload and nil or LEADERBOARD_MESSAGE_NO_DATA
+        self.leaderboardState = self:buildLeaderboardState(
+            cacheEntry.payload and LEADERBOARD_STATUS_READY or LEADERBOARD_STATUS_ERROR,
+            fallbackMessage,
+            cacheEntry.payload,
+            cacheEntry.fetchedAt
+        )
+        return
+    end
+
+    self:beginLeaderboardFetch(onlineConfig)
 end
 
 function Game:openLeaderboard(options)
@@ -332,6 +603,62 @@ function Game:openLeaderboard(options)
     self.leaderboardReturnScreen = openOptions.returnScreen or "menu"
     self.leaderboardMapUuid = openOptions.mapUuid
     self.leaderboardTitle = openOptions.title or (self.leaderboardMapUuid and "Map Leaderboard" or "Online Leaderboard")
+    self.leaderboardHoverInfo = nil
+    self:refreshLeaderboard()
+end
+
+function Game:openLeaderboardForMap(mapUuid, mapName)
+    if not mapUuid or mapUuid == "" then
+        return
+    end
+
+    self.leaderboardMapUuid = mapUuid
+    self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardHoverInfo = nil
+    self:refreshLeaderboard()
+end
+
+function Game:getLeaderboardCycleMapUuids()
+    local mapUuids = {}
+
+    for _, descriptor in ipairs(self.availableMaps or {}) do
+        if descriptor.mapUuid and descriptor.mapUuid ~= "" then
+            mapUuids[#mapUuids + 1] = descriptor.mapUuid
+        end
+    end
+
+    return mapUuids
+end
+
+function Game:cycleLeaderboardMapFilter()
+    local mapUuids = self:getLeaderboardCycleMapUuids()
+    if #mapUuids == 0 then
+        self:clearLeaderboardMapFilter()
+        return
+    end
+
+    local nextMapUuid = mapUuids[1]
+    if self.leaderboardMapUuid and self.leaderboardMapUuid ~= "" then
+        for index, mapUuid in ipairs(mapUuids) do
+            if mapUuid == self.leaderboardMapUuid then
+                nextMapUuid = mapUuids[index + 1]
+                break
+            end
+        end
+    end
+
+    if not nextMapUuid then
+        self:clearLeaderboardMapFilter()
+        return
+    end
+
+    self:openLeaderboardForMap(nextMapUuid)
+end
+
+function Game:clearLeaderboardMapFilter()
+    self.leaderboardMapUuid = nil
+    self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardHoverInfo = nil
     self:refreshLeaderboard()
 end
 
@@ -357,6 +684,21 @@ end
 
 function Game:refreshMaps()
     self.availableMaps = mapStorage.listMaps()
+    self.mapNameByUuid = {}
+
+    for _, descriptor in ipairs(self.availableMaps) do
+        if descriptor.mapUuid and descriptor.mapUuid ~= "" then
+            self.mapNameByUuid[descriptor.mapUuid] = descriptor.displayName or descriptor.name or LEADERBOARD_MAP_NAME_UNKNOWN
+        end
+    end
+end
+
+function Game:getMapNameByUuid(mapUuid)
+    if not mapUuid or mapUuid == "" then
+        return LEADERBOARD_MAP_NAME_UNKNOWN
+    end
+
+    return self.mapNameByUuid[mapUuid] or LEADERBOARD_MAP_NAME_UNKNOWN
 end
 
 function Game:getLevelSelectMaps()
@@ -616,6 +958,8 @@ function Game:openResults()
 end
 
 function Game:update(dt)
+    self:updateLeaderboardFetchState()
+
     if self.screen == "level_select" then
         self:updateLevelSelectAnimation(dt)
         return
@@ -719,9 +1063,7 @@ function Game:keypressed(key)
     end
 
     if self.screen == "leaderboard" then
-        if key == "r" then
-            self:refreshLeaderboard()
-        elseif key == "m" then
+        if key == "m" then
             self:returnFromLeaderboard()
         end
         return
@@ -799,7 +1141,7 @@ function Game:keypressed(key)
             self:openLeaderboard({
                 returnScreen = "results",
                 mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
-                title = "Current Map Leaderboard",
+                title = "Online Leaderboard",
             })
             return
         end
@@ -896,8 +1238,16 @@ function Game:mousepressed(x, y, button)
         local action = ui.getLeaderboardActionAt(self, viewportX, viewportY)
         if action == "back" then
             self:returnFromLeaderboard()
-        elseif action == "refresh" then
-            self:refreshLeaderboard()
+            return
+        end
+        if action == "cycle_filter" then
+            self:cycleLeaderboardMapFilter()
+            return
+        end
+
+        local mapHit = ui.getLeaderboardMapHitAt(self, viewportX, viewportY)
+        if mapHit then
+            self:openLeaderboardForMap(mapHit.mapUuid, mapHit.mapName)
         end
         return
     end
@@ -955,7 +1305,7 @@ function Game:mousepressed(x, y, button)
             self:openLeaderboard({
                 returnScreen = "results",
                 mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
-                title = "Current Map Leaderboard",
+                title = "Online Leaderboard",
             })
         elseif hit == "menu" then
             self:openMenu()
@@ -982,6 +1332,12 @@ function Game:mousepressed(x, y, button)
 end
 
 function Game:mousemoved(x, y)
+    if self.screen == "leaderboard" then
+        local viewportX, viewportY = self:toViewportPosition(x, y)
+        self.leaderboardHoverInfo = ui.getLeaderboardHoverInfoAt(self, viewportX, viewportY)
+        return
+    end
+
     if self.screen == "level_select" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
         self.levelSelectFilterHoverId = ui.getLevelSelectFilterHoverId(self, viewportX, viewportY)

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -40,6 +40,35 @@ local LEVEL_SELECT_PREVIEW_STATUS_ERROR = "error"
 local LEVEL_SELECT_PREVIEW_MESSAGE_LOADING = "Loading leaderboard..."
 local LEVEL_SELECT_PREVIEW_MESSAGE_EMPTY = "No scores yet."
 local LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA = "No local leaderboard data."
+local LEVEL_SELECT_MODE_LIBRARY = "library"
+local LEVEL_SELECT_MODE_MARKETPLACE = "marketplace"
+local LEVEL_SELECT_MARKETPLACE_TAB_TOP = "top"
+local LEVEL_SELECT_MARKETPLACE_TAB_RANDOM = "random"
+local LEVEL_SELECT_MARKETPLACE_TAB_SEARCH = "search"
+local LEVEL_SELECT_MARKETPLACE_SEARCH_MAX_LENGTH = 40
+local LEVEL_SELECT_MARKETPLACE_TAB_ORDER = {
+    LEVEL_SELECT_MARKETPLACE_TAB_TOP,
+    LEVEL_SELECT_MARKETPLACE_TAB_RANDOM,
+    LEVEL_SELECT_MARKETPLACE_TAB_SEARCH,
+}
+local LEVEL_SELECT_MARKETPLACE_SOURCE_FAVORITES = "favorites"
+local LEVEL_SELECT_MARKETPLACE_SOURCE_SEARCH = "search"
+local LEVEL_SELECT_MARKETPLACE_SCOPE_FAVORITES = "favorites"
+local LEVEL_SELECT_MARKETPLACE_SCOPE_SEARCH_PREFIX = "search:"
+local LEVEL_SELECT_MARKETPLACE_REMOTE_LIMIT = 10
+local LEVEL_SELECT_MARKETPLACE_FETCH_TIMEOUT_SECONDS = 5
+local LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS = 60
+local LEVEL_SELECT_MARKETPLACE_STATUS_IDLE = "idle"
+local LEVEL_SELECT_MARKETPLACE_STATUS_LOADING = "loading"
+local LEVEL_SELECT_MARKETPLACE_STATUS_READY = "ready"
+local LEVEL_SELECT_MARKETPLACE_STATUS_ERROR = "error"
+local LEVEL_SELECT_MARKETPLACE_STATUS_DISABLED = "disabled"
+local LEVEL_SELECT_MARKETPLACE_MESSAGE_LOADING = "Loading online maps..."
+local LEVEL_SELECT_MARKETPLACE_MESSAGE_EMPTY_SEARCH = "Type a map name, UUID, code, or creator to search."
+local LEVEL_SELECT_MARKETPLACE_MESSAGE_FETCH_FAILED = "The online maps could not be loaded."
+local LEVEL_SELECT_ACTION_STATUS_INFO = "info"
+local LEVEL_SELECT_ACTION_STATUS_SUCCESS = "success"
+local LEVEL_SELECT_ACTION_STATUS_ERROR = "error"
 
 local function getNowSeconds()
     if love and love.timer and love.timer.getTime then
@@ -111,6 +140,19 @@ end
 
 local function trimLastUtf8Character(value)
     return (value or ""):gsub("[%z\1-\127\194-\244][\128-\191]*$", "")
+end
+
+local function deepCopy(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, entry in pairs(value) do
+        copy[deepCopy(key)] = deepCopy(entry)
+    end
+
+    return copy
 end
 
 local function normalizeLeaderboardEntry(entry, fallbackMapUuid, fallbackRank)
@@ -218,9 +260,13 @@ function Game.new()
     self.levelSelectIssue = nil
     self.levelSelectSelectedId = nil
     self.levelSelectFilter = "all"
-    self.levelSelectFilterHoverId = nil
+    self.levelSelectHoverId = nil
     self.levelSelectVisualIndex = nil
     self.levelSelectScroll = 0
+    self.levelSelectMode = LEVEL_SELECT_MODE_LIBRARY
+    self.levelSelectMarketplaceTab = LEVEL_SELECT_MARKETPLACE_TAB_TOP
+    self.levelSelectMarketplaceSearchQuery = ""
+    self.levelSelectActionState = nil
     self.levelSelectLeaderboardFlipMapUuid = nil
     self.levelSelectPreviewCacheByMap = leaderboardPreviewCache.load()
     self.levelSelectPreviewNextFetchAtByMap = {}
@@ -233,6 +279,13 @@ function Game.new()
     self.activeLevelSelectPreviewRequestId = nil
     self.activeLevelSelectPreviewRequestStartedAt = nil
     self.activeLevelSelectPreviewRequestMapUuid = nil
+    self.marketplaceCacheByScope = {}
+    self.marketplaceNextFetchAtByScope = {}
+    self.marketplaceStateByScope = {}
+    self.marketplaceRequestSequence = 0
+    self.activeMarketplaceRequestId = nil
+    self.activeMarketplaceRequestStartedAt = nil
+    self.activeMarketplaceRequestScopeKey = nil
     self.resultsSummary = nil
     self.resultsOnlineState = nil
     self.profileSetupNameBuffer = profile.playerDisplayName or ""
@@ -342,6 +395,123 @@ function Game:getActiveOnlineConfig()
     end
 
     return resolvedConfig
+end
+
+function Game:setLevelSelectActionState(status, message)
+    if not status or not message or message == "" then
+        self.levelSelectActionState = nil
+        return
+    end
+
+    self.levelSelectActionState = {
+        status = status,
+        message = message,
+    }
+end
+
+function Game:clearLevelSelectActionState()
+    self.levelSelectActionState = nil
+end
+
+function Game:getMarketplaceScopeDetails(tabId, query)
+    local resolvedTabId = tabId or self.levelSelectMarketplaceTab or LEVEL_SELECT_MARKETPLACE_TAB_TOP
+    local normalizedQuery = trim(query or self.levelSelectMarketplaceSearchQuery or "")
+
+    if resolvedTabId == LEVEL_SELECT_MARKETPLACE_TAB_SEARCH then
+        if normalizedQuery == "" then
+            return {
+                fetchMode = LEVEL_SELECT_MARKETPLACE_SOURCE_SEARCH,
+                scopeKey = LEVEL_SELECT_MARKETPLACE_SCOPE_SEARCH_PREFIX,
+                query = "",
+                needsRequest = false,
+            }
+        end
+
+        return {
+            fetchMode = LEVEL_SELECT_MARKETPLACE_SOURCE_SEARCH,
+            scopeKey = LEVEL_SELECT_MARKETPLACE_SCOPE_SEARCH_PREFIX .. string.lower(normalizedQuery),
+            query = normalizedQuery,
+            needsRequest = true,
+        }
+    end
+
+    return {
+        fetchMode = LEVEL_SELECT_MARKETPLACE_SOURCE_FAVORITES,
+        scopeKey = LEVEL_SELECT_MARKETPLACE_SCOPE_FAVORITES,
+        query = nil,
+        needsRequest = true,
+    }
+end
+
+function Game:getMarketplaceCacheEntry(scopeKey)
+    local resolvedScopeKey = scopeKey or self:getMarketplaceScopeDetails().scopeKey
+    return self.marketplaceCacheByScope[resolvedScopeKey] or {
+        payload = nil,
+        fetchedAt = nil,
+    }
+end
+
+function Game:setMarketplaceCacheEntry(scopeKey, payload, fetchedAt)
+    self.marketplaceCacheByScope[scopeKey] = {
+        payload = payload,
+        fetchedAt = fetchedAt,
+    }
+end
+
+function Game:setMarketplaceState(scopeKey, status, message)
+    self.marketplaceStateByScope[scopeKey] = {
+        status = status or LEVEL_SELECT_MARKETPLACE_STATUS_IDLE,
+        message = message,
+    }
+end
+
+function Game:getMarketplaceViewState()
+    local scopeDetails = self:getMarketplaceScopeDetails()
+    local scopeKey = scopeDetails.scopeKey
+    local state = self.marketplaceStateByScope[scopeKey]
+    if state then
+        return state
+    end
+
+    if scopeDetails.fetchMode == LEVEL_SELECT_MARKETPLACE_SOURCE_SEARCH and not scopeDetails.needsRequest then
+        return {
+            status = LEVEL_SELECT_MARKETPLACE_STATUS_IDLE,
+            message = LEVEL_SELECT_MARKETPLACE_MESSAGE_EMPTY_SEARCH,
+        }
+    end
+
+    return {
+        status = LEVEL_SELECT_MARKETPLACE_STATUS_IDLE,
+        message = nil,
+    }
+end
+
+function Game:getMarketplaceEntries()
+    local scopeDetails = self:getMarketplaceScopeDetails()
+    if scopeDetails.fetchMode == LEVEL_SELECT_MARKETPLACE_SOURCE_SEARCH and not scopeDetails.needsRequest then
+        return {}
+    end
+
+    local cacheEntry = self:getMarketplaceCacheEntry(scopeDetails.scopeKey)
+    local payload = cacheEntry.payload
+    if type(payload) ~= "table" or type(payload.entries) ~= "table" then
+        return {}
+    end
+
+    return payload.entries
+end
+
+function Game:isMarketplaceCacheFresh(scopeKey)
+    local cacheEntry = self:getMarketplaceCacheEntry(scopeKey)
+    if not cacheEntry.payload or not cacheEntry.fetchedAt then
+        return false
+    end
+
+    return (getNowSeconds() - cacheEntry.fetchedAt) < LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS
+end
+
+function Game:isMarketplaceFetchAllowed(scopeKey)
+    return getNowSeconds() >= (self.marketplaceNextFetchAtByScope[scopeKey] or 0)
 end
 
 function Game:setLevelSelectPreviewState(mapUuid, status, message)
@@ -649,13 +819,64 @@ function Game:applyLevelSelectPreviewFetchResult(response, mapUuid)
     self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
 end
 
+function Game:beginMarketplaceFetch(onlineConfig, scopeDetails)
+    if self.activeMarketplaceRequestId ~= nil or not scopeDetails or not scopeDetails.needsRequest then
+        return
+    end
+
+    self:ensureLeaderboardWorker()
+    local scopeKey = scopeDetails.scopeKey
+    self.marketplaceRequestSequence = self.marketplaceRequestSequence + 1
+    self.activeMarketplaceRequestId = self.marketplaceRequestSequence
+    self.activeMarketplaceRequestStartedAt = getNowSeconds()
+    self.activeMarketplaceRequestScopeKey = scopeKey
+    self:setMarketplaceState(scopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_LOADING, LEVEL_SELECT_MARKETPLACE_MESSAGE_LOADING)
+    self.leaderboardRequestChannel:push(json.encode({
+        kind = "marketplace",
+        requestId = self.activeMarketplaceRequestId,
+        config = {
+            apiKey = onlineConfig.apiKey,
+            apiBaseUrl = onlineConfig.apiBaseUrl,
+            mode = scopeDetails.fetchMode,
+            query = scopeDetails.query,
+            limit = LEVEL_SELECT_MARKETPLACE_REMOTE_LIMIT,
+        },
+    }))
+end
+
+function Game:applyMarketplaceFetchResult(response, scopeKey)
+    if not scopeKey or scopeKey == "" then
+        return
+    end
+
+    if response.ok and type(response.payload) == "table" then
+        local fetchedAt = getNowSeconds()
+        self:setMarketplaceCacheEntry(scopeKey, response.payload, fetchedAt)
+        self.marketplaceNextFetchAtByScope[scopeKey] = fetchedAt + LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS
+        self:setMarketplaceState(scopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_READY, nil)
+        return
+    end
+
+    self.marketplaceNextFetchAtByScope[scopeKey] = getNowSeconds() + LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS
+    self:setMarketplaceState(
+        scopeKey,
+        LEVEL_SELECT_MARKETPLACE_STATUS_ERROR,
+        response.error or LEVEL_SELECT_MARKETPLACE_MESSAGE_FETCH_FAILED
+    )
+end
+
 function Game:updateLeaderboardFetchState()
     local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
     local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
     local activePreviewMapUuid = self.activeLevelSelectPreviewRequestMapUuid
     local previewCacheEntry = self:getLevelSelectPreviewCacheEntry(activePreviewMapUuid)
+    local marketplaceScopeKey = self.activeMarketplaceRequestScopeKey
 
-    if self.leaderboardWorkerThread and (self.activeLeaderboardRequestId ~= nil or self.activeLevelSelectPreviewRequestId ~= nil) then
+    if self.leaderboardWorkerThread and (
+        self.activeLeaderboardRequestId ~= nil
+        or self.activeLevelSelectPreviewRequestId ~= nil
+        or self.activeMarketplaceRequestId ~= nil
+    ) then
         local threadError = self.leaderboardWorkerThread:getError()
         if threadError then
             if self.activeLeaderboardRequestId ~= nil then
@@ -685,6 +906,16 @@ function Game:updateLeaderboardFetchState()
                     end
                 end
                 self.activeLevelSelectPreviewRequestMapUuid = nil
+            end
+
+            if self.activeMarketplaceRequestId ~= nil then
+                self.activeMarketplaceRequestId = nil
+                self.activeMarketplaceRequestStartedAt = nil
+                if marketplaceScopeKey and marketplaceScopeKey ~= "" then
+                    self.marketplaceNextFetchAtByScope[marketplaceScopeKey] = getNowSeconds() + LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS
+                    self:setMarketplaceState(marketplaceScopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_ERROR, threadError)
+                end
+                self.activeMarketplaceRequestScopeKey = nil
             end
 
             self.leaderboardWorkerThread = nil
@@ -730,6 +961,20 @@ function Game:updateLeaderboardFetchState()
         end
     end
 
+    if self.activeMarketplaceRequestId ~= nil and self.activeMarketplaceRequestStartedAt ~= nil then
+        local elapsedSeconds = getNowSeconds() - self.activeMarketplaceRequestStartedAt
+        if elapsedSeconds >= LEVEL_SELECT_MARKETPLACE_FETCH_TIMEOUT_SECONDS then
+            local timedOutScopeKey = self.activeMarketplaceRequestScopeKey
+            self.activeMarketplaceRequestId = nil
+            self.activeMarketplaceRequestStartedAt = nil
+            if timedOutScopeKey and timedOutScopeKey ~= "" then
+                self.marketplaceNextFetchAtByScope[timedOutScopeKey] = getNowSeconds() + LEVEL_SELECT_MARKETPLACE_CACHE_DURATION_SECONDS
+                self:setMarketplaceState(timedOutScopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_ERROR, LEVEL_SELECT_MARKETPLACE_MESSAGE_FETCH_FAILED)
+            end
+            self.activeMarketplaceRequestScopeKey = nil
+        end
+    end
+
     while true do
         local encodedResponse = self.leaderboardResponseChannel:pop()
         if not encodedResponse then
@@ -748,6 +993,12 @@ function Game:updateLeaderboardFetchState()
             self.activeLevelSelectPreviewRequestStartedAt = nil
             self.activeLevelSelectPreviewRequestMapUuid = nil
             self:applyLevelSelectPreviewFetchResult(decodedResponse, previewMapUuid)
+        elseif type(decodedResponse) == "table" and decodedResponse.kind == "marketplace" and decodedResponse.requestId == self.activeMarketplaceRequestId then
+            local responseScopeKey = self.activeMarketplaceRequestScopeKey
+            self.activeMarketplaceRequestId = nil
+            self.activeMarketplaceRequestStartedAt = nil
+            self.activeMarketplaceRequestScopeKey = nil
+            self:applyMarketplaceFetchResult(decodedResponse, responseScopeKey)
         end
     end
 
@@ -775,6 +1026,35 @@ function Game:updateLeaderboardFetchState()
             self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
         else
             self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+        end
+    end
+
+    if self.screen == "level_select" and self:isLevelSelectMarketplaceMode() then
+        local scopeDetails = self:getMarketplaceScopeDetails()
+        local scopeKey = scopeDetails.scopeKey
+        local onlineConfig = self:getActiveOnlineConfig()
+
+        if not scopeDetails.needsRequest then
+            self:setMarketplaceState(scopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_IDLE, LEVEL_SELECT_MARKETPLACE_MESSAGE_EMPTY_SEARCH)
+            return
+        end
+
+        if not onlineConfig.isConfigured then
+            self:setMarketplaceState(
+                scopeKey,
+                LEVEL_SELECT_MARKETPLACE_STATUS_DISABLED,
+                table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " ")
+            )
+            return
+        end
+
+        if self.activeMarketplaceRequestId == nil
+            and not self:isMarketplaceCacheFresh(scopeKey)
+            and self:isMarketplaceFetchAllowed(scopeKey)
+        then
+            self:beginMarketplaceFetch(onlineConfig, scopeDetails)
+        elseif self:isMarketplaceCacheFresh(scopeKey) then
+            self:setMarketplaceState(scopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_READY, nil)
         end
     end
 end
@@ -893,6 +1173,145 @@ function Game:submitResultsScore()
             or "Score uploaded successfully.",
     }
     self:updateLevelSelectPreviewCacheFromSubmit(response)
+end
+
+function Game:canUploadMapDescriptor(mapDescriptor)
+    return mapDescriptor ~= nil
+        and mapDescriptor.source == "user"
+        and mapDescriptor.isRemoteImport ~= true
+end
+
+function Game:isUploadSelectedMapAvailable(mapDescriptor)
+    return self.levelSelectMode == LEVEL_SELECT_MODE_LIBRARY
+        and self.levelSelectFilter == "user"
+        and self:canUploadMapDescriptor(mapDescriptor or self:getSelectedLevelMap())
+end
+
+function Game:uploadSelectedMap()
+    local selectedMap = self:getSelectedLevelMap()
+    if not self:canUploadMapDescriptor(selectedMap) then
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            "Only your own local user maps can be uploaded."
+        )
+        return
+    end
+
+    local onlineConfig = self:getActiveOnlineConfig()
+    if not onlineConfig.isConfigured then
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " ")
+        )
+        return
+    end
+
+    local mapData, loadError = mapStorage.loadMap(selectedMap)
+    if not mapData or type(mapData.level) ~= "table" then
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            loadError or "The selected map could not be uploaded."
+        )
+        return
+    end
+
+    local response, uploadError = leaderboardClient.uploadMap({
+        mapUuid = mapData.mapUuid or selectedMap.mapUuid,
+        mapName = mapData.name or selectedMap.displayName or selectedMap.name,
+        creatorUuid = self.profile and self.profile.playerId or "",
+        map = deepCopy(mapData.level),
+    }, onlineConfig)
+
+    if uploadError then
+        self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_ERROR, uploadError)
+        return
+    end
+
+    local identifier = type(response) == "table" and tostring(response.internal_identifier or "") or ""
+    local successMessage = identifier ~= ""
+        and string.format("Map uploaded. Code: %s", identifier)
+        or "Map uploaded successfully."
+    self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_SUCCESS, successMessage)
+end
+
+function Game:downloadMarketplaceMap(mapDescriptor)
+    local selectedMap = mapDescriptor or self:getSelectedLevelMap()
+    local sourceEntry = selectedMap and selectedMap.remoteSourceEntry or nil
+    if type(sourceEntry) ~= "table" or type(sourceEntry.map) ~= "table" then
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            "The selected online map could not be downloaded."
+        )
+        return
+    end
+
+    local importedPayload = {
+        version = 1,
+        mapUuid = tostring(sourceEntry.map_uuid or selectedMap.mapUuid or ""),
+        name = tostring(sourceEntry.map_name or selectedMap.displayName or selectedMap.name or "Untitled Map"),
+        previewDescription = selectedMap.previewDescription,
+        level = deepCopy(sourceEntry.map),
+        remoteSource = {
+            creatorUuid = tostring(sourceEntry.creator_uuid or ""),
+            creatorDisplayName = tostring(sourceEntry.creator_display_name or ""),
+            favoriteCount = tonumber(sourceEntry.favorite_count or 0) or 0,
+            internalIdentifier = tostring(sourceEntry.internal_identifier or ""),
+            mapCategory = tostring(sourceEntry.map_category or ""),
+        },
+    }
+
+    if type(importedPayload.level) == "table" then
+        importedPayload.level.id = importedPayload.mapUuid
+        importedPayload.level.mapUuid = importedPayload.mapUuid
+        importedPayload.level.title = importedPayload.level.title or importedPayload.name
+    end
+
+    local importedDescriptor, importError = mapStorage.importMap(importedPayload.name, importedPayload)
+    if not importedDescriptor then
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            importError or "The selected online map could not be saved locally."
+        )
+        return
+    end
+
+    self:refreshMaps()
+    self:setLevelSelectActionState(
+        LEVEL_SELECT_ACTION_STATUS_SUCCESS,
+        string.format("%s was saved to your local maps.", importedDescriptor.displayName or importedDescriptor.name or "Map")
+    )
+end
+
+function Game:refreshMarketplaceData()
+    local scopeDetails = self:getMarketplaceScopeDetails()
+    local scopeKey = scopeDetails.scopeKey
+    self.marketplaceCacheByScope[scopeKey] = nil
+    self.marketplaceNextFetchAtByScope[scopeKey] = 0
+
+    if not scopeDetails.needsRequest then
+        self:setMarketplaceState(scopeKey, LEVEL_SELECT_MARKETPLACE_STATUS_IDLE, LEVEL_SELECT_MARKETPLACE_MESSAGE_EMPTY_SEARCH)
+        self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_INFO, LEVEL_SELECT_MARKETPLACE_MESSAGE_EMPTY_SEARCH)
+        return
+    end
+
+    local onlineConfig = self:getActiveOnlineConfig()
+    if not onlineConfig.isConfigured then
+        self:setMarketplaceState(
+            scopeKey,
+            LEVEL_SELECT_MARKETPLACE_STATUS_DISABLED,
+            table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " ")
+        )
+        self:setLevelSelectActionState(
+            LEVEL_SELECT_ACTION_STATUS_ERROR,
+            table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " ")
+        )
+        return
+    end
+
+    if self.activeMarketplaceRequestId == nil then
+        self:beginMarketplaceFetch(onlineConfig, scopeDetails)
+    end
+    self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_INFO, LEVEL_SELECT_MARKETPLACE_MESSAGE_LOADING)
 end
 
 function Game:refreshLeaderboard()
@@ -1060,9 +1479,19 @@ function Game:getSelectedLevelMap()
     return fallback
 end
 
+function Game:isLevelSelectMarketplaceMode()
+    return self.levelSelectMode == LEVEL_SELECT_MODE_MARKETPLACE
+end
+
+function Game:isLevelSelectMarketplaceSearchActive()
+    return self:isLevelSelectMarketplaceMode()
+        and self.levelSelectMarketplaceTab == LEVEL_SELECT_MARKETPLACE_TAB_SEARCH
+end
+
 function Game:setLevelSelectSelection(mapDescriptor)
     self.levelSelectSelectedId = mapDescriptor and mapDescriptor.id or nil
     self.levelSelectScroll = 0
+    self:clearLevelSelectActionState()
     self:clearLevelSelectLeaderboardFlip()
 end
 
@@ -1074,10 +1503,95 @@ end
 
 function Game:setLevelSelectFilter(filterId)
     self.levelSelectFilter = filterId or "all"
+    self:clearLevelSelectActionState()
     self:getSelectedLevelMap()
     self:resetLevelSelectVisualIndex()
     self.levelSelectScroll = 0
     self:clearLevelSelectLeaderboardFlip()
+end
+
+function Game:setLevelSelectMode(mode)
+    local resolvedMode = mode == LEVEL_SELECT_MODE_MARKETPLACE
+        and LEVEL_SELECT_MODE_MARKETPLACE
+        or LEVEL_SELECT_MODE_LIBRARY
+    if self.levelSelectMode == resolvedMode then
+        return
+    end
+
+    self.levelSelectMode = resolvedMode
+    self.levelSelectHoverId = nil
+    self.levelSelectIssue = nil
+    self:clearLevelSelectActionState()
+    self:clearLevelSelectLeaderboardFlip()
+end
+
+function Game:toggleLevelSelectMode()
+    if self:isLevelSelectMarketplaceMode() then
+        self:setLevelSelectMode(LEVEL_SELECT_MODE_LIBRARY)
+        return
+    end
+
+    self:setLevelSelectMode(LEVEL_SELECT_MODE_MARKETPLACE)
+end
+
+function Game:setLevelSelectMarketplaceTab(tabId)
+    for _, allowedTabId in ipairs(LEVEL_SELECT_MARKETPLACE_TAB_ORDER) do
+        if tabId == allowedTabId then
+            self.levelSelectMarketplaceTab = tabId
+            self.levelSelectHoverId = nil
+            self:clearLevelSelectActionState()
+            self:getSelectedLevelMap()
+            self:resetLevelSelectVisualIndex()
+            self.levelSelectScroll = 0
+            return
+        end
+    end
+end
+
+function Game:cycleLevelSelectMarketplaceTab(direction)
+    local currentIndex = 1
+    for index, tabId in ipairs(LEVEL_SELECT_MARKETPLACE_TAB_ORDER) do
+        if tabId == self.levelSelectMarketplaceTab then
+            currentIndex = index
+            break
+        end
+    end
+
+    local nextIndex = currentIndex + direction
+    if nextIndex < 1 then
+        nextIndex = #LEVEL_SELECT_MARKETPLACE_TAB_ORDER
+    elseif nextIndex > #LEVEL_SELECT_MARKETPLACE_TAB_ORDER then
+        nextIndex = 1
+    end
+
+    self:setLevelSelectMarketplaceTab(LEVEL_SELECT_MARKETPLACE_TAB_ORDER[nextIndex])
+end
+
+function Game:appendLevelSelectMarketplaceSearch(text)
+    if text == "" or not self:isLevelSelectMarketplaceSearchActive() then
+        return
+    end
+
+    local nextValue = self.levelSelectMarketplaceSearchQuery .. text
+    if #nextValue > LEVEL_SELECT_MARKETPLACE_SEARCH_MAX_LENGTH then
+        return
+    end
+
+    self.levelSelectMarketplaceSearchQuery = nextValue
+    self:clearLevelSelectActionState()
+    self:getSelectedLevelMap()
+    self:resetLevelSelectVisualIndex()
+end
+
+function Game:backspaceLevelSelectMarketplaceSearch()
+    if not self:isLevelSelectMarketplaceSearchActive() then
+        return
+    end
+
+    self.levelSelectMarketplaceSearchQuery = trimLastUtf8Character(self.levelSelectMarketplaceSearchQuery)
+    self:clearLevelSelectActionState()
+    self:getSelectedLevelMap()
+    self:resetLevelSelectVisualIndex()
 end
 
 function Game:updateLevelSelectAnimation(dt)
@@ -1181,7 +1695,8 @@ function Game:openMenu()
 
     self.screen = "menu"
     self.levelSelectIssue = nil
-    self.levelSelectFilterHoverId = nil
+    self.levelSelectHoverId = nil
+    self:clearLevelSelectActionState()
     self.resultsSummary = nil
     self.playOverlayMode = nil
     self:refreshMaps()
@@ -1191,7 +1706,11 @@ function Game:openLevelSelect()
     self.screen = "level_select"
     self.levelSelectIssue = nil
     self.levelSelectFilter = "all"
-    self.levelSelectFilterHoverId = nil
+    self.levelSelectHoverId = nil
+    self.levelSelectMode = LEVEL_SELECT_MODE_LIBRARY
+    self.levelSelectMarketplaceTab = LEVEL_SELECT_MARKETPLACE_TAB_TOP
+    self.levelSelectMarketplaceSearchQuery = ""
+    self:clearLevelSelectActionState()
     self:clearLevelSelectLeaderboardFlip()
     self.resultsSummary = nil
     self.playOverlayMode = nil
@@ -1431,6 +1950,41 @@ function Game:keypressed(key)
             self:openEditorMap(self.levelSelectIssue.map)
             return
         end
+        if key == "tab" then
+            self:toggleLevelSelectMode()
+            return
+        end
+        if self:isLevelSelectMarketplaceMode() then
+            if key == "up" then
+                self:cycleLevelSelectMarketplaceTab(-1)
+                return
+            end
+            if key == "down" then
+                self:cycleLevelSelectMarketplaceTab(1)
+                return
+            end
+            if key == "left" then
+                self:moveLevelSelectSelection(-1)
+                return
+            end
+            if key == "right" then
+                self:moveLevelSelectSelection(1)
+                return
+            end
+            if key == "pageup" then
+                self:scrollLevelSelect(-3)
+                return
+            end
+            if key == "pagedown" then
+                self:scrollLevelSelect(3)
+                return
+            end
+            if key == "backspace" then
+                self:backspaceLevelSelectMarketplaceSearch()
+                return
+            end
+            return
+        end
         if key == "left" then
             self:moveLevelSelectSelection(-1)
             return
@@ -1559,6 +2113,8 @@ end
 function Game:textinput(text)
     if self.screen == "profile_setup" then
         self:appendProfileNameInput(text)
+    elseif self.screen == "level_select" then
+        self:appendLevelSelectMarketplaceSearch(text)
     elseif self.screen == "editor" then
         self.editor:textinput(text)
     end
@@ -1617,6 +2173,10 @@ function Game:mousepressed(x, y, button)
 
         if hit.kind == "back" then
             self:openMenu()
+        elseif hit.kind == "toggle_mode" then
+            self:toggleLevelSelectMode()
+        elseif hit.kind == "set_marketplace_tab" then
+            self:setLevelSelectMarketplaceTab(hit.tab)
         elseif hit.kind == "set_filter" then
             self:setLevelSelectFilter(hit.filter)
         elseif hit.kind == "issue_edit" then
@@ -1627,6 +2187,14 @@ function Game:mousepressed(x, y, button)
             return
         elseif hit.kind == "select_map" then
             self:setLevelSelectSelection(hit.map)
+        elseif hit.kind == "download_map" then
+            self:setLevelSelectSelection(hit.map)
+            self:downloadMarketplaceMap(hit.map)
+        elseif hit.kind == "refresh_marketplace" then
+            self:refreshMarketplaceData()
+        elseif hit.kind == "upload_map" then
+            self:setLevelSelectSelection(hit.map)
+            self:uploadSelectedMap()
         elseif hit.kind == "toggle_leaderboard_card" then
             self:toggleLevelSelectLeaderboardFlip(hit.map)
         elseif hit.kind == "open_map" then
@@ -1699,7 +2267,7 @@ function Game:mousemoved(x, y)
 
     if self.screen == "level_select" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
-        self.levelSelectFilterHoverId = ui.getLevelSelectFilterHoverId(self, viewportX, viewportY)
+        self.levelSelectHoverId = ui.getLevelSelectHoverId(self, viewportX, viewportY)
         return
     end
 

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -71,6 +71,7 @@ function Game.new()
     self.editor = mapEditor.new(self.viewport.w, self.viewport.h, nil)
     self.availableMaps = {}
     self.currentMapDescriptor = nil
+    self.currentRunOrigin = nil
     self.levelSelectIssue = nil
     self.levelSelectSelectedId = nil
     self.levelSelectFilter = "all"
@@ -285,15 +286,17 @@ function Game:showMapIssue(mapDescriptor, mapData, fallbackError)
     }
 end
 
-function Game:startMap(mapDescriptor)
+function Game:startMap(mapDescriptor, options)
     local mapData, loadError = mapStorage.loadMap(mapDescriptor)
     if not mapData or not mapData.level then
         return false, loadError or "That map does not contain playable level data.", mapData
     end
 
+    local startOptions = options or {}
     self.levelComplete = false
     self.failureReason = nil
     self.currentMapDescriptor = mapDescriptor
+    self.currentRunOrigin = startOptions.origin
     self.levelSelectIssue = nil
     self.resultsSummary = nil
     self.playOverlayMode = nil
@@ -302,12 +305,35 @@ function Game:startMap(mapDescriptor)
     return true
 end
 
+function Game:processEditorPlaytestRequest()
+    local descriptor = self.editor:consumePlaytestRequest()
+    if not descriptor then
+        return
+    end
+
+    local ok, startError = self:startMap(descriptor, { origin = "editor" })
+    if not ok then
+        self.screen = "editor"
+        self.editor:showStatus(startError or "The saved map could not be started.")
+    end
+end
+
+function Game:navigateBackFromRun()
+    if self.currentRunOrigin == "editor" and self.currentMapDescriptor then
+        if self:openEditorMap(self.currentMapDescriptor) then
+            return
+        end
+    end
+
+    self:openMenu()
+end
+
 function Game:restart()
     if not self.currentMapDescriptor then
         return
     end
 
-    self:startMap(self.currentMapDescriptor)
+    self:startMap(self.currentMapDescriptor, { origin = self.currentRunOrigin })
 end
 
 function Game:isRunLocked()
@@ -333,6 +359,7 @@ function Game:update(dt)
 
     if self.screen == "editor" then
         self.editor:update(dt)
+        self:processEditorPlaytestRequest()
         return
     end
 
@@ -391,6 +418,8 @@ function Game:keypressed(key)
             if not self.editor:keypressed(key) then
                 self:openMenu()
             end
+        elseif self.screen == "play" or self.screen == "results" then
+            self:navigateBackFromRun()
         else
             self:openMenu()
         end
@@ -471,7 +500,7 @@ function Game:keypressed(key)
 
     if self.screen == "results" then
         if key == "m" then
-            self:openMenu()
+            self:navigateBackFromRun()
             return
         end
         if (key == "e" or key == "tab") and self.currentMapDescriptor then
@@ -507,7 +536,7 @@ function Game:keypressed(key)
     end
 
     if key == "m" then
-        self:openMenu()
+        self:navigateBackFromRun()
         return
     end
 
@@ -615,7 +644,7 @@ function Game:mousepressed(x, y, button)
     end
 
     if ui.getPlayBackHit(self, viewportX, viewportY) then
-        self:openMenu()
+        self:navigateBackFromRun()
         return
     end
 

--- a/src/game/json.lua
+++ b/src/game/json.lua
@@ -1,0 +1,316 @@
+local json = {}
+
+local function isArray(value)
+    if type(value) ~= "table" then
+        return false
+    end
+
+    local count = 0
+    local maxIndex = 0
+    for key, _ in pairs(value) do
+        if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then
+            return false
+        end
+        count = count + 1
+        if key > maxIndex then
+            maxIndex = key
+        end
+    end
+
+    return count == maxIndex
+end
+
+local ESCAPE_MAP = {
+    ['\\'] = '\\\\',
+    ['"'] = '\\"',
+    ['\b'] = '\\b',
+    ['\f'] = '\\f',
+    ['\n'] = '\\n',
+    ['\r'] = '\\r',
+    ['\t'] = '\\t',
+}
+
+local function encodeString(value)
+    return '"' .. value:gsub('[%z\1-\31\\"]', function(character)
+        return ESCAPE_MAP[character] or string.format("\\u%04x", character:byte())
+    end) .. '"'
+end
+
+local function encodeValue(value)
+    local valueType = type(value)
+
+    if valueType == "nil" then
+        return "null"
+    end
+    if valueType == "boolean" then
+        return value and "true" or "false"
+    end
+    if valueType == "number" then
+        if value ~= value or value == math.huge or value == -math.huge then
+            error("Cannot encode non-finite number to JSON")
+        end
+        return tostring(value)
+    end
+    if valueType == "string" then
+        return encodeString(value)
+    end
+    if valueType ~= "table" then
+        error("Unsupported JSON value type: " .. valueType)
+    end
+
+    if isArray(value) then
+        local items = {}
+        for index = 1, #value do
+            items[index] = encodeValue(value[index])
+        end
+        return "[" .. table.concat(items, ",") .. "]"
+    end
+
+    local items = {}
+    for key, entry in pairs(value) do
+        if type(key) ~= "string" then
+            error("JSON object keys must be strings")
+        end
+        items[#items + 1] = encodeString(key) .. ":" .. encodeValue(entry)
+    end
+    table.sort(items)
+    return "{" .. table.concat(items, ",") .. "}"
+end
+
+local function decodeError(index, message)
+    return nil, string.format("JSON decode error at character %d: %s", index, message)
+end
+
+local function codepointToUtf8(codepoint)
+    if codepoint <= 0x7F then
+        return string.char(codepoint)
+    end
+    if codepoint <= 0x7FF then
+        local byte1 = 0xC0 + math.floor(codepoint / 0x40)
+        local byte2 = 0x80 + (codepoint % 0x40)
+        return string.char(byte1, byte2)
+    end
+    if codepoint <= 0xFFFF then
+        local byte1 = 0xE0 + math.floor(codepoint / 0x1000)
+        local byte2 = 0x80 + (math.floor(codepoint / 0x40) % 0x40)
+        local byte3 = 0x80 + (codepoint % 0x40)
+        return string.char(byte1, byte2, byte3)
+    end
+
+    local byte1 = 0xF0 + math.floor(codepoint / 0x40000)
+    local byte2 = 0x80 + (math.floor(codepoint / 0x1000) % 0x40)
+    local byte3 = 0x80 + (math.floor(codepoint / 0x40) % 0x40)
+    local byte4 = 0x80 + (codepoint % 0x40)
+    return string.char(byte1, byte2, byte3, byte4)
+end
+
+local function skipWhitespace(text, index)
+    while true do
+        local character = text:sub(index, index)
+        if character == " " or character == "\t" or character == "\r" or character == "\n" then
+            index = index + 1
+        else
+            break
+        end
+    end
+    return index
+end
+
+local parseValue
+
+local function parseString(text, index)
+    index = index + 1
+    local parts = {}
+
+    while index <= #text do
+        local character = text:sub(index, index)
+        if character == '"' then
+            return table.concat(parts), index + 1
+        end
+
+        if character == "\\" then
+            local escape = text:sub(index + 1, index + 1)
+            if escape == '"' or escape == "\\" or escape == "/" then
+                parts[#parts + 1] = escape
+                index = index + 2
+            elseif escape == "b" then
+                parts[#parts + 1] = "\b"
+                index = index + 2
+            elseif escape == "f" then
+                parts[#parts + 1] = "\f"
+                index = index + 2
+            elseif escape == "n" then
+                parts[#parts + 1] = "\n"
+                index = index + 2
+            elseif escape == "r" then
+                parts[#parts + 1] = "\r"
+                index = index + 2
+            elseif escape == "t" then
+                parts[#parts + 1] = "\t"
+                index = index + 2
+            elseif escape == "u" then
+                local hex = text:sub(index + 2, index + 5)
+                if #hex < 4 or not hex:match("^[0-9a-fA-F]+$") then
+                    return decodeError(index, "invalid unicode escape")
+                end
+                parts[#parts + 1] = codepointToUtf8(tonumber(hex, 16))
+                index = index + 6
+            else
+                return decodeError(index, "invalid escape character")
+            end
+        else
+            parts[#parts + 1] = character
+            index = index + 1
+        end
+    end
+
+    return decodeError(index, "unterminated string")
+end
+
+local function parseNumber(text, index)
+    local startIndex = index
+    local token = text:match("^-?%d+%.?%d*[eE]?[+-]?%d*", index)
+    if not token or token == "" then
+        return decodeError(index, "invalid number")
+    end
+
+    local number = tonumber(token)
+    if not number then
+        return decodeError(index, "invalid number")
+    end
+
+    return number, startIndex + #token
+end
+
+local function parseLiteral(text, index, literal, value)
+    if text:sub(index, index + #literal - 1) ~= literal then
+        return decodeError(index, "invalid literal")
+    end
+    return value, index + #literal
+end
+
+local function parseArray(text, index)
+    index = index + 1
+    local result = {}
+    index = skipWhitespace(text, index)
+    if text:sub(index, index) == "]" then
+        return result, index + 1
+    end
+
+    while index <= #text do
+        local value, nextIndex = parseValue(text, index)
+        if nextIndex == nil then
+            return value, nextIndex
+        end
+        result[#result + 1] = value
+        index = skipWhitespace(text, nextIndex)
+        local character = text:sub(index, index)
+        if character == "]" then
+            return result, index + 1
+        end
+        if character ~= "," then
+            return decodeError(index, "expected ',' or ']' in array")
+        end
+        index = skipWhitespace(text, index + 1)
+    end
+
+    return decodeError(index, "unterminated array")
+end
+
+local function parseObject(text, index)
+    index = index + 1
+    local result = {}
+    index = skipWhitespace(text, index)
+    if text:sub(index, index) == "}" then
+        return result, index + 1
+    end
+
+    while index <= #text do
+        if text:sub(index, index) ~= '"' then
+            return decodeError(index, "expected string key")
+        end
+
+        local key, nextIndex = parseString(text, index)
+        if nextIndex == nil then
+            return key, nextIndex
+        end
+
+        index = skipWhitespace(text, nextIndex)
+        if text:sub(index, index) ~= ":" then
+            return decodeError(index, "expected ':' after key")
+        end
+
+        local value
+        value, nextIndex = parseValue(text, skipWhitespace(text, index + 1))
+        if nextIndex == nil then
+            return value, nextIndex
+        end
+        result[key] = value
+        index = skipWhitespace(text, nextIndex)
+
+        local character = text:sub(index, index)
+        if character == "}" then
+            return result, index + 1
+        end
+        if character ~= "," then
+            return decodeError(index, "expected ',' or '}' in object")
+        end
+        index = skipWhitespace(text, index + 1)
+    end
+
+    return decodeError(index, "unterminated object")
+end
+
+parseValue = function(text, index)
+    index = skipWhitespace(text, index)
+    local character = text:sub(index, index)
+
+    if character == '"' then
+        return parseString(text, index)
+    end
+    if character == "{" then
+        return parseObject(text, index)
+    end
+    if character == "[" then
+        return parseArray(text, index)
+    end
+    if character == "-" or character:match("%d") then
+        return parseNumber(text, index)
+    end
+    if character == "t" then
+        return parseLiteral(text, index, "true", true)
+    end
+    if character == "f" then
+        return parseLiteral(text, index, "false", false)
+    end
+    if character == "n" then
+        return parseLiteral(text, index, "null", nil)
+    end
+
+    return decodeError(index, "unexpected character")
+end
+
+function json.encode(value)
+    return encodeValue(value)
+end
+
+function json.decode(text)
+    if type(text) ~= "string" then
+        return nil, "JSON decode expects a string"
+    end
+
+    local value, index = parseValue(text, 1)
+    if index == nil then
+        return value, index
+    end
+
+    index = skipWhitespace(text, index)
+    if index <= #text then
+        return decodeError(index, "trailing characters")
+    end
+
+    return value
+end
+
+return json
+

--- a/src/game/leaderboard_client.lua
+++ b/src/game/leaderboard_client.lua
@@ -1,40 +1,52 @@
 local envLoader = require("src.game.env_loader")
 local json = require("src.game.json")
 
-local simpleboardsClient = {}
+local leaderboardClient = {}
 
-local SCRIPT_FILE = "simpleboards_request.ps1"
-local REQUEST_FILE = "simpleboards_request.json"
+local SCRIPT_FILE = "leaderboard_request.ps1"
+local REQUEST_FILE = "leaderboard_request.json"
+local REQUEST_MODE_SUBMIT = "submit"
 
 local POWERSHELL_SCRIPT = [[
 param(
     [string]$Mode,
     [string]$ApiKey,
-    [string]$LeaderboardId,
+    [string]$ApiBaseUrl,
+    [string]$EndpointPath,
     [string]$BodyPath
 )
 
 $ErrorActionPreference = 'Stop'
 $headers = @{ 'x-api-key' = $ApiKey }
+$uri = $ApiBaseUrl.TrimEnd('/') + $EndpointPath
 
 try {
     if ($Mode -eq 'submit') {
         $body = Get-Content -Raw -Path $BodyPath
-        $result = Invoke-RestMethod -Method Post -Uri 'https://api.simpleboards.dev/api/entries' -Headers $headers -ContentType 'application/json' -Body $body
-    }
-    elseif ($Mode -eq 'fetch') {
-        $uri = ('https://api.simpleboards.dev/api/leaderboards/{0}/entries' -f $LeaderboardId)
-        $result = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+        $response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri $uri -Headers $headers -ContentType 'application/json' -Body $body
     }
     else {
         throw ('Unsupported mode: ' + $Mode)
     }
 
-    @{ ok = $true; data = $result } | ConvertTo-Json -Depth 12 -Compress
+    $data = $null
+    if ($response.Content -and $response.Content.Trim().Length -gt 0) {
+        $data = $response.Content | ConvertFrom-Json
+    }
+
+    @{ ok = $true; status = [int]$response.StatusCode; data = $data } | ConvertTo-Json -Depth 12 -Compress
 }
 catch {
     $detail = ''
+    $statusCode = $null
     if ($_.Exception.Response) {
+        try {
+            $statusCode = [int]$_.Exception.Response.StatusCode
+        }
+        catch {
+            $statusCode = $null
+        }
+
         try {
             $stream = $_.Exception.Response.GetResponseStream()
             if ($stream) {
@@ -49,10 +61,10 @@ catch {
 
     $message = $_.Exception.Message
     if ($detail -and $detail.Trim().Length -gt 0) {
-        $message = $message + ' | ' + $detail.Trim()
+        $message = $detail.Trim()
     }
 
-    @{ ok = $false; error = $message } | ConvertTo-Json -Depth 6 -Compress
+    @{ ok = $false; status = $statusCode; error = $message } | ConvertTo-Json -Depth 8 -Compress
     exit 1
 }
 ]]
@@ -71,10 +83,15 @@ local function quoteArgument(value)
 end
 
 local function ensurePowerShellScript()
-    if not love.filesystem.getInfo(SCRIPT_FILE, "file") then
+    local existingScript = nil
+    if love.filesystem.getInfo(SCRIPT_FILE, "file") then
+        existingScript = love.filesystem.read(SCRIPT_FILE)
+    end
+
+    if existingScript ~= POWERSHELL_SCRIPT then
         local ok, writeError = love.filesystem.write(SCRIPT_FILE, POWERSHELL_SCRIPT)
         if not ok then
-            return nil, writeError or "The SimpleBoards helper script could not be written."
+            return nil, writeError or "The leaderboard helper script could not be written."
         end
     end
 
@@ -92,18 +109,21 @@ local function runCommand(command)
     return output
 end
 
-local function normalizeRemoteErrorMessage(message)
-    local text = tostring(message or "")
-    local lowerText = string.lower(text)
-
-    if lowerText:find("key not found", 1, true) then
-        return "SimpleBoards could not find this key. Check whether API_KEY and LEADERBOARD_ID are correct and belong to the same leaderboard."
+local function extractJsonError(message)
+    local decoded = json.decode(tostring(message or ""))
+    if type(decoded) == "table" and type(decoded.error) == "string" and decoded.error ~= "" then
+        return decoded.error
     end
 
+    return tostring(message or "")
+end
+
+local function normalizeRemoteErrorMessage(message)
+    local text = extractJsonError(message)
     return text ~= "" and text or "The online request failed."
 end
 
-local function runPowerShell(mode, config, payload)
+local function runPowerShell(mode, config, endpointPath, payload)
     if not isWindows() then
         return nil, "Online score sync currently requires Windows PowerShell."
     end
@@ -113,14 +133,10 @@ local function runPowerShell(mode, config, payload)
         return nil, scriptError
     end
 
-    local requestPath
-    if payload ~= nil then
-        local requestBody = json.encode(payload)
-        local ok, writeError = love.filesystem.write(REQUEST_FILE, requestBody)
-        if not ok then
-            return nil, writeError or "The score payload could not be written."
-        end
-        requestPath = absoluteSavePath(REQUEST_FILE)
+    local requestBody = json.encode(payload)
+    local ok, writeError = love.filesystem.write(REQUEST_FILE, requestBody)
+    if not ok then
+        return nil, writeError or "The score payload could not be written."
     end
 
     local command = table.concat({
@@ -130,10 +146,12 @@ local function runPowerShell(mode, config, payload)
         quoteArgument(mode),
         "-ApiKey",
         quoteArgument(config.apiKey),
-        "-LeaderboardId",
-        quoteArgument(config.leaderboardId),
+        "-ApiBaseUrl",
+        quoteArgument(config.apiBaseUrl),
+        "-EndpointPath",
+        quoteArgument(endpointPath),
         "-BodyPath",
-        quoteArgument(requestPath or ""),
+        quoteArgument(absoluteSavePath(REQUEST_FILE)),
     }, " ")
 
     local output, runError = runCommand(command)
@@ -150,56 +168,40 @@ local function runPowerShell(mode, config, payload)
         return nil, normalizeRemoteErrorMessage(response.error)
     end
 
-    return response.data
+    return response.data, nil, response.status
 end
 
 local function normalizeConfig(config)
     local resolvedConfig = config or envLoader.load()
     if not resolvedConfig.isConfigured then
-        return nil, table.concat(resolvedConfig.errors or { "SimpleBoards is not configured." }, " ")
+        return nil, table.concat(resolvedConfig.errors or { "The online leaderboard is not configured." }, " ")
     end
     return resolvedConfig
 end
 
-function simpleboardsClient.getConfig()
+function leaderboardClient.getConfig()
     return envLoader.load()
 end
 
-function simpleboardsClient.submitScore(submission, config)
+function leaderboardClient.submitScore(submission, config)
     local resolvedConfig, configError = normalizeConfig(config)
     if not resolvedConfig then
         return nil, configError
     end
 
+    local mapUuid = tostring(submission.mapUuid or "")
+    if mapUuid == "" then
+        return nil, "The score could not be uploaded because the map UUID is missing."
+    end
+
+    local endpointPath = string.format("/api/maps/%s/score", mapUuid)
     local payload = {
-        leaderboardId = resolvedConfig.leaderboardId,
-        playerId = submission.playerId,
-        playerDisplayName = submission.playerDisplayName,
-        score = tostring(submission.score or "0"),
-        metadata = submission.metadata or "",
+        player_uuid = tostring(submission.playerUuid or ""),
+        display_name = tostring(submission.playerDisplayName or ""),
+        score = tonumber(submission.score or 0) or 0,
     }
 
-    return runPowerShell("submit", resolvedConfig, payload)
+    return runPowerShell(REQUEST_MODE_SUBMIT, resolvedConfig, endpointPath, payload)
 end
 
-function simpleboardsClient.fetchLeaderboard(config)
-    local resolvedConfig, configError = normalizeConfig(config)
-    if not resolvedConfig then
-        return nil, configError
-    end
-
-    local response, fetchError = runPowerShell("fetch", resolvedConfig)
-    if not response then
-        return nil, fetchError or "The leaderboard could not be loaded."
-    end
-
-    if type(response) == "table" and type(response.entries) == "table" then
-        return response.entries
-    end
-
-    return response
-end
-
-return simpleboardsClient
-
-
+return leaderboardClient

--- a/src/game/leaderboard_client.lua
+++ b/src/game/leaderboard_client.lua
@@ -6,6 +6,7 @@ local leaderboardClient = {}
 local SCRIPT_FILE = "leaderboard_request.ps1"
 local REQUEST_FILE = "leaderboard_request.json"
 local REQUEST_MODE_SUBMIT = "submit"
+local REQUEST_MODE_UPLOAD_MAP = "upload_map"
 
 local POWERSHELL_SCRIPT = [[
 param(
@@ -13,7 +14,8 @@ param(
     [string]$ApiKey,
     [string]$ApiBaseUrl,
     [string]$EndpointPath,
-    [string]$BodyPath
+    [string]$BodyPath,
+    [string]$HmacSecret
 )
 
 $ErrorActionPreference = 'Stop'
@@ -21,8 +23,20 @@ $headers = @{ 'x-api-key' = $ApiKey }
 $uri = $ApiBaseUrl.TrimEnd('/') + $EndpointPath
 
 try {
-    if ($Mode -eq 'submit') {
+    if ($Mode -eq 'submit' -or $Mode -eq 'upload_map') {
         $body = Get-Content -Raw -Path $BodyPath
+        if ($HmacSecret -and $HmacSecret.Trim().Length -gt 0) {
+            $encoding = [System.Text.Encoding]::UTF8
+            $hmac = [System.Security.Cryptography.HMACSHA256]::new($encoding.GetBytes($HmacSecret))
+            try {
+                $signatureBytes = $hmac.ComputeHash($encoding.GetBytes($body))
+            }
+            finally {
+                $hmac.Dispose()
+            }
+            $signature = [System.BitConverter]::ToString($signatureBytes).Replace('-', '').ToLowerInvariant()
+            $headers['x-signature'] = 'sha256=' + $signature
+        }
         $response = Invoke-WebRequest -UseBasicParsing -Method Post -Uri $uri -Headers $headers -ContentType 'application/json' -Body $body
     }
     else {
@@ -152,6 +166,8 @@ local function runPowerShell(mode, config, endpointPath, payload)
         quoteArgument(endpointPath),
         "-BodyPath",
         quoteArgument(absoluteSavePath(REQUEST_FILE)),
+        "-HmacSecret",
+        quoteArgument(config.hmacSecret),
     }, " ")
 
     local output, runError = runCommand(command)
@@ -202,6 +218,41 @@ function leaderboardClient.submitScore(submission, config)
     }
 
     return runPowerShell(REQUEST_MODE_SUBMIT, resolvedConfig, endpointPath, payload)
+end
+
+function leaderboardClient.uploadMap(submission, config)
+    local resolvedConfig, configError = normalizeConfig(config)
+    if not resolvedConfig then
+        return nil, configError
+    end
+
+    local mapUuid = tostring(submission.mapUuid or "")
+    if mapUuid == "" then
+        return nil, "The map could not be uploaded because the map UUID is missing."
+    end
+
+    local creatorUuid = tostring(submission.creatorUuid or "")
+    if creatorUuid == "" then
+        return nil, "The map could not be uploaded because the creator UUID is missing."
+    end
+
+    local mapName = tostring(submission.mapName or ""):gsub("^%s+", ""):gsub("%s+$", "")
+    if mapName == "" then
+        mapName = "Untitled Map"
+    end
+
+    if type(submission.map) ~= "table" then
+        return nil, "The map could not be uploaded because its level data is missing."
+    end
+
+    local payload = {
+        map_uuid = mapUuid,
+        map_name = mapName,
+        creator_uuid = creatorUuid,
+        map = submission.map,
+    }
+
+    return runPowerShell(REQUEST_MODE_UPLOAD_MAP, resolvedConfig, "/api/maps", payload)
 end
 
 return leaderboardClient

--- a/src/game/leaderboard_fetch_thread.lua
+++ b/src/game/leaderboard_fetch_thread.lua
@@ -3,9 +3,12 @@ local json = require("src.game.json")
 local REQUEST_CHANNEL_NAME = "signal_leaderboard_request"
 local RESPONSE_CHANNEL_NAME = "signal_leaderboard_response"
 local REQUEST_KIND_FETCH = "fetch"
+local REQUEST_KIND_PREVIEW = "preview"
 local CURL_STATUS_PREFIX = "__STATUS__"
 local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
 local DEFAULT_LEADERBOARD_LIMIT = 50
+local DEFAULT_PREVIEW_LIMIT = 5
+local DEFAULT_REQUEST_TIMEOUT_SECONDS = 5
 
 local requestChannel = love.thread.getChannel(REQUEST_CHANNEL_NAME)
 local responseChannel = love.thread.getChannel(RESPONSE_CHANNEL_NAME)
@@ -36,24 +39,38 @@ local function splitCurlOutput(output)
     return tonumber(statusCode), body, nil
 end
 
-local function buildLeaderboardUri(config)
-    local baseUrl = tostring(config.apiBaseUrl or DEFAULT_API_BASE_URL):gsub("/+$", "")
-    local limit = tonumber(config.limit) or DEFAULT_LEADERBOARD_LIMIT
-    local mapUuid = tostring(config.mapUuid or "")
-
-    if mapUuid ~= "" then
-        return string.format("%s/api/maps/%s/leaderboard?limit=%d", baseUrl, mapUuid, limit)
-    end
-
-    return string.format("%s/api/leaderboard?limit=%d", baseUrl, limit)
+local function normalizeBaseUrl(baseUrl)
+    return tostring(baseUrl or DEFAULT_API_BASE_URL):gsub("/+$", "")
 end
 
-local function fetchLeaderboardEntries(config)
-    local uri = buildLeaderboardUri(config)
-    local header = string.format("x-api-key: %s", tostring(config.apiKey or ""))
+local function buildLeaderboardUri(baseUrl, mapUuid, limit)
+    local resolvedBaseUrl = normalizeBaseUrl(baseUrl)
+    local resolvedLimit = tonumber(limit) or DEFAULT_LEADERBOARD_LIMIT
+    local resolvedMapUuid = tostring(mapUuid or "")
+
+    if resolvedMapUuid ~= "" then
+        return string.format("%s/api/maps/%s/leaderboard?limit=%d", resolvedBaseUrl, resolvedMapUuid, resolvedLimit)
+    end
+
+    return string.format("%s/api/leaderboard?limit=%d", resolvedBaseUrl, resolvedLimit)
+end
+
+local function buildMapAroundUri(baseUrl, mapUuid, playerUuid)
+    return string.format(
+        "%s/api/maps/%s/leaderboard/around/%s",
+        normalizeBaseUrl(baseUrl),
+        tostring(mapUuid or ""),
+        tostring(playerUuid or "")
+    )
+end
+
+local function fetchJson(uri, apiKey)
+    local header = string.format("x-api-key: %s", tostring(apiKey or ""))
     local command = table.concat({
         "curl.exe",
         "-sS",
+        "--max-time",
+        tostring(DEFAULT_REQUEST_TIMEOUT_SECONDS),
         quoteArgument(uri),
         "-H",
         quoteArgument(header),
@@ -72,15 +89,78 @@ local function fetchLeaderboardEntries(config)
     end
 
     if statusCode ~= 200 then
-        return nil, (body and body ~= "") and body or string.format("Leaderboard request failed with status %d.", statusCode)
+        return nil, (body and body ~= "") and body or string.format("Leaderboard request failed with status %d.", statusCode), statusCode
     end
 
-    local decodedEntries = json.decode(body)
-    if type(decodedEntries) ~= "table" then
+    local decodedPayload = json.decode(body)
+    if type(decodedPayload) ~= "table" then
         return nil, "Leaderboard response was not valid JSON."
     end
 
-    return decodedEntries
+    return decodedPayload, nil, statusCode
+end
+
+local function fetchLeaderboardEntries(config)
+    local uri = buildLeaderboardUri(config.apiBaseUrl, config.mapUuid, config.limit)
+    return fetchJson(uri, config.apiKey)
+end
+
+local function extractPlayerPreviewEntry(aroundPayload, playerUuid)
+    local entries = type(aroundPayload) == "table" and aroundPayload.entries or nil
+    if type(entries) ~= "table" then
+        return nil
+    end
+
+    local resolvedPlayerUuid = tostring(playerUuid or "")
+    for _, entry in ipairs(entries) do
+        if tostring(entry.player_uuid or entry.playerUuid or "") == resolvedPlayerUuid then
+            return entry
+        end
+    end
+
+    return entries[1]
+end
+
+local function fetchLeaderboardPreview(config)
+    local mapUuid = tostring(config.mapUuid or "")
+    if mapUuid == "" then
+        return nil, "Leaderboard preview could not be loaded because the map UUID is missing."
+    end
+
+    local topPayload, topError = fetchJson(
+        buildLeaderboardUri(config.apiBaseUrl, mapUuid, tonumber(config.limit) or DEFAULT_PREVIEW_LIMIT),
+        config.apiKey
+    )
+    if not topPayload then
+        return nil, topError
+    end
+
+    local previewPayload = {
+        map_uuid = mapUuid,
+        top_entries = type(topPayload.entries) == "table" and topPayload.entries or {},
+        player_entry = nil,
+        target_rank = nil,
+    }
+
+    local playerUuid = tostring(config.playerUuid or "")
+    if playerUuid == "" then
+        return previewPayload
+    end
+
+    local aroundPayload, aroundError, aroundStatus = fetchJson(
+        buildMapAroundUri(config.apiBaseUrl, mapUuid, playerUuid),
+        config.apiKey
+    )
+    if not aroundPayload then
+        if aroundStatus == 404 then
+            return previewPayload
+        end
+        return nil, aroundError
+    end
+
+    previewPayload.player_entry = extractPlayerPreviewEntry(aroundPayload, playerUuid)
+    previewPayload.target_rank = tonumber(aroundPayload.target_rank) or nil
+    return previewPayload
 end
 
 while true do
@@ -90,6 +170,16 @@ while true do
     if type(request) == "table" and request.kind == REQUEST_KIND_FETCH then
         local payload, fetchError = fetchLeaderboardEntries(request.config or {})
         responseChannel:push(json.encode({
+            kind = REQUEST_KIND_FETCH,
+            requestId = request.requestId,
+            ok = payload ~= nil,
+            payload = payload,
+            error = fetchError,
+        }))
+    elseif type(request) == "table" and request.kind == REQUEST_KIND_PREVIEW then
+        local payload, fetchError = fetchLeaderboardPreview(request.config or {})
+        responseChannel:push(json.encode({
+            kind = REQUEST_KIND_PREVIEW,
             requestId = request.requestId,
             ok = payload ~= nil,
             payload = payload,

--- a/src/game/leaderboard_fetch_thread.lua
+++ b/src/game/leaderboard_fetch_thread.lua
@@ -1,0 +1,99 @@
+local json = require("src.game.json")
+
+local REQUEST_CHANNEL_NAME = "signal_leaderboard_request"
+local RESPONSE_CHANNEL_NAME = "signal_leaderboard_response"
+local REQUEST_KIND_FETCH = "fetch"
+local CURL_STATUS_PREFIX = "__STATUS__"
+local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
+local DEFAULT_LEADERBOARD_LIMIT = 50
+
+local requestChannel = love.thread.getChannel(REQUEST_CHANNEL_NAME)
+local responseChannel = love.thread.getChannel(RESPONSE_CHANNEL_NAME)
+
+local function quoteArgument(value)
+    return '"' .. tostring(value or ""):gsub('"', '\\"') .. '"'
+end
+
+local function runCommand(command)
+    local handle = io.popen(command .. " 2>&1")
+    if not handle then
+        return nil
+    end
+
+    local output = handle:read("*a") or ""
+    handle:close()
+    return output
+end
+
+local function splitCurlOutput(output)
+    local text = tostring(output or "")
+    local statusLineStart, statusLineEnd, statusCode = text:find("\r?\n" .. CURL_STATUS_PREFIX .. "(%d%d%d)%s*$")
+    if not statusCode then
+        return nil, nil, text
+    end
+
+    local body = text:sub(1, statusLineStart - 1)
+    return tonumber(statusCode), body, nil
+end
+
+local function buildLeaderboardUri(config)
+    local baseUrl = tostring(config.apiBaseUrl or DEFAULT_API_BASE_URL):gsub("/+$", "")
+    local limit = tonumber(config.limit) or DEFAULT_LEADERBOARD_LIMIT
+    local mapUuid = tostring(config.mapUuid or "")
+
+    if mapUuid ~= "" then
+        return string.format("%s/api/maps/%s/leaderboard?limit=%d", baseUrl, mapUuid, limit)
+    end
+
+    return string.format("%s/api/leaderboard?limit=%d", baseUrl, limit)
+end
+
+local function fetchLeaderboardEntries(config)
+    local uri = buildLeaderboardUri(config)
+    local header = string.format("x-api-key: %s", tostring(config.apiKey or ""))
+    local command = table.concat({
+        "curl.exe",
+        "-sS",
+        quoteArgument(uri),
+        "-H",
+        quoteArgument(header),
+        "-w",
+        quoteArgument("\\n" .. CURL_STATUS_PREFIX .. "%{http_code}"),
+    }, " ")
+
+    local output = runCommand(command)
+    if not output then
+        return nil, "Leaderboard request could not be started."
+    end
+
+    local statusCode, body, splitError = splitCurlOutput(output)
+    if not statusCode then
+        return nil, splitError or "Leaderboard response could not be parsed."
+    end
+
+    if statusCode ~= 200 then
+        return nil, (body and body ~= "") and body or string.format("Leaderboard request failed with status %d.", statusCode)
+    end
+
+    local decodedEntries = json.decode(body)
+    if type(decodedEntries) ~= "table" then
+        return nil, "Leaderboard response was not valid JSON."
+    end
+
+    return decodedEntries
+end
+
+while true do
+    local encodedRequest = requestChannel:demand()
+    local request = json.decode(encodedRequest)
+
+    if type(request) == "table" and request.kind == REQUEST_KIND_FETCH then
+        local payload, fetchError = fetchLeaderboardEntries(request.config or {})
+        responseChannel:push(json.encode({
+            requestId = request.requestId,
+            ok = payload ~= nil,
+            payload = payload,
+            error = fetchError,
+        }))
+    end
+end

--- a/src/game/leaderboard_fetch_thread.lua
+++ b/src/game/leaderboard_fetch_thread.lua
@@ -4,11 +4,15 @@ local REQUEST_CHANNEL_NAME = "signal_leaderboard_request"
 local RESPONSE_CHANNEL_NAME = "signal_leaderboard_response"
 local REQUEST_KIND_FETCH = "fetch"
 local REQUEST_KIND_PREVIEW = "preview"
+local REQUEST_KIND_MARKETPLACE = "marketplace"
 local CURL_STATUS_PREFIX = "__STATUS__"
 local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
 local DEFAULT_LEADERBOARD_LIMIT = 50
 local DEFAULT_PREVIEW_LIMIT = 5
+local DEFAULT_MARKETPLACE_LIMIT = 10
 local DEFAULT_REQUEST_TIMEOUT_SECONDS = 5
+local MARKETPLACE_MODE_FAVORITES = "favorites"
+local MARKETPLACE_MODE_SEARCH = "search"
 
 local requestChannel = love.thread.getChannel(REQUEST_CHANNEL_NAME)
 local responseChannel = love.thread.getChannel(RESPONSE_CHANNEL_NAME)
@@ -43,6 +47,13 @@ local function normalizeBaseUrl(baseUrl)
     return tostring(baseUrl or DEFAULT_API_BASE_URL):gsub("/+$", "")
 end
 
+local function urlEncode(value)
+    local text = tostring(value or "")
+    return (text:gsub("([^%w%-_%.~])", function(character)
+        return string.format("%%%02X", character:byte())
+    end))
+end
+
 local function buildLeaderboardUri(baseUrl, mapUuid, limit)
     local resolvedBaseUrl = normalizeBaseUrl(baseUrl)
     local resolvedLimit = tonumber(limit) or DEFAULT_LEADERBOARD_LIMIT
@@ -62,6 +73,17 @@ local function buildMapAroundUri(baseUrl, mapUuid, playerUuid)
         tostring(mapUuid or ""),
         tostring(playerUuid or "")
     )
+end
+
+local function buildMarketplaceFavoritesUri(baseUrl, limit)
+    local resolvedLimit = tonumber(limit) or DEFAULT_MARKETPLACE_LIMIT
+    return string.format("%s/api/maps/favorites?limit=%d", normalizeBaseUrl(baseUrl), resolvedLimit)
+end
+
+local function buildMarketplaceSearchUri(baseUrl, query, limit)
+    local resolvedLimit = tonumber(limit) or DEFAULT_MARKETPLACE_LIMIT
+    local queryParameter = urlEncode(tostring(query or ""))
+    return string.format("%s/api/maps/search?q=%s&limit=%d", normalizeBaseUrl(baseUrl), queryParameter, resolvedLimit)
 end
 
 local function fetchJson(uri, apiKey)
@@ -163,6 +185,19 @@ local function fetchLeaderboardPreview(config)
     return previewPayload
 end
 
+local function fetchMarketplaceEntries(config)
+    local mode = tostring(config.mode or MARKETPLACE_MODE_FAVORITES)
+    local uri
+
+    if mode == MARKETPLACE_MODE_SEARCH then
+        uri = buildMarketplaceSearchUri(config.apiBaseUrl, config.query, config.limit)
+    else
+        uri = buildMarketplaceFavoritesUri(config.apiBaseUrl, config.limit)
+    end
+
+    return fetchJson(uri, config.apiKey)
+end
+
 while true do
     local encodedRequest = requestChannel:demand()
     local request = json.decode(encodedRequest)
@@ -180,6 +215,15 @@ while true do
         local payload, fetchError = fetchLeaderboardPreview(request.config or {})
         responseChannel:push(json.encode({
             kind = REQUEST_KIND_PREVIEW,
+            requestId = request.requestId,
+            ok = payload ~= nil,
+            payload = payload,
+            error = fetchError,
+        }))
+    elseif type(request) == "table" and request.kind == REQUEST_KIND_MARKETPLACE then
+        local payload, fetchError = fetchMarketplaceEntries(request.config or {})
+        responseChannel:push(json.encode({
+            kind = REQUEST_KIND_MARKETPLACE,
             requestId = request.requestId,
             ok = payload ~= nil,
             payload = payload,

--- a/src/game/leaderboard_preview_cache.lua
+++ b/src/game/leaderboard_preview_cache.lua
@@ -1,0 +1,34 @@
+local json = require("src.game.json")
+
+local leaderboardPreviewCache = {}
+
+local CACHE_FILE = "leaderboard_preview_cache.json"
+
+local function readCacheFile()
+    if not love.filesystem.getInfo(CACHE_FILE, "file") then
+        return {}
+    end
+
+    local content, readError = love.filesystem.read(CACHE_FILE)
+    if not content then
+        return {}
+    end
+
+    local decoded = json.decode(content)
+    if type(decoded) ~= "table" then
+        return {}
+    end
+
+    return decoded
+end
+
+function leaderboardPreviewCache.load()
+    return readCacheFile()
+end
+
+function leaderboardPreviewCache.save(cache)
+    local encodedCache = json.encode(cache or {})
+    return love.filesystem.write(CACHE_FILE, encodedCache)
+end
+
+return leaderboardPreviewCache

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -1,11 +1,16 @@
 local mapStorage = require("src.game.map_storage")
 local authoredMap = require("src.game.authored_map")
+local roadTypes = require("src.game.road_types")
 
 local mapEditor = {}
 mapEditor.__index = mapEditor
 
 local DEFAULT_CONTROL = "direct"
+local DEFAULT_ROAD_TYPE = roadTypes.DEFAULT_ID
 local CONTROL_ORDER = { "direct", "delayed", "pump" }
+local ROAD_TYPE_OPTIONS = roadTypes.getOrderedOptions()
+local ROAD_PATTERN_OUTLINE = { 0.04, 0.05, 0.07, 0.98 }
+local ROAD_PATTERN_FILL = { 0.97, 0.98, 1.0, 0.94 }
 local CONTROL_LABELS = {
     direct = "D",
     delayed = "T",
@@ -89,6 +94,46 @@ local function routePairKey(a, b)
         return a .. "|" .. b
     end
     return b .. "|" .. a
+end
+
+local function segmentLength(a, b)
+    local dx = b.x - a.x
+    local dy = b.y - a.y
+    return math.sqrt(dx * dx + dy * dy)
+end
+
+local function angleBetweenPoints(a, b)
+    local dx = b.x - a.x
+    local dy = b.y - a.y
+
+    if math.atan2 then
+        return math.atan2(dy, dx)
+    end
+
+    if dx == 0 then
+        if dy >= 0 then
+            return math.pi * 0.5
+        end
+        return -math.pi * 0.5
+    end
+
+    local angle = math.atan(dy / dx)
+    if dx < 0 then
+        angle = angle + math.pi
+    end
+    return angle
+end
+
+local function buildDefaultSegmentRoadTypes(pointCount, fallbackRoadType)
+    local segmentRoadTypes = {}
+    local normalizedRoadType = roadTypes.normalizeRoadType(fallbackRoadType)
+    local segmentCount = math.max(0, (pointCount or 0) - 1)
+
+    for segmentIndex = 1, segmentCount do
+        segmentRoadTypes[segmentIndex] = normalizedRoadType
+    end
+
+    return segmentRoadTypes
 end
 
 local function formatNumber(value)
@@ -282,6 +327,7 @@ function mapEditor.new(viewportW, viewportH, level)
     self.selectedPointIndex = nil
     self.drag = nil
     self.colorPicker = nil
+    self.routeTypePicker = nil
     self.dialog = nil
     self.currentMapName = nil
     self.sourceInfo = nil
@@ -335,6 +381,60 @@ function mapEditor:getSelectedRoute()
     end
 
     return nil
+end
+
+function mapEditor:getRouteSegmentCount(route)
+    if not route or not route.points then
+        return 0
+    end
+
+    return math.max(0, #route.points - 1)
+end
+
+function mapEditor:ensureRouteSegmentRoadTypes(route)
+    if not route then
+        return {}
+    end
+
+    local segmentCount = self:getRouteSegmentCount(route)
+    local segmentRoadTypes = route.segmentRoadTypes or {}
+    local normalizedRoadTypes = {}
+    local fallbackRoadType = roadTypes.normalizeRoadType(route.roadType)
+
+    for segmentIndex = 1, segmentCount do
+        normalizedRoadTypes[segmentIndex] = roadTypes.normalizeRoadType(segmentRoadTypes[segmentIndex] or fallbackRoadType)
+    end
+
+    route.segmentRoadTypes = normalizedRoadTypes
+    route.roadType = nil
+    return route.segmentRoadTypes
+end
+
+function mapEditor:getRouteSegmentRoadType(route, segmentIndex)
+    local segmentRoadTypes = self:ensureRouteSegmentRoadTypes(route)
+    return segmentRoadTypes[segmentIndex] or DEFAULT_ROAD_TYPE
+end
+
+function mapEditor:summarizeRouteRoadTypes(route)
+    local counts = {}
+    local summaryParts = {}
+
+    for _, roadTypeId in ipairs(self:ensureRouteSegmentRoadTypes(route)) do
+        counts[roadTypeId] = (counts[roadTypeId] or 0) + 1
+    end
+
+    for _, option in ipairs(ROAD_TYPE_OPTIONS) do
+        local count = counts[option.id] or 0
+        if count > 0 then
+            summaryParts[#summaryParts + 1] = string.format("%d %s", count, option.label:lower())
+        end
+    end
+
+    if #summaryParts == 0 then
+        return "No road segments."
+    end
+
+    return table.concat(summaryParts, ", ")
 end
 
 function mapEditor:createEndpoint(kind, x, y, colors, id)
@@ -441,7 +541,7 @@ function mapEditor:refreshValidation(mapName)
     return level, buildError, self.validationErrors
 end
 
-function mapEditor:createRoute(points, color, id, label, colorId, startColors, endColors, startEndpointId, endEndpointId)
+function mapEditor:createRoute(points, color, id, label, colorId, startColors, endColors, startEndpointId, endEndpointId, segmentRoadTypes)
     local routeId = id or ("route_" .. self.nextRouteId)
     local resolvedColorId = colorId or nearestColorId(color)
     local resolvedColor = normalizeColor(color or getColorById(resolvedColorId))
@@ -460,6 +560,7 @@ function mapEditor:createRoute(points, color, id, label, colorId, startColors, e
         startEndpointId = startEndpoint.id,
         endEndpointId = endEndpoint.id,
         points = {},
+        segmentRoadTypes = {},
     }
 
     for _, point in ipairs(points) do
@@ -468,6 +569,12 @@ function mapEditor:createRoute(points, color, id, label, colorId, startColors, e
 
     self.routes[#self.routes + 1] = route
     self.nextRouteId = self.nextRouteId + 1
+    route.segmentRoadTypes = buildDefaultSegmentRoadTypes(#route.points, DEFAULT_ROAD_TYPE)
+    if type(segmentRoadTypes) == "table" then
+        for segmentIndex = 1, #route.segmentRoadTypes do
+            route.segmentRoadTypes[segmentIndex] = roadTypes.normalizeRoadType(segmentRoadTypes[segmentIndex])
+        end
+    end
     self:updateRouteEndpointPoint(route, "start")
     self:updateRouteEndpointPoint(route, "end")
     return route
@@ -533,6 +640,10 @@ function mapEditor:closeColorPicker()
     self.colorPicker = nil
 end
 
+function mapEditor:closeRouteTypePicker()
+    self.routeTypePicker = nil
+end
+
 function mapEditor:openColorPicker(route, magnetKind)
     local point = magnetKind == "start" and route.points[1] or route.points[#route.points]
     self.colorPicker = {
@@ -541,6 +652,17 @@ function mapEditor:openColorPicker(route, magnetKind)
         anchorX = point.x,
         anchorY = point.y,
     }
+    self:closeRouteTypePicker()
+end
+
+function mapEditor:openRouteTypePicker(route, segmentIndex, anchorX, anchorY)
+    self.routeTypePicker = {
+        routeId = route.id,
+        segmentIndex = segmentIndex,
+        anchorX = anchorX,
+        anchorY = anchorY,
+    }
+    self:closeColorPicker()
 end
 
 function mapEditor:getColorPickerLayout()
@@ -587,6 +709,51 @@ function mapEditor:getColorPickerLayout()
     return {
         rect = rect,
         swatches = swatches,
+    }
+end
+
+function mapEditor:getRouteTypePickerLayout()
+    if not self.routeTypePicker then
+        return nil
+    end
+
+    local optionCount = #ROAD_TYPE_OPTIONS
+    local optionHeight = 42
+    local optionGap = 10
+    local rect = {
+        w = 236,
+        h = 66 + optionCount * optionHeight + math.max(0, optionCount - 1) * optionGap,
+    }
+    rect.x = clamp(
+        self.routeTypePicker.anchorX + 18,
+        self.canvas.x + 8,
+        self.viewport.w - rect.w - 8
+    )
+    rect.y = clamp(
+        self.routeTypePicker.anchorY - rect.h * 0.5,
+        self.canvas.y + 8,
+        self.viewport.h - rect.h - 8
+    )
+
+    local optionRects = {}
+    local currentY = rect.y + 46
+
+    for _, option in ipairs(ROAD_TYPE_OPTIONS) do
+        optionRects[#optionRects + 1] = {
+            option = option,
+            rect = {
+                x = rect.x + 14,
+                y = currentY,
+                w = rect.w - 28,
+                h = optionHeight,
+            },
+        }
+        currentY = currentY + optionHeight + optionGap
+    end
+
+    return {
+        rect = rect,
+        options = optionRects,
     }
 end
 
@@ -639,6 +806,7 @@ function mapEditor:getExportData()
     end
 
     for _, route in ipairs(self.routes) do
+        self:ensureRouteSegmentRoadTypes(route)
         local exportRoute = {
             id = route.id,
             label = route.label or route.id,
@@ -646,6 +814,7 @@ function mapEditor:getExportData()
             startEndpointId = route.startEndpointId,
             endEndpointId = route.endEndpointId,
             points = {},
+            segmentRoadTypes = {},
         }
 
         for _, point in ipairs(route.points) do
@@ -653,6 +822,10 @@ function mapEditor:getExportData()
                 x = point.x / self.viewport.w,
                 y = point.y / self.viewport.h,
             }
+        end
+
+        for _, roadTypeId in ipairs(route.segmentRoadTypes) do
+            exportRoute.segmentRoadTypes[#exportRoute.segmentRoadTypes + 1] = roadTypeId
         end
 
         export.routes[#export.routes + 1] = exportRoute
@@ -697,6 +870,7 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
     self.sourceInfo = sourceInfo
     self:closeDialog()
     self:closeColorPicker()
+    self:closeRouteTypePicker()
     self:clearSelection()
 
     for _, endpointData in ipairs((editorData or {}).endpoints or {}) do
@@ -727,7 +901,8 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
             nil,
             nil,
             routeData.startEndpointId,
-            routeData.endEndpointId
+            routeData.endEndpointId,
+            routeData.segmentRoadTypes or buildDefaultSegmentRoadTypes(#points, routeData.roadType)
         )
     end
 
@@ -914,6 +1089,7 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
         self.importedJunctionState = {}
         self.drag = nil
         self:closeColorPicker()
+        self:closeRouteTypePicker()
         self:clearSelection()
         self:rebuildIntersections()
         return
@@ -939,6 +1115,7 @@ function mapEditor:resetFromLevel(level)
     self.importedJunctionState = {}
     self.drag = nil
     self:closeColorPicker()
+    self:closeRouteTypePicker()
     self:clearSelection()
 
     if not level then
@@ -1090,6 +1267,7 @@ function mapEditor:findSegmentHit(x, y)
                 bestDistance = distance
                 bestHit = {
                     route = route,
+                    segmentIndex = pointIndex,
                     insertIndex = pointIndex + 1,
                     point = { x = closestX, y = closestY },
                 }
@@ -1107,8 +1285,10 @@ function mapEditor:deleteSelection()
     end
 
     self:closeColorPicker()
+    self:closeRouteTypePicker()
 
     if self.selectedPointIndex and self.selectedPointIndex > 1 and self.selectedPointIndex < #selectedRoute.points then
+        self:mergeRouteSegmentStyle(selectedRoute, self.selectedPointIndex)
         table.remove(selectedRoute.points, self.selectedPointIndex)
         self.selectedPointIndex = nil
         self:rebuildIntersections()
@@ -1343,7 +1523,10 @@ function mapEditor:beginRoute(x, y)
         nil,
         colorOption.id,
         { colorOption.id },
-        { colorOption.id }
+        { colorOption.id },
+        nil,
+        nil,
+        { DEFAULT_ROAD_TYPE }
     )
 
     self.selectedRouteId = route.id
@@ -1359,6 +1542,7 @@ function mapEditor:beginRoute(x, y)
         magnetKind = "end",
     }
     self:closeColorPicker()
+    self:closeRouteTypePicker()
     self:rebuildIntersections()
 end
 
@@ -1553,6 +1737,61 @@ function mapEditor:handleColorPickerClick(x, y, button)
     return true
 end
 
+function mapEditor:splitRouteSegmentStyle(route, segmentIndex)
+    local segmentRoadTypes = self:ensureRouteSegmentRoadTypes(route)
+    local duplicatedRoadType = segmentRoadTypes[segmentIndex] or DEFAULT_ROAD_TYPE
+    table.insert(segmentRoadTypes, segmentIndex + 1, duplicatedRoadType)
+end
+
+function mapEditor:mergeRouteSegmentStyle(route, selectedPointIndex)
+    local segmentRoadTypes = self:ensureRouteSegmentRoadTypes(route)
+    table.remove(segmentRoadTypes, selectedPointIndex)
+end
+
+function mapEditor:setRouteSegmentRoadType(route, segmentIndex, roadType)
+    if not route or not segmentIndex then
+        return
+    end
+
+    local normalizedRoadType = roadTypes.normalizeRoadType(roadType)
+    local segmentRoadTypes = self:ensureRouteSegmentRoadTypes(route)
+    if not segmentRoadTypes[segmentIndex] then
+        return
+    end
+
+    segmentRoadTypes[segmentIndex] = normalizedRoadType
+    self:refreshValidation()
+    self:showStatus("Segment road type set to " .. roadTypes.getConfig(normalizedRoadType).label .. ".")
+end
+
+function mapEditor:handleRouteTypePickerClick(x, y)
+    local layout = self:getRouteTypePickerLayout()
+    if not layout then
+        return false
+    end
+
+    if not pointInRect(x, y, layout.rect) then
+        self:closeRouteTypePicker()
+        return false
+    end
+
+    local route = self:getRouteById(self.routeTypePicker.routeId)
+    if not route then
+        self:closeRouteTypePicker()
+        return true
+    end
+
+    for _, optionEntry in ipairs(layout.options) do
+        if pointInRect(x, y, optionEntry.rect) then
+            self:setRouteSegmentRoadType(route, self.routeTypePicker.segmentIndex, optionEntry.option.id)
+            self:closeRouteTypePicker()
+            return true
+        end
+    end
+
+    return true
+end
+
 function mapEditor:handleDialogClick(x, y)
     if not self.dialog then
         return false
@@ -1598,6 +1837,16 @@ function mapEditor:keypressed(key)
         if self.dialog then
             self:closeDialog()
             self:showStatus("Dialog closed.")
+            return true
+        end
+        if self.colorPicker then
+            self:closeColorPicker()
+            self:showStatus("Color picker closed.")
+            return true
+        end
+        if self.routeTypePicker then
+            self:closeRouteTypePicker()
+            self:showStatus("Road type picker closed.")
             return true
         end
         return false
@@ -1672,6 +1921,10 @@ function mapEditor:mousepressed(x, y, button)
         return true
     end
 
+    if self.routeTypePicker and self:handleRouteTypePickerClick(x, y) then
+        return true
+    end
+
     if button == 2 then
         local hitIntersection = self:findIntersectionHit(x, y)
         if hitIntersection
@@ -1680,6 +1933,16 @@ function mapEditor:mousepressed(x, y, button)
             self:cycleIntersectionOutput(hitIntersection, -1)
             return true
         end
+
+        local segmentHit = self:findSegmentHit(x, y)
+        if segmentHit and segmentHit.route then
+            self.selectedRouteId = segmentHit.route.id
+            self.selectedPointIndex = nil
+            self:openRouteTypePicker(segmentHit.route, segmentHit.segmentIndex, x, y)
+            self:showStatus("Road type picker opened.")
+            return true
+        end
+
         return false
     end
 
@@ -1734,6 +1997,7 @@ function mapEditor:mousepressed(x, y, button)
     local segmentHit = self:findSegmentHit(x, y)
     if segmentHit then
         table.insert(segmentHit.route.points, segmentHit.insertIndex, segmentHit.point)
+        self:splitRouteSegmentStyle(segmentHit.route, segmentHit.segmentIndex)
         self.selectedRouteId = segmentHit.route.id
         self.selectedPointIndex = segmentHit.insertIndex
         self.drag = {
@@ -1747,6 +2011,7 @@ function mapEditor:mousepressed(x, y, button)
             magnetKind = nil,
         }
         self:closeColorPicker()
+        self:closeRouteTypePicker()
         self:rebuildIntersections()
         self:showStatus("Bend point added.")
         return true
@@ -1758,6 +2023,7 @@ function mapEditor:mousepressed(x, y, button)
     end
 
     self:closeColorPicker()
+    self:closeRouteTypePicker()
 
     if pointInRect(x, y, self.canvas) or pointInRect(x, y, self.sidePanel) then
         self:clearSelection()
@@ -1837,12 +2103,18 @@ function mapEditor:serialize()
     lines[#lines + 1] = "    routes = {"
 
     for _, route in ipairs(self.routes) do
+        self:ensureRouteSegmentRoadTypes(route)
         lines[#lines + 1] = "        {"
         lines[#lines + 1] = string.format("            id = %q,", route.id)
         lines[#lines + 1] = string.format("            label = %q,", route.label or route.id)
         lines[#lines + 1] = string.format("            color = %q,", route.colorId)
         lines[#lines + 1] = string.format("            startEndpointId = %q,", route.startEndpointId)
         lines[#lines + 1] = string.format("            endEndpointId = %q,", route.endEndpointId)
+        lines[#lines + 1] = "            segmentRoadTypes = {"
+        for _, roadTypeId in ipairs(route.segmentRoadTypes) do
+            lines[#lines + 1] = string.format("                %q,", roadTypeId)
+        end
+        lines[#lines + 1] = "            },"
         lines[#lines + 1] = "            points = {"
         for _, point in ipairs(route.points) do
             lines[#lines + 1] = string.format(
@@ -1931,9 +2203,81 @@ function mapEditor:drawMagnet(route, point, magnetKind, selected)
     end
 end
 
+function mapEditor:drawRoutePatternStroke(pointA, pointB, roadTypeId, alpha)
+    local roadTypeConfig = roadTypes.getConfig(roadTypeId)
+    if roadTypeConfig.pattern == "plain" then
+        return
+    end
+
+    local graphics = love.graphics
+    local length = segmentLength(pointA, pointB)
+    if length <= 0.001 then
+        return
+    end
+
+    local angle = angleBetweenPoints(pointA, pointB)
+    local directionX = math.cos(angle)
+    local directionY = math.sin(angle)
+    local normalX = -directionY
+    local normalY = directionX
+    local markerSpacing = roadTypeConfig.markerSpacing
+    local markerSize = roadTypeConfig.markerSize
+    local markerDistance = markerSpacing * 0.5
+    local outlineWidth = roadTypeConfig.markerWidth + 2
+    local fillWidth = roadTypeConfig.markerWidth
+
+    local function drawPatternSegment(startX, startY, endX, endY)
+        graphics.setColor(ROAD_PATTERN_OUTLINE[1], ROAD_PATTERN_OUTLINE[2], ROAD_PATTERN_OUTLINE[3], alpha)
+        graphics.setLineWidth(outlineWidth)
+        graphics.line(startX, startY, endX, endY)
+        graphics.setColor(ROAD_PATTERN_FILL[1], ROAD_PATTERN_FILL[2], ROAD_PATTERN_FILL[3], alpha)
+        graphics.setLineWidth(fillWidth)
+        graphics.line(startX, startY, endX, endY)
+    end
+
+    while markerDistance < length do
+        local markerX = pointA.x + directionX * markerDistance
+        local markerY = pointA.y + directionY * markerDistance
+
+        if roadTypeConfig.pattern == "chevron" then
+            local tipX = markerX + directionX * markerSize
+            local tipY = markerY + directionY * markerSize
+            local leftX = markerX - normalX * markerSize * 0.7
+            local leftY = markerY - normalY * markerSize * 0.7
+            local rightX = markerX + normalX * markerSize * 0.7
+            local rightY = markerY + normalY * markerSize * 0.7
+            drawPatternSegment(leftX, leftY, tipX, tipY)
+            drawPatternSegment(rightX, rightY, tipX, tipY)
+        elseif roadTypeConfig.pattern == "crossbar" then
+            local startX = markerX - normalX * markerSize
+            local startY = markerY - normalY * markerSize
+            local endX = markerX + normalX * markerSize
+            local endY = markerY + normalY * markerSize
+            drawPatternSegment(startX, startY, endX, endY)
+        end
+
+        markerDistance = markerDistance + markerSpacing
+    end
+end
+
+function mapEditor:drawRouteRoadTypeMarkers(route, selectedRouteId)
+    local alpha = selectedRouteId == route.id and 0.98 or 0.86
+    local segmentRoadTypes = self:ensureRouteSegmentRoadTypes(route)
+
+    for segmentIndex = 1, #route.points - 1 do
+        self:drawRoutePatternStroke(
+            route.points[segmentIndex],
+            route.points[segmentIndex + 1],
+            segmentRoadTypes[segmentIndex],
+            alpha
+        )
+    end
+end
+
 function mapEditor:drawRoute(route, selectedRouteId)
     local graphics = love.graphics
     local points = {}
+    self:ensureRouteSegmentRoadTypes(route)
 
     for _, point in ipairs(route.points) do
         points[#points + 1] = point.x
@@ -1949,6 +2293,8 @@ function mapEditor:drawRoute(route, selectedRouteId)
     graphics.setColor(route.color[1], route.color[2], route.color[3], selectedRouteId == route.id and 1 or 0.86)
     graphics.setLineWidth(selectedRouteId == route.id and 8 or 6)
     graphics.line(points)
+
+    self:drawRouteRoadTypeMarkers(route, selectedRouteId)
 
     for pointIndex, point in ipairs(route.points) do
         local selected = selectedRouteId == route.id and pointIndex == self.selectedPointIndex
@@ -2110,6 +2456,95 @@ function mapEditor:drawColorPicker(game)
     end
 end
 
+function mapEditor:drawRoadTypePreview(option, rect, alpha)
+    local graphics = love.graphics
+    local centerY = rect.y + rect.h * 0.5
+    local startX = rect.x + 10
+    local endX = rect.x + rect.w - 10
+
+    graphics.setColor(0.1, 0.12, 0.16, alpha)
+    graphics.setLineWidth(10)
+    graphics.line(startX, centerY, endX, centerY)
+    graphics.setColor(0.84, 0.88, 0.92, alpha)
+    graphics.setLineWidth(4)
+    graphics.line(startX, centerY, endX, centerY)
+
+    if option.pattern == "chevron" then
+        self:drawRoutePatternStroke(
+            { x = rect.x + 18, y = centerY },
+            { x = rect.x + rect.w - 18, y = centerY },
+            option.id,
+            alpha
+        )
+    elseif option.pattern == "crossbar" then
+        self:drawRoutePatternStroke(
+            { x = rect.x + 18, y = centerY },
+            { x = rect.x + rect.w - 18, y = centerY },
+            option.id,
+            alpha
+        )
+    end
+end
+
+function mapEditor:drawRouteTypePicker(game)
+    local layout = self:getRouteTypePickerLayout()
+    if not layout then
+        return
+    end
+
+    local route = self:getRouteById(self.routeTypePicker.routeId)
+    if not route then
+        return
+    end
+
+    local graphics = love.graphics
+    local selectedRoadType = self:getRouteSegmentRoadType(route, self.routeTypePicker.segmentIndex)
+
+    graphics.setColor(0.08, 0.1, 0.14, 0.98)
+    graphics.rectangle("fill", layout.rect.x, layout.rect.y, layout.rect.w, layout.rect.h, 16, 16)
+    graphics.setColor(0.24, 0.32, 0.4, 1)
+    graphics.rectangle("line", layout.rect.x, layout.rect.y, layout.rect.w, layout.rect.h, 16, 16)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(
+        "Road Type For Segment " .. tostring(self.routeTypePicker.segmentIndex),
+        layout.rect.x + 14,
+        layout.rect.y + 14,
+        layout.rect.w - 28,
+        "center"
+    )
+
+    for _, optionEntry in ipairs(layout.options) do
+        local option = optionEntry.option
+        local rect = optionEntry.rect
+        local isSelected = option.id == selectedRoadType
+
+        graphics.setColor(0.05, 0.06, 0.08, 1)
+        graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 12, 12)
+        graphics.setColor(0.58, 0.64, 0.7, 1)
+        graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 12, 12)
+
+        self:drawRoadTypePreview(option, {
+            x = rect.x + 10,
+            y = rect.y + 8,
+            w = 48,
+            h = rect.h - 16,
+        }, 1)
+
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print(option.label, rect.x + 68, rect.y + 8)
+        graphics.setColor(0.72, 0.78, 0.84, 1)
+        graphics.print(string.format("%d%% speed", math.floor(option.speedScale * 100 + 0.5)), rect.x + 68, rect.y + 22)
+
+        if isSelected then
+            graphics.setColor(0.97, 0.98, 1, 1)
+            graphics.setLineWidth(2)
+            graphics.rectangle("line", rect.x - 2, rect.y - 2, rect.w + 4, rect.h + 4, 14, 14)
+        end
+    end
+end
+
 function mapEditor:drawDialog(game)
     if not self.dialog then
         return
@@ -2205,6 +2640,7 @@ function mapEditor:draw(game)
     end
 
     self:drawColorPicker(game)
+    self:drawRouteTypePicker(game)
 
     graphics.setColor(0.09, 0.11, 0.15, 0.98)
     graphics.rectangle("fill", self.sidePanel.x, self.sidePanel.y, self.sidePanel.w, self.sidePanel.h, 18, 18)
@@ -2238,6 +2674,10 @@ function mapEditor:draw(game)
         panelWidth
     )
     currentY = currentY + 30
+
+    graphics.setColor(0.68, 0.74, 0.8, 1)
+    graphics.printf("Right click a route segment to change its road type.", panelX, currentY, panelWidth)
+    currentY = currentY + 34
 
     if #(self.validationErrors or {}) == 0 then
         graphics.setColor(0.48, 0.92, 0.62, 1)
@@ -2286,7 +2726,7 @@ function mapEditor:draw(game)
         currentY = currentY + 24
         graphics.setColor(0.84, 0.88, 0.92, 1)
         graphics.printf(
-            "Start magnet: " .. startColors .. "\nExit magnet: " .. endColors,
+            "Road styles: " .. self:summarizeRouteRoadTypes(selectedRoute) .. "\nStart magnet: " .. startColors .. "\nExit magnet: " .. endColors,
             panelX,
             currentY,
             panelWidth

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -1,6 +1,7 @@
 local mapStorage = require("src.game.map_storage")
 local authoredMap = require("src.game.authored_map")
 local roadTypes = require("src.game.road_types")
+local uuid = require("src.game.uuid")
 
 local mapEditor = {}
 mapEditor.__index = mapEditor
@@ -405,6 +406,7 @@ function mapEditor.new(viewportW, viewportH, level)
     self.routeTypePicker = nil
     self.dialog = nil
     self.currentMapName = nil
+    self.editingMapUuid = nil
     self.sourceInfo = nil
     self.lastSavedDescriptor = nil
     self.pendingPlaytestDescriptor = nil
@@ -782,7 +784,8 @@ end
 function mapEditor:refreshValidation(mapName)
     local level, buildError, buildErrors = authoredMap.buildPlayableLevel(
         mapName or self.currentMapName or "Untitled",
-        self:getExportData()
+        self:getExportData(),
+        self.editingMapUuid
     )
     self.lastValidationError = buildError
     self.validationErrors = buildErrors or {}
@@ -1639,6 +1642,7 @@ function mapEditor:saveMap(name)
     local payload = {
         version = 1,
         name = trimmedName,
+        mapUuid = self.editingMapUuid or uuid.generateV4(),
         savedAt = os.date("!%Y-%m-%dT%H:%M:%SZ"),
         editor = self:getExportData(),
     }
@@ -1652,6 +1656,7 @@ function mapEditor:saveMap(name)
     end
 
     self.currentMapName = trimmedName
+    self.editingMapUuid = payload.mapUuid
     self.sourceInfo = record
     self.lastSavedDescriptor = record.hasLevel and record or nil
     self.loadedMapPayload = payload
@@ -1668,12 +1673,14 @@ end
 function mapEditor:resetFromMap(mapData, sourceInfo)
     self.loadedMapPayload = mapData
     self.sourceInfo = sourceInfo
+    self.editingMapUuid = mapData and mapData.mapUuid or nil
     self.lastSavedDescriptor = sourceInfo and sourceInfo.hasLevel and sourceInfo or nil
     self.pendingPlaytestDescriptor = nil
 
     if not mapData then
         self.level = nil
         self.currentMapName = nil
+        self.editingMapUuid = nil
         self.endpoints = {}
         self.routes = {}
         self.trains = {}
@@ -1695,6 +1702,9 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
     end
 
     if mapData.editor then
+        if sourceInfo and sourceInfo.source == "builtin" then
+            self.editingMapUuid = nil
+        end
         self:loadEditorData(mapData.editor, mapData.name, sourceInfo, mapData.level)
         return
     end

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -406,6 +406,8 @@ function mapEditor.new(viewportW, viewportH, level)
     self.dialog = nil
     self.currentMapName = nil
     self.sourceInfo = nil
+    self.lastSavedDescriptor = nil
+    self.pendingPlaytestDescriptor = nil
     self.loadedMapPayload = nil
     self.lastValidationError = nil
     self.validationErrors = {}
@@ -787,6 +789,27 @@ function mapEditor:refreshValidation(mapName)
     return level, buildError, self.validationErrors
 end
 
+function mapEditor:canPlaySavedMap()
+    return self.lastSavedDescriptor ~= nil and self.lastSavedDescriptor.hasLevel == true
+end
+
+function mapEditor:requestPlaytestFromSavedMap()
+    if not self:canPlaySavedMap() then
+        self:showStatus("Save a playable map first, then test it from here.")
+        return false
+    end
+
+    self.pendingPlaytestDescriptor = self.lastSavedDescriptor
+    self:showStatus("Starting test run from the saved map...")
+    return true
+end
+
+function mapEditor:consumePlaytestRequest()
+    local descriptor = self.pendingPlaytestDescriptor
+    self.pendingPlaytestDescriptor = nil
+    return descriptor
+end
+
 function mapEditor:createRoute(points, color, id, label, colorId, startColors, endColors, startEndpointId, endEndpointId, segmentRoadTypes)
     local routeId = id or ("route_" .. self.nextRouteId)
     local resolvedColorId = colorId or nearestColorId(color)
@@ -829,13 +852,22 @@ end
 function mapEditor:getSaveButtonRect()
     return {
         x = self.sidePanel.x + 18,
-        y = self.sidePanel.y + self.sidePanel.h - 210,
+        y = self.sidePanel.y + self.sidePanel.h - 260,
         w = self.sidePanel.w - 36,
         h = 38,
     }
 end
 
 function mapEditor:getOpenButtonRect()
+    return {
+        x = self.sidePanel.x + 18,
+        y = self.sidePanel.y + self.sidePanel.h - 210,
+        w = self.sidePanel.w - 36,
+        h = 38,
+    }
+end
+
+function mapEditor:getPlayTestButtonRect()
     return {
         x = self.sidePanel.x + 18,
         y = self.sidePanel.y + self.sidePanel.h - 160,
@@ -1139,6 +1171,7 @@ function mapEditor:openOpenDialog()
     self.dialog = {
         type = "open",
         maps = mapStorage.listMaps(),
+        scroll = 0,
     }
 end
 
@@ -1149,6 +1182,106 @@ function mapEditor:getDialogRect()
         w = 520,
         h = 360,
     }
+end
+
+function mapEditor:getOpenDialogListLayout()
+    local rect = self:getDialogRect()
+    local maps = (self.dialog and self.dialog.maps) or {}
+    local listRect = {
+        x = rect.x + 24,
+        y = rect.y + 78,
+        w = rect.w - 48,
+        h = rect.h - 142,
+    }
+    local rowStride = 54
+    local rowHeight = 44
+    local visibleRows = math.max(1, math.floor(listRect.h / rowStride))
+    local maxScroll = math.max(0, #maps - visibleRows)
+    local scroll = clamp((self.dialog and self.dialog.scroll) or 0, 0, maxScroll)
+
+    if self.dialog then
+        self.dialog.scroll = scroll
+    end
+
+    local contentWidth = listRect.w
+    local scrollbar = nil
+    if maxScroll > 0 then
+        local track = {
+            x = listRect.x + listRect.w - 8,
+            y = listRect.y,
+            w = 8,
+            h = listRect.h,
+        }
+        local thumbHeight = math.max(26, track.h * (visibleRows / #maps))
+        local thumbY = track.y + ((track.h - thumbHeight) * (scroll / maxScroll))
+        scrollbar = {
+            track = track,
+            thumb = {
+                x = track.x,
+                y = thumbY,
+                w = track.w,
+                h = thumbHeight,
+            },
+            maxScroll = maxScroll,
+        }
+        contentWidth = listRect.w - 14
+    end
+
+    local rows = {}
+    for slot = 1, visibleRows do
+        local mapIndex = scroll + slot
+        local savedMap = maps[mapIndex]
+        if not savedMap then
+            break
+        end
+
+        rows[#rows + 1] = {
+            index = mapIndex,
+            map = savedMap,
+            rect = {
+                x = listRect.x,
+                y = listRect.y + (slot - 1) * rowStride,
+                w = contentWidth,
+                h = rowHeight,
+            },
+        }
+    end
+
+    return {
+        listRect = listRect,
+        rows = rows,
+        totalMaps = #maps,
+        visibleRows = visibleRows,
+        maxScroll = maxScroll,
+        firstVisibleIndex = (#rows > 0) and rows[1].index or 0,
+        lastVisibleIndex = (#rows > 0) and rows[#rows].index or 0,
+        scrollbar = scrollbar,
+    }
+end
+
+function mapEditor:scrollOpenDialog(delta)
+    if not self.dialog or self.dialog.type ~= "open" then
+        return false
+    end
+
+    local layout = self:getOpenDialogListLayout()
+    if layout.maxScroll <= 0 then
+        return false
+    end
+
+    self.dialog.scroll = clamp((self.dialog.scroll or 0) + delta, 0, layout.maxScroll)
+    return true
+end
+
+function mapEditor:openDialogMap(savedMap)
+    local loadedMap, loadError = mapStorage.loadMap(savedMap)
+    if not loadedMap or not loadedMap.editor then
+        self:showStatus(loadError or "That map could not be opened.")
+        return false
+    end
+
+    self:resetFromMap(loadedMap, savedMap)
+    return true
 end
 
 function mapEditor:synthesizeTrainsFromLevel(levelData)
@@ -1520,11 +1653,12 @@ function mapEditor:saveMap(name)
 
     self.currentMapName = trimmedName
     self.sourceInfo = record
+    self.lastSavedDescriptor = record.hasLevel and record or nil
     self.loadedMapPayload = payload
     self.validationErrors = buildErrors or {}
     self:closeDialog()
     if level then
-        self:showStatus((wasBuiltinTemplate and "Saved copy: " or "Saved map: ") .. trimmedName .. " to " .. mapStorage.getSaveDirectory())
+        self:showStatus((wasBuiltinTemplate and "Saved copy: " or "Saved map: ") .. trimmedName .. " to " .. mapStorage.getSaveDirectory() .. ". Press Play Saved Map (P) to test.")
     else
         self:showStatus("Saved map: " .. trimmedName .. ". Remaining issues: " .. buildError)
     end
@@ -1534,6 +1668,8 @@ end
 function mapEditor:resetFromMap(mapData, sourceInfo)
     self.loadedMapPayload = mapData
     self.sourceInfo = sourceInfo
+    self.lastSavedDescriptor = sourceInfo and sourceInfo.hasLevel and sourceInfo or nil
+    self.pendingPlaytestDescriptor = nil
 
     if not mapData then
         self.level = nil
@@ -2561,20 +2697,18 @@ function mapEditor:handleDialogClick(x, y)
     end
 
     if self.dialog.type == "open" then
-        for mapIndex, savedMap in ipairs(self.dialog.maps or {}) do
-            local itemRect = {
-                x = rect.x + 24,
-                y = rect.y + 78 + (mapIndex - 1) * 54,
-                w = rect.w - 48,
-                h = 44,
-            }
-            if pointInRect(x, y, itemRect) then
-                local loadedMap, loadError = mapStorage.loadMap(savedMap)
-                if not loadedMap or not loadedMap.editor then
-                    self:showStatus(loadError or "That map could not be opened.")
-                else
-                    self:resetFromMap(loadedMap, savedMap)
-                end
+        local layout = self:getOpenDialogListLayout()
+        if layout.scrollbar and pointInRect(x, y, layout.scrollbar.track) then
+            local thumbTravel = math.max(1, layout.scrollbar.track.h - layout.scrollbar.thumb.h)
+            local thumbY = clamp(y - layout.scrollbar.thumb.h * 0.5, layout.scrollbar.track.y, layout.scrollbar.track.y + thumbTravel)
+            self.dialog.scroll = ((thumbY - layout.scrollbar.track.y) / thumbTravel) * layout.scrollbar.maxScroll
+            self.dialog.scroll = math.floor(self.dialog.scroll + 0.5)
+            return true
+        end
+
+        for _, row in ipairs(layout.rows) do
+            if pointInRect(x, y, row.rect) then
+                self:openDialogMap(row.map)
                 self:closeDialog()
                 return true
             end
@@ -2632,6 +2766,44 @@ function mapEditor:keypressed(key)
             end
         end
 
+        if self.dialog.type == "open" then
+            if key == "up" then
+                self:scrollOpenDialog(-1)
+                return true
+            end
+            if key == "down" then
+                self:scrollOpenDialog(1)
+                return true
+            end
+            if key == "pageup" then
+                local layout = self:getOpenDialogListLayout()
+                self:scrollOpenDialog(-layout.visibleRows)
+                return true
+            end
+            if key == "pagedown" then
+                local layout = self:getOpenDialogListLayout()
+                self:scrollOpenDialog(layout.visibleRows)
+                return true
+            end
+            if key == "home" then
+                self.dialog.scroll = 0
+                return true
+            end
+            if key == "end" then
+                local layout = self:getOpenDialogListLayout()
+                self.dialog.scroll = layout.maxScroll
+                return true
+            end
+            if key == "return" or key == "kpenter" then
+                local layout = self:getOpenDialogListLayout()
+                if layout.rows[1] then
+                    self:openDialogMap(layout.rows[1].map)
+                    self:closeDialog()
+                end
+                return true
+            end
+        end
+
         return true
     end
 
@@ -2663,6 +2835,12 @@ function mapEditor:keypressed(key)
     if key == "o" then
         self:commitTextField()
         self:openOpenDialog()
+        return true
+    end
+
+    if key == "p" then
+        self:commitTextField()
+        self:requestPlaytestFromSavedMap()
         return true
     end
 
@@ -2750,6 +2928,11 @@ function mapEditor:mousepressed(x, y, button)
         return true
     end
 
+    if pointInRect(x, y, self:getPlayTestButtonRect()) then
+        self:requestPlaytestFromSavedMap()
+        return true
+    end
+
     if pointInRect(x, y, self:getSequencerButtonRect()) then
         self.sidePanelMode = "sequencer"
         self:showStatus("Sequencer opened.")
@@ -2829,6 +3012,18 @@ function mapEditor:mousepressed(x, y, button)
 end
 
 function mapEditor:wheelmoved(_, y)
+    if self.dialog and self.dialog.type == "open" then
+        if y > 0 then
+            self:scrollOpenDialog(-1)
+            return true
+        end
+        if y < 0 then
+            self:scrollOpenDialog(1)
+            return true
+        end
+        return false
+    end
+
     if self.sidePanelMode ~= "sequencer" then
         return false
     end
@@ -3221,15 +3416,27 @@ function mapEditor:drawIntersection(intersection)
     end
 end
 
-function mapEditor:drawPanelButton(rect, label, accentColor)
+function mapEditor:drawPanelButton(rect, label, accentColor, isDisabled)
     local graphics = love.graphics
     local font = graphics.getFont()
-    graphics.setColor(0.1, 0.12, 0.16, 0.96)
+    if isDisabled then
+        graphics.setColor(0.08, 0.1, 0.13, 0.72)
+    else
+        graphics.setColor(0.1, 0.12, 0.16, 0.96)
+    end
     graphics.rectangle("fill", rect.x, rect.y, rect.w, rect.h, 12, 12)
     graphics.setLineWidth(1.5)
-    graphics.setColor(accentColor[1], accentColor[2], accentColor[3], 1)
+    if isDisabled then
+        graphics.setColor(0.34, 0.38, 0.42, 0.85)
+    else
+        graphics.setColor(accentColor[1], accentColor[2], accentColor[3], 1)
+    end
     graphics.rectangle("line", rect.x, rect.y, rect.w, rect.h, 12, 12)
-    graphics.setColor(0.97, 0.98, 1, 1)
+    if isDisabled then
+        graphics.setColor(0.6, 0.64, 0.68, 0.9)
+    else
+        graphics.setColor(0.97, 0.98, 1, 1)
+    end
     graphics.printf(label, rect.x, rect.y + math.floor((rect.h - font:getHeight()) * 0.5), rect.w, "center")
 end
 
@@ -3436,18 +3643,16 @@ function mapEditor:drawDialog(game)
     graphics.printf("Open Map", rect.x, rect.y + 20, rect.w, "center")
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.84, 0.88, 0.92, 1)
-    if #(self.dialog.maps or {}) == 0 then
+    local layout = self:getOpenDialogListLayout()
+    if layout.totalMaps == 0 then
         graphics.printf("No maps were found yet.", rect.x + 24, rect.y + 142, rect.w - 48, "center")
         return
     end
 
-    for mapIndex, savedMap in ipairs(self.dialog.maps or {}) do
-        local itemRect = {
-            x = rect.x + 24,
-            y = rect.y + 78 + (mapIndex - 1) * 54,
-            w = rect.w - 48,
-            h = 44,
-        }
+    love.graphics.setScissor(layout.listRect.x, layout.listRect.y, layout.listRect.w, layout.listRect.h)
+    for _, row in ipairs(layout.rows) do
+        local savedMap = row.map
+        local itemRect = row.rect
         graphics.setColor(0.05, 0.06, 0.08, 1)
         graphics.rectangle("fill", itemRect.x, itemRect.y, itemRect.w, itemRect.h, 12, 12)
         graphics.setColor(0.3, 0.36, 0.42, 1)
@@ -3455,8 +3660,21 @@ function mapEditor:drawDialog(game)
         graphics.setColor(0.97, 0.98, 1, 1)
         graphics.print(savedMap.name, itemRect.x + 14, itemRect.y + 12)
         graphics.setColor(0.72, 0.78, 0.84, 1)
-        graphics.print(savedMap.source == "builtin" and "Tutorial" or "User Save", itemRect.x + itemRect.w - 110, itemRect.y + 12)
+        graphics.printf(savedMap.source == "builtin" and "Tutorial" or "User Save", itemRect.x, itemRect.y + 12, itemRect.w - 12, "right")
     end
+    love.graphics.setScissor()
+
+    if layout.scrollbar then
+        graphics.setColor(0.1, 0.12, 0.16, 1)
+        graphics.rectangle("fill", layout.scrollbar.track.x, layout.scrollbar.track.y, layout.scrollbar.track.w, layout.scrollbar.track.h, 4, 4)
+        graphics.setColor(0.34, 0.44, 0.54, 1)
+        graphics.rectangle("fill", layout.scrollbar.thumb.x, layout.scrollbar.thumb.y, layout.scrollbar.thumb.w, layout.scrollbar.thumb.h, 4, 4)
+    end
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.72, 0.78, 0.84, 1)
+    local rangeText = string.format("Showing %d-%d of %d", layout.firstVisibleIndex, layout.lastVisibleIndex, layout.totalMaps)
+    graphics.printf(rangeText, rect.x + 24, rect.y + rect.h - 52, rect.w - 48, "left")
 end
 
 function mapEditor:drawTextField(label, rect, valueText, accentColor, active)
@@ -3705,6 +3923,7 @@ function mapEditor:drawDefaultSidePanel(game)
     love.graphics.setFont(game.fonts.small)
     self:drawPanelButton(self:getSaveButtonRect(), "Save Map (S)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getOpenButtonRect(), "Open Map (O)", { 0.33, 0.8, 0.98 })
+    self:drawPanelButton(self:getPlayTestButtonRect(), "Play Saved Map (P)", { 0.64, 0.86, 0.98 }, not self:canPlaySavedMap())
     self:drawPanelButton(self:getSequencerButtonRect(), "Sequencer (C)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getResetButtonRect(), "Reset To Map (R)", { 0.99, 0.78, 0.32 })
 end

--- a/src/game/map_storage.lua
+++ b/src/game/map_storage.lua
@@ -1,5 +1,6 @@
 local mapStorage = {}
 local authoredMap = require("src.game.authored_map")
+local uuid = require("src.game.uuid")
 
 local USER_MAP_DIR = "maps"
 local BUILTIN_MAP_DIR = "src/game/maps"
@@ -128,6 +129,11 @@ local function loadMapFile(path)
     return data
 end
 
+local function writeMapFile(path, payload)
+    local body = "return " .. serializeValue(payload) .. "\n"
+    return love.filesystem.write(path, body)
+end
+
 local function getBuiltinDirectory(mapKind)
     if mapKind == "tutorial" then
         return BUILTIN_TUTORIAL_DIR
@@ -182,6 +188,7 @@ local function buildDescriptor(source, fileName, data, options)
     local mapKind = descriptorOptions.mapKind or inferMapKind(source, data, descriptorOptions.directory)
     return {
         id = source .. ":" .. fileName,
+        mapUuid = data.mapUuid,
         source = source,
         name = name,
         displayName = buildDisplayName(name, fileName),
@@ -228,8 +235,13 @@ function mapStorage.saveMap(name, payload)
 
     local fileName = sanitizeFileName(name)
     local path = USER_MAP_DIR .. "/" .. fileName
-    local body = "return " .. serializeValue(payload) .. "\n"
-    local ok, writeError = love.filesystem.write(path, body)
+    payload.mapUuid = payload.mapUuid or uuid.generateV4()
+    if payload.level then
+        payload.level.id = payload.mapUuid
+        payload.level.mapUuid = payload.mapUuid
+    end
+
+    local ok, writeError = writeMapFile(path, payload)
     if not ok then
         return nil, writeError
     end
@@ -260,6 +272,22 @@ function mapStorage.loadMap(fileNameOrDescriptor, source, mapKind, directory)
         return nil, loadError
     end
 
+    if type(data.mapUuid) ~= "string" or data.mapUuid == "" then
+        if resolvedSource == "user" then
+            data.mapUuid = uuid.generateV4()
+            writeMapFile(path, data)
+        elseif type(data.level) == "table" and type(data.level.id) == "string" and data.level.id ~= "" then
+            data.mapUuid = data.level.id
+        else
+            data.mapUuid = "builtin-" .. fileName:gsub("%.lua$", "")
+        end
+    end
+
+    if data.level then
+        data.level.id = data.mapUuid
+        data.level.mapUuid = data.mapUuid
+    end
+
     data.fileName = fileName
     data.path = path
     data.source = resolvedSource
@@ -269,10 +297,20 @@ function mapStorage.loadMap(fileNameOrDescriptor, source, mapKind, directory)
     data.validationErrors = {}
     data.validationErrorText = nil
     if data.editor then
-        local level, errorText, errors = authoredMap.buildPlayableLevel(data.name or fileName:gsub("%.lua$", ""), data.editor)
+        local existingLevel = data.level
+        local level, errorText, errors = authoredMap.buildPlayableLevel(data.name or fileName:gsub("%.lua$", ""), data.editor, data.mapUuid)
         data.validationErrors = errors or {}
         data.validationErrorText = errorText
         if level then
+            if existingLevel then
+                level.title = existingLevel.title or level.title
+                level.description = existingLevel.description or level.description
+                level.hint = existingLevel.hint or level.hint
+                level.footer = existingLevel.footer or level.footer
+                if existingLevel.timeLimit ~= nil then
+                    level.timeLimit = existingLevel.timeLimit
+                end
+            end
             data.level = level
         end
     end

--- a/src/game/map_storage.lua
+++ b/src/game/map_storage.lua
@@ -6,6 +6,7 @@ local USER_MAP_DIR = "maps"
 local BUILTIN_MAP_DIR = "src/game/maps"
 local BUILTIN_TUTORIAL_DIR = BUILTIN_MAP_DIR .. "/tutorial"
 local BUILTIN_CAMPAIGN_DIR = BUILTIN_MAP_DIR .. "/campaign"
+local IMPORT_DUPLICATE_START_INDEX = 2
 
 local function ensureUserMapDirectory()
     if not love.filesystem.getInfo(USER_MAP_DIR, "directory") then
@@ -24,6 +25,15 @@ local function sanitizeFileName(name)
     end
 
     return slug .. ".lua"
+end
+
+local function splitFileName(fileName)
+    local baseName, extension = tostring(fileName or ""):match("^(.*)(%.[^%.]+)$")
+    if baseName then
+        return baseName, extension
+    end
+
+    return tostring(fileName or ""), ""
 end
 
 local function isIdentifier(value)
@@ -203,7 +213,47 @@ local function buildDescriptor(source, fileName, data, options)
         isTemplate = source == "builtin" and data.template == true,
         previewLevel = data.level,
         previewDescription = data.previewDescription or (data.level and (data.level.previewDescription or data.level.description)) or nil,
+        isRemoteImport = type(data.remoteSource) == "table",
+        remoteSource = data.remoteSource,
     }
+end
+
+local function findUserMapFileNameByUuid(mapUuid)
+    if type(mapUuid) ~= "string" or mapUuid == "" then
+        return nil
+    end
+
+    ensureUserMapDirectory()
+    for _, fileName in ipairs(love.filesystem.getDirectoryItems(USER_MAP_DIR)) do
+        if fileName:sub(-4) == ".lua" then
+            local data = mapStorage.loadMap(fileName, "user")
+            if data and data.mapUuid == mapUuid then
+                return fileName
+            end
+        end
+    end
+
+    return nil
+end
+
+local function resolveImportedFileName(name, payload)
+    local mapUuid = type(payload) == "table" and payload.mapUuid or nil
+    local existingFileName = findUserMapFileNameByUuid(mapUuid)
+    if existingFileName then
+        return existingFileName
+    end
+
+    local baseFileName = sanitizeFileName(name)
+    local baseName, extension = splitFileName(baseFileName)
+    local candidateFileName = baseFileName
+    local duplicateIndex = IMPORT_DUPLICATE_START_INDEX
+
+    while love.filesystem.getInfo(USER_MAP_DIR .. "/" .. candidateFileName, "file") do
+        candidateFileName = string.format("%s_%d%s", baseName, duplicateIndex, extension)
+        duplicateIndex = duplicateIndex + 1
+    end
+
+    return candidateFileName
 end
 
 local function listSourceMaps(source, directory, mapKind)
@@ -247,6 +297,26 @@ function mapStorage.saveMap(name, payload)
     end
 
     return buildDescriptor("user", fileName, payload)
+end
+
+function mapStorage.importMap(name, payload)
+    ensureUserMapDirectory()
+
+    local fileName = resolveImportedFileName(name, payload or {})
+    local path = USER_MAP_DIR .. "/" .. fileName
+    local resolvedPayload = payload or {}
+    resolvedPayload.mapUuid = resolvedPayload.mapUuid or uuid.generateV4()
+    if resolvedPayload.level then
+        resolvedPayload.level.id = resolvedPayload.mapUuid
+        resolvedPayload.level.mapUuid = resolvedPayload.mapUuid
+    end
+
+    local ok, writeError = writeMapFile(path, resolvedPayload)
+    if not ok then
+        return nil, writeError
+    end
+
+    return buildDescriptor("user", fileName, resolvedPayload)
 end
 
 function mapStorage.loadMap(fileNameOrDescriptor, source, mapKind, directory)

--- a/src/game/maps/tutorial/01_direct_lever.lua
+++ b/src/game/maps/tutorial/01_direct_lever.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "83ea86be-9245-41c3-8ce3-7c1b1b845b7c",
     name = "Map 1: Direct Lever",
     template = true,
     editor = {

--- a/src/game/maps/tutorial/02_delayed_button.lua
+++ b/src/game/maps/tutorial/02_delayed_button.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "c1b2124c-ed71-4b1e-8ec6-8c56bbb1e0a1",
     name = "Map 2: Delayed Button",
     template = true,
     editor = {

--- a/src/game/maps/tutorial/03_charge_lever.lua
+++ b/src/game/maps/tutorial/03_charge_lever.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "95eac4e5-4297-4a36-a113-231debbeca96",
     name = "Map 3: Charge Lever",
     template = true,
     editor = {

--- a/src/game/maps/tutorial/04_spring_switch.lua
+++ b/src/game/maps/tutorial/04_spring_switch.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "5316d5c9-8e75-4252-8f2f-547bf9e928d3",
     name = "Map 4: Spring Switch",
     template = true,
     editor = {

--- a/src/game/maps/tutorial/05_relay_dial.lua
+++ b/src/game/maps/tutorial/05_relay_dial.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "029e1fd2-e138-4f6e-909f-e52b7005500b",
     name = "Map 5: Relay Dial",
     template = true,
     editor = {

--- a/src/game/maps/tutorial/06_trip_switch.lua
+++ b/src/game/maps/tutorial/06_trip_switch.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "e042a65d-e425-40e0-8c36-43a4acd0d69b",
     name = "Map 6: Trip Switch",
     previewDescription = "One click arms the next passing train only.",
     template = true,

--- a/src/game/maps/tutorial/07_crossbar_dial.lua
+++ b/src/game/maps/tutorial/07_crossbar_dial.lua
@@ -1,5 +1,6 @@
 return {
     version = 1,
+    mapUuid = "e806cef3-7f32-482d-a367-acaa5e470545",
     name = "Map 7: Crossbar Dial",
     previewDescription = "The active input is always routed to the mirrored exit.",
     template = true,

--- a/src/game/profile_storage.lua
+++ b/src/game/profile_storage.lua
@@ -1,0 +1,139 @@
+local profileStorage = {}
+local uuid = require("src.game.uuid")
+
+local PROFILE_FILE = "profile.lua"
+
+local function isIdentifier(value)
+    return type(value) == "string" and value:match("^[%a_][%w_]*$") ~= nil
+end
+
+local function isArray(value)
+    if type(value) ~= "table" then
+        return false
+    end
+
+    local count = 0
+    local maxIndex = 0
+    for key, _ in pairs(value) do
+        if type(key) ~= "number" or key < 1 or key % 1 ~= 0 then
+            return false
+        end
+        count = count + 1
+        if key > maxIndex then
+            maxIndex = key
+        end
+    end
+
+    return count == maxIndex
+end
+
+local function sortedKeys(value)
+    local keys = {}
+    for key, _ in pairs(value) do
+        keys[#keys + 1] = key
+    end
+    table.sort(keys, function(a, b)
+        if type(a) == type(b) then
+            return a < b
+        end
+        return tostring(a) < tostring(b)
+    end)
+    return keys
+end
+
+local function serializeValue(value, indent)
+    local valueType = type(value)
+    indent = indent or 0
+
+    if valueType == "nil" then
+        return "nil"
+    end
+    if valueType == "number" or valueType == "boolean" then
+        return tostring(value)
+    end
+    if valueType == "string" then
+        return string.format("%q", value)
+    end
+    if valueType ~= "table" then
+        error("Unsupported profile value type: " .. valueType)
+    end
+
+    local nextIndent = indent + 4
+    local prefix = string.rep(" ", nextIndent)
+    local closingIndent = string.rep(" ", indent)
+    local lines = { "{" }
+
+    if isArray(value) then
+        for _, entry in ipairs(value) do
+            lines[#lines + 1] = prefix .. serializeValue(entry, nextIndent) .. ","
+        end
+    else
+        for _, key in ipairs(sortedKeys(value)) do
+            local keyText = isIdentifier(key) and key or ("[" .. serializeValue(key, nextIndent) .. "]")
+            lines[#lines + 1] = prefix .. keyText .. " = " .. serializeValue(value[key], nextIndent) .. ","
+        end
+    end
+
+    lines[#lines + 1] = closingIndent .. "}"
+    return table.concat(lines, "\n")
+end
+
+local function sanitizeProfile(profile)
+    local sanitized = {
+        version = 1,
+        playerId = type(profile.playerId) == "string" and profile.playerId or "",
+        playerDisplayName = type(profile.playerDisplayName) == "string" and profile.playerDisplayName or "",
+        debugMode = profile.debugMode == true,
+    }
+
+    if sanitized.playerId == "" then
+        sanitized.playerId = uuid.generatePlayerId()
+    end
+
+    return sanitized
+end
+
+function profileStorage.save(profile)
+    local sanitized = sanitizeProfile(profile or {})
+    local body = "return " .. serializeValue(sanitized) .. "\n"
+    local ok, writeError = love.filesystem.write(PROFILE_FILE, body)
+    if not ok then
+        return nil, writeError or "Profile could not be saved."
+    end
+    return sanitized
+end
+
+function profileStorage.load()
+    local loadedProfile
+
+    if love.filesystem.getInfo(PROFILE_FILE, "file") then
+        local chunk, loadError = love.filesystem.load(PROFILE_FILE)
+        if chunk then
+            local ok, result = pcall(chunk)
+            if ok and type(result) == "table" then
+                loadedProfile = result
+            end
+        elseif loadError then
+            loadedProfile = nil
+        end
+    end
+
+    local sanitized = sanitizeProfile(loadedProfile or {})
+    local needsSave = loadedProfile == nil
+        or loadedProfile.playerId ~= sanitized.playerId
+        or loadedProfile.playerDisplayName ~= sanitized.playerDisplayName
+        or loadedProfile.debugMode ~= sanitized.debugMode
+
+    if needsSave then
+        local savedProfile = profileStorage.save(sanitized)
+        if savedProfile then
+            sanitized = savedProfile
+        end
+    end
+
+    return sanitized
+end
+
+return profileStorage
+
+

--- a/src/game/profile_storage.lua
+++ b/src/game/profile_storage.lua
@@ -2,6 +2,8 @@ local profileStorage = {}
 local uuid = require("src.game.uuid")
 
 local PROFILE_FILE = "profile.lua"
+local PLAYER_ID_PREFIX = "player-"
+local UUID_PATTERN = "^[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+$"
 
 local function isIdentifier(value)
     return type(value) == "string" and value:match("^[%a_][%w_]*$") ~= nil
@@ -78,10 +80,23 @@ local function serializeValue(value, indent)
     return table.concat(lines, "\n")
 end
 
+local function normalizePlayerId(value)
+    if type(value) ~= "string" then
+        return ""
+    end
+
+    local normalizedValue = value:gsub("^" .. PLAYER_ID_PREFIX, "")
+    if normalizedValue:match(UUID_PATTERN) then
+        return string.lower(normalizedValue)
+    end
+
+    return ""
+end
+
 local function sanitizeProfile(profile)
     local sanitized = {
         version = 1,
-        playerId = type(profile.playerId) == "string" and profile.playerId or "",
+        playerId = normalizePlayerId(profile.playerId),
         playerDisplayName = type(profile.playerDisplayName) == "string" and profile.playerDisplayName or "",
         debugMode = profile.debugMode == true,
     }

--- a/src/game/road_types.lua
+++ b/src/game/road_types.lua
@@ -1,0 +1,65 @@
+local roadTypes = {}
+
+roadTypes.DEFAULT_ID = "normal"
+roadTypes.ORDER = {
+    "normal",
+    "fast",
+    "slow",
+}
+
+local ROAD_TYPE_LOOKUP = {
+    normal = {
+        id = "normal",
+        label = "Normal",
+        shortLabel = "N",
+        speedScale = 1.0,
+        pattern = "plain",
+        markerSpacing = 0,
+        markerSize = 0,
+        markerWidth = 0,
+    },
+    fast = {
+        id = "fast",
+        label = "Fast",
+        shortLabel = "F",
+        speedScale = 1.35,
+        pattern = "chevron",
+        markerSpacing = 42,
+        markerSize = 10,
+        markerWidth = 3.5,
+    },
+    slow = {
+        id = "slow",
+        label = "Slow",
+        shortLabel = "S",
+        speedScale = 0.72,
+        pattern = "crossbar",
+        markerSpacing = 24,
+        markerSize = 10,
+        markerWidth = 3.5,
+    },
+}
+
+function roadTypes.normalizeRoadType(roadType)
+    if ROAD_TYPE_LOOKUP[roadType] then
+        return roadType
+    end
+
+    return roadTypes.DEFAULT_ID
+end
+
+function roadTypes.getConfig(roadType)
+    return ROAD_TYPE_LOOKUP[roadTypes.normalizeRoadType(roadType)]
+end
+
+function roadTypes.getOrderedOptions()
+    local options = {}
+
+    for _, roadTypeId in ipairs(roadTypes.ORDER) do
+        options[#options + 1] = ROAD_TYPE_LOOKUP[roadTypeId]
+    end
+
+    return options
+end
+
+return roadTypes

--- a/src/game/simpleboards_client.lua
+++ b/src/game/simpleboards_client.lua
@@ -1,0 +1,205 @@
+local envLoader = require("src.game.env_loader")
+local json = require("src.game.json")
+
+local simpleboardsClient = {}
+
+local SCRIPT_FILE = "simpleboards_request.ps1"
+local REQUEST_FILE = "simpleboards_request.json"
+
+local POWERSHELL_SCRIPT = [[
+param(
+    [string]$Mode,
+    [string]$ApiKey,
+    [string]$LeaderboardId,
+    [string]$BodyPath
+)
+
+$ErrorActionPreference = 'Stop'
+$headers = @{ 'x-api-key' = $ApiKey }
+
+try {
+    if ($Mode -eq 'submit') {
+        $body = Get-Content -Raw -Path $BodyPath
+        $result = Invoke-RestMethod -Method Post -Uri 'https://api.simpleboards.dev/api/entries' -Headers $headers -ContentType 'application/json' -Body $body
+    }
+    elseif ($Mode -eq 'fetch') {
+        $uri = ('https://api.simpleboards.dev/api/leaderboards/{0}/entries' -f $LeaderboardId)
+        $result = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+    }
+    else {
+        throw ('Unsupported mode: ' + $Mode)
+    }
+
+    @{ ok = $true; data = $result } | ConvertTo-Json -Depth 12 -Compress
+}
+catch {
+    $detail = ''
+    if ($_.Exception.Response) {
+        try {
+            $stream = $_.Exception.Response.GetResponseStream()
+            if ($stream) {
+                $reader = New-Object System.IO.StreamReader($stream)
+                $detail = $reader.ReadToEnd()
+            }
+        }
+        catch {
+            $detail = ''
+        }
+    }
+
+    $message = $_.Exception.Message
+    if ($detail -and $detail.Trim().Length -gt 0) {
+        $message = $message + ' | ' + $detail.Trim()
+    }
+
+    @{ ok = $false; error = $message } | ConvertTo-Json -Depth 6 -Compress
+    exit 1
+}
+]]
+
+local function isWindows()
+    return package.config:sub(1, 1) == "\\"
+end
+
+local function absoluteSavePath(relativePath)
+    local separator = package.config:sub(1, 1)
+    return love.filesystem.getSaveDirectory() .. separator .. relativePath:gsub("/", separator)
+end
+
+local function quoteArgument(value)
+    return '"' .. tostring(value or ""):gsub('"', '""') .. '"'
+end
+
+local function ensurePowerShellScript()
+    if not love.filesystem.getInfo(SCRIPT_FILE, "file") then
+        local ok, writeError = love.filesystem.write(SCRIPT_FILE, POWERSHELL_SCRIPT)
+        if not ok then
+            return nil, writeError or "The SimpleBoards helper script could not be written."
+        end
+    end
+
+    return absoluteSavePath(SCRIPT_FILE)
+end
+
+local function runCommand(command)
+    local handle = io.popen(command .. " 2>&1")
+    if not handle then
+        return nil, "PowerShell could not be started."
+    end
+
+    local output = handle:read("*a") or ""
+    handle:close()
+    return output
+end
+
+local function normalizeRemoteErrorMessage(message)
+    local text = tostring(message or "")
+    local lowerText = string.lower(text)
+
+    if lowerText:find("key not found", 1, true) then
+        return "SimpleBoards could not find this key. Check whether API_KEY and LEADERBOARD_ID are correct and belong to the same leaderboard."
+    end
+
+    return text ~= "" and text or "The online request failed."
+end
+
+local function runPowerShell(mode, config, payload)
+    if not isWindows() then
+        return nil, "Online score sync currently requires Windows PowerShell."
+    end
+
+    local scriptPath, scriptError = ensurePowerShellScript()
+    if not scriptPath then
+        return nil, scriptError
+    end
+
+    local requestPath
+    if payload ~= nil then
+        local requestBody = json.encode(payload)
+        local ok, writeError = love.filesystem.write(REQUEST_FILE, requestBody)
+        if not ok then
+            return nil, writeError or "The score payload could not be written."
+        end
+        requestPath = absoluteSavePath(REQUEST_FILE)
+    end
+
+    local command = table.concat({
+        "powershell.exe -NoProfile -ExecutionPolicy Bypass -File",
+        quoteArgument(scriptPath),
+        "-Mode",
+        quoteArgument(mode),
+        "-ApiKey",
+        quoteArgument(config.apiKey),
+        "-LeaderboardId",
+        quoteArgument(config.leaderboardId),
+        "-BodyPath",
+        quoteArgument(requestPath or ""),
+    }, " ")
+
+    local output, runError = runCommand(command)
+    if not output then
+        return nil, runError
+    end
+
+    local response, decodeError = json.decode(output)
+    if not response then
+        return nil, normalizeRemoteErrorMessage(decodeError or output)
+    end
+
+    if response.ok ~= true then
+        return nil, normalizeRemoteErrorMessage(response.error)
+    end
+
+    return response.data
+end
+
+local function normalizeConfig(config)
+    local resolvedConfig = config or envLoader.load()
+    if not resolvedConfig.isConfigured then
+        return nil, table.concat(resolvedConfig.errors or { "SimpleBoards is not configured." }, " ")
+    end
+    return resolvedConfig
+end
+
+function simpleboardsClient.getConfig()
+    return envLoader.load()
+end
+
+function simpleboardsClient.submitScore(submission, config)
+    local resolvedConfig, configError = normalizeConfig(config)
+    if not resolvedConfig then
+        return nil, configError
+    end
+
+    local payload = {
+        leaderboardId = resolvedConfig.leaderboardId,
+        playerId = submission.playerId,
+        playerDisplayName = submission.playerDisplayName,
+        score = tostring(submission.score or "0"),
+        metadata = submission.metadata or "",
+    }
+
+    return runPowerShell("submit", resolvedConfig, payload)
+end
+
+function simpleboardsClient.fetchLeaderboard(config)
+    local resolvedConfig, configError = normalizeConfig(config)
+    if not resolvedConfig then
+        return nil, configError
+    end
+
+    local response, fetchError = runPowerShell("fetch", resolvedConfig)
+    if not response then
+        return nil, fetchError or "The leaderboard could not be loaded."
+    end
+
+    if type(response) == "table" and type(response.entries) == "table" then
+        return response.entries
+    end
+
+    return response
+end
+
+return simpleboardsClient
+
+

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -61,6 +61,54 @@ local PLAY_OVERLAY = {
     sectionGap = 14,
 }
 
+local MENU_LAYOUT = {
+    buttonWidth = 320,
+    buttonHeight = 56,
+    buttonGap = 16,
+    firstButtonY = 248,
+    debugMarginX = 36,
+    debugMarginY = 36,
+    debugWidth = 240,
+    debugHeight = 48,
+    footerY = 654,
+}
+
+local LEADERBOARD_LOADING = {
+    spinnerRadius = 18,
+    spinnerThickness = 4,
+    spinnerArcLength = math.pi * 1.35,
+    spinnerSpeed = 3.2,
+    emptyStateYOffset = 180,
+    emptySpinnerYOffset = 34,
+    emptyTextYOffset = 68,
+}
+
+local LEADERBOARD_LAYOUT = {
+    panelX = 36,
+    panelY = 100,
+    panelMargin = 72,
+    contentPadding = 28,
+    titlePadding = 24,
+    headerY = 116,
+    rowYOffset = 28,
+    rowHeight = 34,
+    rowGap = 8,
+    rowRadius = 10,
+    rankWidth = 40,
+    mapGap = 28,
+    mapWidth = 260,
+    playerXOffset = 52,
+    playerRightPadding = 36,
+    scoreWidth = 120,
+    tooltipWidth = 360,
+    tooltipHeight = 62,
+    tooltipOffsetY = 18,
+    filterBadgeY = 74,
+    filterBadgeHeight = 28,
+    filterBadgePaddingX = 16,
+    filterBadgeMaxWidth = 460,
+}
+
 local function pointInRect(x, y, rect)
     return x >= rect.x
         and x <= rect.x + rect.w
@@ -115,6 +163,143 @@ local function drawMetalPanel(rect, innerAlpha)
     graphics.setColor(PANEL_COLORS.panelInnerLine[1], PANEL_COLORS.panelInnerLine[2], PANEL_COLORS.panelInnerLine[3], PANEL_COLORS.panelInnerLine[4])
     graphics.rectangle("line", rect.x + 4, rect.y + 4, rect.w - 8, rect.h - 8, 17, 17)
     graphics.setLineWidth(1)
+end
+
+local function drawLoadingSpinner(centerX, centerY, color)
+    local graphics = love.graphics
+    local tint = color or { 0.48, 0.92, 0.62, 1 }
+    local startAngle = (love.timer.getTime() or 0) * LEADERBOARD_LOADING.spinnerSpeed
+    local endAngle = startAngle + LEADERBOARD_LOADING.spinnerArcLength
+
+    graphics.setColor(tint[1], tint[2], tint[3], tint[4] or 1)
+    graphics.setLineWidth(LEADERBOARD_LOADING.spinnerThickness)
+    graphics.arc("line", "open", centerX, centerY, LEADERBOARD_LOADING.spinnerRadius, startAngle, endAngle)
+    graphics.setLineWidth(1)
+end
+
+local function getLeaderboardPanelRect(game)
+    return {
+        x = LEADERBOARD_LAYOUT.panelX,
+        y = LEADERBOARD_LAYOUT.panelY,
+        w = game.viewport.w - LEADERBOARD_LAYOUT.panelMargin,
+        h = game.viewport.h - 148,
+    }
+end
+
+local function shouldShowLeaderboardMapColumn(game)
+    local state = game.leaderboardState or {}
+    return state.scope == "global"
+end
+
+local function getLeaderboardContentLayout(game)
+    local panel = getLeaderboardPanelRect(game)
+    local contentX = panel.x + LEADERBOARD_LAYOUT.contentPadding
+    local contentW = panel.w - (LEADERBOARD_LAYOUT.contentPadding * 2)
+    local scoreX = contentX + math.floor((contentW - LEADERBOARD_LAYOUT.scoreWidth) * 0.5 + 0.5)
+    local mapX = scoreX + LEADERBOARD_LAYOUT.scoreWidth + LEADERBOARD_LAYOUT.mapGap
+    local playerX = contentX + LEADERBOARD_LAYOUT.playerXOffset
+    local playerRightEdge = shouldShowLeaderboardMapColumn(game)
+        and (mapX - LEADERBOARD_LAYOUT.mapGap)
+        or scoreX
+    local playerWidth = playerRightEdge - playerX - LEADERBOARD_LAYOUT.playerRightPadding
+
+    return {
+        panel = panel,
+        contentX = contentX,
+        contentW = contentW,
+        mapX = mapX,
+        scoreX = scoreX,
+        playerX = playerX,
+        playerWidth = playerWidth,
+    }
+end
+
+local function getLeaderboardFilterBadgeRect(game)
+    local panel = getLeaderboardPanelRect(game)
+    local filterText = game.leaderboardMapUuid
+        and string.format("Current Map: %s", game:getMapNameByUuid(game.leaderboardMapUuid))
+        or "All Maps"
+    local badgeWidth = math.min(
+        LEADERBOARD_LAYOUT.filterBadgeMaxWidth,
+        game.fonts.small:getWidth(filterText) + (LEADERBOARD_LAYOUT.filterBadgePaddingX * 2)
+    )
+
+    return {
+        x = panel.x + math.floor((panel.w - badgeWidth) * 0.5 + 0.5),
+        y = panel.y + LEADERBOARD_LAYOUT.filterBadgeY,
+        w = badgeWidth,
+        h = LEADERBOARD_LAYOUT.filterBadgeHeight,
+        text = filterText,
+    }
+end
+
+local function buildLeaderboardRowRects(game, entries)
+    local layout = getLeaderboardContentLayout(game)
+    local rects = {}
+    local maxEntries = math.min(12, #(entries or {}))
+    local rowY = layout.panel.y + LEADERBOARD_LAYOUT.headerY + LEADERBOARD_LAYOUT.rowYOffset
+
+    for index = 1, maxEntries do
+        local entry = entries[index]
+        local rowRect = {
+            entry = entry,
+            row = {
+                x = layout.contentX,
+                y = rowY - 6,
+                w = layout.contentW,
+                h = LEADERBOARD_LAYOUT.rowHeight,
+            },
+            player = {
+                x = layout.playerX,
+                y = rowY,
+                w = layout.playerWidth,
+                h = game.fonts.small:getHeight() + 8,
+            },
+            map = shouldShowLeaderboardMapColumn(game) and {
+                x = layout.mapX,
+                y = rowY,
+                w = LEADERBOARD_LAYOUT.mapWidth,
+                h = game.fonts.small:getHeight() + 8,
+            } or nil,
+        }
+
+        rects[#rects + 1] = rowRect
+        rowY = rowY + LEADERBOARD_LAYOUT.rowHeight + LEADERBOARD_LAYOUT.rowGap
+    end
+
+    return rects
+end
+
+local function drawLeaderboardTooltip(game, hoverInfo)
+    if not hoverInfo or not hoverInfo.text or hoverInfo.text == "" then
+        return
+    end
+
+    local graphics = love.graphics
+    local tooltipX = math.min(game.viewport.w - LEADERBOARD_LAYOUT.tooltipWidth - 24, math.max(24, hoverInfo.x - (LEADERBOARD_LAYOUT.tooltipWidth * 0.5)))
+    local tooltipY = math.min(game.viewport.h - LEADERBOARD_LAYOUT.tooltipHeight - 24, hoverInfo.y + LEADERBOARD_LAYOUT.tooltipOffsetY)
+
+    graphics.setColor(0.06, 0.08, 0.12, 0.98)
+    graphics.rectangle("fill", tooltipX, tooltipY, LEADERBOARD_LAYOUT.tooltipWidth, LEADERBOARD_LAYOUT.tooltipHeight, 14, 14)
+    graphics.setColor(0.32, 0.42, 0.52, 1)
+    graphics.rectangle("line", tooltipX, tooltipY, LEADERBOARD_LAYOUT.tooltipWidth, LEADERBOARD_LAYOUT.tooltipHeight, 14, 14)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf(hoverInfo.label, tooltipX + 16, tooltipY + 10, LEADERBOARD_LAYOUT.tooltipWidth - 32, "left")
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(hoverInfo.text, tooltipX + 16, tooltipY + 28, LEADERBOARD_LAYOUT.tooltipWidth - 32, "left")
+end
+
+local function getMenuDebugButton(game)
+    return {
+        id = "debug",
+        x = MENU_LAYOUT.debugMarginX,
+        y = game.viewport.h - MENU_LAYOUT.debugMarginY - MENU_LAYOUT.debugHeight,
+        w = MENU_LAYOUT.debugWidth,
+        h = MENU_LAYOUT.debugHeight,
+        label = game:isDebugModeEnabled() and "Debug Mode: On" or "Debug Mode: Off",
+    }
 end
 
 local function getPlayInfoOverlayRect(game)
@@ -978,46 +1163,39 @@ local function drawLevelSelectEmptyState(game, filterId)
 end
 
 local function getMenuButtons(game)
-    local centerX = game.viewport.w * 0.5 - 160
+    local centerX = math.floor((game.viewport.w - MENU_LAYOUT.buttonWidth) * 0.5 + 0.5)
+    local buttonY = MENU_LAYOUT.firstButtonY
     return {
         {
             id = "play",
             x = centerX,
-            y = 248,
-            w = 320,
-            h = 56,
+            y = buttonY,
+            w = MENU_LAYOUT.buttonWidth,
+            h = MENU_LAYOUT.buttonHeight,
             label = "Level Select",
         },
         {
             id = "leaderboard",
             x = centerX,
-            y = 320,
-            w = 320,
-            h = 56,
+            y = buttonY + MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap,
+            w = MENU_LAYOUT.buttonWidth,
+            h = MENU_LAYOUT.buttonHeight,
             label = "Online Leaderboard",
         },
         {
             id = "editor",
             x = centerX,
-            y = 392,
-            w = 320,
-            h = 56,
+            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 2),
+            w = MENU_LAYOUT.buttonWidth,
+            h = MENU_LAYOUT.buttonHeight,
             label = "Map Editor",
-        },
-        {
-            id = "debug",
-            x = centerX,
-            y = 464,
-            w = 320,
-            h = 56,
-            label = game:isDebugModeEnabled() and "Debug Mode: On" or "Debug Mode: Off",
         },
         {
             id = "quit",
             x = centerX,
-            y = 536,
-            w = 320,
-            h = 56,
+            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 3),
+            w = MENU_LAYOUT.buttonWidth,
+            h = MENU_LAYOUT.buttonHeight,
             label = "Quit",
         },
     }
@@ -1035,7 +1213,6 @@ end
 local function getLeaderboardActionRects(game)
     return {
         back = { x = 42, y = 38, w = 148, h = 42 },
-        refresh = { x = game.viewport.w - 190, y = 38, w = 148, h = 42 },
     }
 end
 
@@ -1064,6 +1241,10 @@ function ui.getMenuActionAt(game, x, y)
         end
     end
 
+    if pointInRect(x, y, getMenuDebugButton(game)) then
+        return "debug"
+    end
+
     return nil
 end
 
@@ -1079,9 +1260,65 @@ function ui.getLeaderboardActionAt(game, x, y)
     if pointInRect(x, y, buttons.back) then
         return "back"
     end
-    if pointInRect(x, y, buttons.refresh) then
-        return "refresh"
+    if pointInRect(x, y, getLeaderboardFilterBadgeRect(game)) then
+        return "cycle_filter"
     end
+    return nil
+end
+
+function ui.getLeaderboardHoverInfoAt(game, x, y)
+    local state = game.leaderboardState or { entries = {} }
+    local rowRects = buildLeaderboardRowRects(game, state.entries or {})
+
+    for _, rowRect in ipairs(rowRects) do
+        if pointInRect(x, y, rowRect.player) then
+            return {
+                x = x,
+                y = y,
+                label = "Player ID",
+                text = rowRect.entry.playerUuid or "No player ID",
+            }
+        end
+
+        if rowRect.map and pointInRect(x, y, rowRect.map) then
+            local mapCount = tonumber(rowRect.entry.mapCount) or 0
+            local mapLabel = mapCount > 1
+                and string.format("Latest map UUID, %d maps total", mapCount)
+                or "Latest map UUID"
+            return {
+                x = x,
+                y = y,
+                label = mapLabel,
+                text = rowRect.entry.mapUuid or "No map UUID",
+            }
+        end
+    end
+
+    if pointInRect(x, y, getLeaderboardFilterBadgeRect(game)) then
+        return {
+            x = x,
+            y = y,
+            label = game.leaderboardMapUuid and "Map UUID" or "Map Filter",
+            text = game.leaderboardMapUuid or "Click to cycle through all maps.",
+        }
+    end
+
+    return nil
+end
+
+function ui.getLeaderboardMapHitAt(game, x, y)
+    local state = game.leaderboardState or { entries = {} }
+    local rowRects = buildLeaderboardRowRects(game, state.entries or {})
+
+    for _, rowRect in ipairs(rowRects) do
+        if rowRect.map and pointInRect(x, y, rowRect.map) and rowRect.entry.mapUuid and rowRect.entry.mapUuid ~= "" then
+            return {
+                mapUuid = rowRect.entry.mapUuid,
+                mapName = rowRect.entry.mapName,
+            }
+        end
+    end
+
     return nil
 end
 
@@ -1199,6 +1436,7 @@ end
 function ui.drawMenu(game)
     local graphics = love.graphics
     local buttons = getMenuButtons(game)
+    local debugButton = getMenuDebugButton(game)
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -1221,31 +1459,16 @@ function ui.drawMenu(game)
         "center"
     )
 
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.72, 0.78, 0.84, 1)
-    graphics.printf(
-        string.format("Signed in as %s", game.profile and game.profile.playerDisplayName or "Unknown"),
-        0,
-        220,
-        game.viewport.w,
-        "center"
-    )
-
-    local onlineText = game.onlineConfig and game.onlineConfig.isConfigured and "Online sync ready" or "Online sync needs API_KEY + LEADERBOARD_ID in .env"
-    local onlineColor = game.onlineConfig and game.onlineConfig.isConfigured and { 0.48, 0.92, 0.62, 1 } or { 0.99, 0.78, 0.32, 1 }
-    graphics.setColor(onlineColor[1], onlineColor[2], onlineColor[3], onlineColor[4])
-    graphics.printf(onlineText, 0, 238, game.viewport.w, "center")
-
     for _, rect in ipairs(buttons) do
-        local strokeColor = rect.id == "debug"
-            and (game:isDebugModeEnabled() and { 0.99, 0.78, 0.32, 1 } or { 0.3, 0.42, 0.54, 1 })
-            or { 0.48, 0.92, 0.62, 1 }
-        drawButton(rect, rect.label, { 0.09, 0.11, 0.15, 0.98 }, strokeColor, game.fonts.body)
+        drawButton(rect, rect.label, { 0.09, 0.11, 0.15, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
     end
 
+    local debugStrokeColor = game:isDebugModeEnabled() and { 0.99, 0.78, 0.32, 1 } or { 0.3, 0.42, 0.54, 1 }
+    drawButton(debugButton, debugButton.label, { 0.09, 0.11, 0.15, 0.98 }, debugStrokeColor, game.fonts.small)
+
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(0.72, 0.78, 0.84, 1)
-    graphics.printf("Enter starts. L opens the leaderboard. D toggles debug mode. Esc quits.", 0, 654, game.viewport.w, "center")
+    graphics.printf("Enter starts. L opens the leaderboard. D toggles debug mode. Esc quits.", 0, MENU_LAYOUT.footerY, game.viewport.w, "center")
 end
 
 function ui.drawProfileSetup(game)
@@ -1316,86 +1539,109 @@ end
 
 function ui.drawLeaderboard(game)
     local graphics = love.graphics
-    local panel = {
-        x = 36,
-        y = 100,
-        w = game.viewport.w - 72,
-        h = game.viewport.h - 148,
-    }
+    local layout = getLeaderboardContentLayout(game)
+    local panel = layout.panel
     local buttons = getLeaderboardActionRects(game)
     local state = game.leaderboardState or { status = "idle", entries = {} }
-    local contentX = panel.x + 28
-    local contentW = panel.w - 56
+    local hasEntries = #(state.entries or {}) > 0
+    local contentX = layout.contentX
+    local contentW = layout.contentW
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
     drawMetalPanel(panel, 0.98)
 
     drawButton(buttons.back, "Back", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.42, 0.54, 1 }, game.fonts.small)
-    drawButton(buttons.refresh, "Refresh", { 0.1, 0.14, 0.18, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.small)
 
     love.graphics.setFont(game.fonts.title)
     graphics.setColor(0.97, 0.98, 1, 1)
     graphics.printf(game.leaderboardTitle or "Online Leaderboard", panel.x + 24, panel.y + 24, panel.w - 48, "center")
 
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.84, 0.88, 0.92, 1)
-    local subtitle = game.leaderboardMapUuid and "Filtered to the current map's UUID." or "Showing all downloaded SimpleBoards entries."
-    graphics.printf(subtitle, panel.x + 24, panel.y + 70, panel.w - 48, "center")
+    local badgeRect = getLeaderboardFilterBadgeRect(game)
 
-    if state.status ~= "ready" then
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.1, 0.14, 0.18, 0.98)
+    graphics.rectangle("fill", badgeRect.x, badgeRect.y, badgeRect.w, badgeRect.h, 14, 14)
+    graphics.setColor(game.leaderboardMapUuid and 0.56 or 0.3, game.leaderboardMapUuid and 0.72 or 0.42, game.leaderboardMapUuid and 0.98 or 0.54, 1)
+    graphics.rectangle("line", badgeRect.x, badgeRect.y, badgeRect.w, badgeRect.h, 14, 14)
+    graphics.setColor(0.9, 0.94, 0.98, 1)
+    graphics.printf(
+        badgeRect.text,
+        badgeRect.x + LEADERBOARD_LAYOUT.filterBadgePaddingX,
+        badgeRect.y + 6,
+        badgeRect.w - (LEADERBOARD_LAYOUT.filterBadgePaddingX * 2),
+        "center"
+    )
+
+    if state.status ~= "ready" and not hasEntries then
+        if state.status == "loading" then
+            drawLoadingSpinner(
+                panel.x + panel.w * 0.5,
+                panel.y + LEADERBOARD_LOADING.emptyStateYOffset + LEADERBOARD_LOADING.emptySpinnerYOffset,
+                { 0.48, 0.92, 0.62, 1 }
+            )
+        end
+
         love.graphics.setFont(game.fonts.body)
-        graphics.setColor(0.99, 0.78, 0.32, 1)
-        graphics.printf(state.message or "The leaderboard is not ready.", contentX, panel.y + 180, contentW, "center")
+        graphics.setColor(state.status == "loading" and 0.84 or 0.99, state.status == "loading" and 0.88 or 0.78, state.status == "loading" and 0.92 or 0.32, 1)
+        graphics.printf(
+            state.message or "The leaderboard is not ready.",
+            contentX,
+            panel.y + LEADERBOARD_LOADING.emptyStateYOffset + LEADERBOARD_LOADING.emptyTextYOffset,
+            contentW,
+            "center"
+        )
         return
     end
 
-    if #(state.entries or {}) == 0 then
+    if not hasEntries then
         love.graphics.setFont(game.fonts.body)
         graphics.setColor(0.84, 0.88, 0.92, 1)
         graphics.printf(state.message or "No entries are available yet.", contentX, panel.y + 180, contentW, "center")
         return
     end
 
-    local headerY = panel.y + 116
+    local headerY = panel.y + LEADERBOARD_LAYOUT.headerY
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(0.68, 0.74, 0.8, 1)
     graphics.print("#", contentX, headerY)
-    graphics.print("Player", contentX + 52, headerY)
-    graphics.printf("Score", contentX + contentW - 180, headerY, 80, "right")
-    graphics.printf(game.leaderboardMapUuid and "Created" or "Map UUID", contentX + contentW - 96, headerY, 96, "right")
-
-    local rowY = headerY + 28
-    local maxEntries = math.min(12, #(state.entries or {}))
-    for index = 1, maxEntries do
-        local entry = state.entries[index]
-        graphics.setColor(0.1, 0.13, 0.17, 0.94)
-        graphics.rectangle("fill", contentX, rowY - 6, contentW, 34, 10, 10)
-        graphics.setColor(0.26, 0.34, 0.42, 1)
-        graphics.rectangle("line", contentX, rowY - 6, contentW, 34, 10, 10)
-
-        graphics.setColor(0.97, 0.98, 1, 1)
-        graphics.print(tostring(index), contentX + 12, rowY + 2)
-        graphics.printf(entry.playerDisplayName or "Unknown", contentX + 52, rowY + 2, contentW - 260, "left")
-        graphics.printf(formatScore(entry.score or 0), contentX + contentW - 180, rowY + 2, 80, "right")
-
-        local tailText = game.leaderboardMapUuid and (entry.createdAt or "-") or ((entry.mapUuid and entry.mapUuid:sub(1, 8)) or "-")
-        graphics.setColor(0.72, 0.78, 0.84, 1)
-        graphics.printf(tailText, contentX + contentW - 96, rowY + 2, 96, "right")
-
-        rowY = rowY + 42
+    graphics.print("Player", layout.playerX, headerY)
+    graphics.printf("Score", layout.scoreX, headerY, LEADERBOARD_LAYOUT.scoreWidth, "center")
+    if shouldShowLeaderboardMapColumn(game) then
+        graphics.printf("Latest Map", layout.mapX, headerY, LEADERBOARD_LAYOUT.mapWidth, "left")
     end
 
-    if #(state.entries or {}) > maxEntries then
+    local rowRects = buildLeaderboardRowRects(game, state.entries or {})
+    for _, rowRect in ipairs(rowRects) do
+        local entry = rowRect.entry
+        local rowY = rowRect.player.y
+        graphics.setColor(0.1, 0.13, 0.17, 0.94)
+        graphics.rectangle("fill", rowRect.row.x, rowRect.row.y, rowRect.row.w, rowRect.row.h, LEADERBOARD_LAYOUT.rowRadius, LEADERBOARD_LAYOUT.rowRadius)
+        graphics.setColor(0.26, 0.34, 0.42, 1)
+        graphics.rectangle("line", rowRect.row.x, rowRect.row.y, rowRect.row.w, rowRect.row.h, LEADERBOARD_LAYOUT.rowRadius, LEADERBOARD_LAYOUT.rowRadius)
+
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print(tostring(entry.rank or 0), contentX + 12, rowY + 2)
+        graphics.printf(entry.playerDisplayName or "Unknown", rowRect.player.x, rowY + 2, rowRect.player.w, "left")
+        graphics.printf(formatScore(entry.score or 0), layout.scoreX, rowY + 2, LEADERBOARD_LAYOUT.scoreWidth, "center")
+        if rowRect.map then
+            graphics.setColor(0.72, 0.78, 0.84, 1)
+            graphics.printf(entry.mapName or "Unknown Map", rowRect.map.x, rowY + 2, rowRect.map.w, "left")
+        end
+    end
+
+    if #(state.entries or {}) > #rowRects then
         graphics.setColor(0.68, 0.74, 0.8, 1)
         graphics.printf(
-            string.format("%d more entry/entries hidden. Refresh later to compare again.", #(state.entries or {}) - maxEntries),
+            string.format("%d more entry/entries hidden.", #(state.entries or {}) - #rowRects),
             contentX,
             panel.y + panel.h - 44,
             contentW,
             "center"
         )
     end
+
+    drawLeaderboardTooltip(game, game.leaderboardHoverInfo)
 end
 
 function ui.drawLevelSelect(game)
@@ -1589,7 +1835,7 @@ function ui.drawResults(game)
     love.graphics.setFont(game.fonts.small)
     local onlineState = game.resultsOnlineState or {}
     local onlineColor = { 0.72, 0.78, 0.84, 1 }
-    if onlineState.status == "submitted" then
+    if onlineState.status == "submitted" or onlineState.status == "kept" then
         onlineColor = { 0.48, 0.92, 0.62, 1 }
     elseif onlineState.status == "error" or onlineState.status == "disabled" then
         onlineColor = { 0.99, 0.78, 0.32, 1 }

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -15,6 +15,30 @@ local LEVEL_SELECT = {
     bottomBarH = 92,
 }
 
+local LEVEL_SELECT_ACTION_LAYOUT = {
+    buttonH = 42,
+    buttonGap = 18,
+    startW = 170,
+    editW = 148,
+    toggleW = 188,
+    uploadW = 170,
+    downloadW = 170,
+    refreshW = 148,
+}
+
+local MARKETPLACE_LAYOUT = {
+    searchW = 460,
+    searchH = 42,
+    browseResultLimit = 10,
+    searchResultLimit = 5,
+    cardIndicatorInset = 14,
+    cardIndicatorH = 28,
+    cardIndicatorRadius = 14,
+    titleMetaTop = 48,
+}
+local MARKETPLACE_REMOTE_SOURCE = "remote"
+local MARKETPLACE_REMOTE_CATEGORY_USERS = "users"
+
 local PREVIEW_COLORS = {
     background = { 0.06, 0.09, 0.12, 1 },
     frame = { 0.24, 0.32, 0.4, 1 },
@@ -51,6 +75,13 @@ local PANEL_COLORS = {
     bodyText = { 0.84, 0.88, 0.92, 1 },
     mutedText = { 0.68, 0.74, 0.8, 1 },
 }
+
+local getLevelSelectActionButtons
+local getMapControlTypes
+local buildMarketplaceDisplayEntries
+local getLevelSelectFilterRect
+local getMarketplaceEntryForDescriptor
+local getMarketplaceIndicatorColors
 
 local PLAY_OVERLAY = {
     margin = 24,
@@ -134,6 +165,10 @@ end
 
 local function lerp(a, b, t)
     return a + ((b - a) * t)
+end
+
+local function trim(value)
+    return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
 end
 
 local function drawButton(rect, label, fillColor, strokeColor, font)
@@ -629,6 +664,15 @@ local function getLevelSelectFilterSegments()
 end
 
 local function getLevelSelectMaps(game)
+    if game.levelSelectMode == "marketplace" then
+        local marketplaceEntries = buildMarketplaceDisplayEntries(game)
+        local maps = {}
+        for _, entry in ipairs(marketplaceEntries) do
+            maps[#maps + 1] = entry.descriptor
+        end
+        return maps
+    end
+
     local maps = {}
     local filterId = game.levelSelectFilter or "all"
 
@@ -663,6 +707,215 @@ local function getSelectedMapIndex(game, maps)
     return fallbackIndex
 end
 
+local function getLevelSelectChromeRect(game)
+    return {
+        x = 2,
+        y = 2,
+        w = game.viewport.w - 4,
+        h = LEVEL_SELECT.chromeH,
+    }
+end
+
+local function getLevelSelectBottomBarRect(game)
+    return {
+        x = 2,
+        y = LEVEL_SELECT.bottomBarY,
+        w = game.viewport.w - 4,
+        h = LEVEL_SELECT.bottomBarH,
+    }
+end
+
+local function getMarketplaceTabSegments()
+    return {
+        { id = "top", label = "Top Maps" },
+        { id = "random", label = "Random" },
+        { id = "search", label = "Search" },
+    }
+end
+
+local function getMarketplaceTabsRect(game)
+    local filterRect = getLevelSelectFilterRect(game)
+    return {
+        x = filterRect.x,
+        y = filterRect.y,
+        w = filterRect.w,
+        h = filterRect.h,
+    }
+end
+
+local function getMarketplaceSearchRect(game)
+    local chromeRect = getLevelSelectChromeRect(game)
+    return {
+        x = math.floor(game.viewport.w * 0.5 - MARKETPLACE_LAYOUT.searchW * 0.5 + 0.5),
+        y = chromeRect.y + math.floor((chromeRect.h - MARKETPLACE_LAYOUT.searchH) * 0.5 + 0.5),
+        w = MARKETPLACE_LAYOUT.searchW,
+        h = MARKETPLACE_LAYOUT.searchH,
+    }
+end
+
+local function getLevelSelectModeButtonRect(game)
+    for _, button in ipairs(getLevelSelectActionButtons(game)) do
+        if button.id == "toggle_mode" then
+            return button
+        end
+    end
+
+    return nil
+end
+
+local function getMarketplaceHash(text)
+    local hash = 0
+    for index = 1, #text do
+        hash = (hash * 33 + text:byte(index)) % 2147483647
+    end
+    return hash
+end
+
+local function normalizeMarketplaceMapKind(category)
+    local normalizedCategory = string.lower(trim(category or ""))
+    if normalizedCategory == "tutorial" then
+        return "tutorial"
+    end
+    if normalizedCategory == "campaign" then
+        return "campaign"
+    end
+    if normalizedCategory == MARKETPLACE_REMOTE_CATEGORY_USERS then
+        return "user"
+    end
+
+    return "user"
+end
+
+local function buildMarketplaceDescriptor(entry)
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    local remoteMap = type(entry.map) == "table" and entry.map or {}
+    local mapUuid = tostring(entry.map_uuid or "")
+    if mapUuid ~= "" then
+        remoteMap.id = remoteMap.id or mapUuid
+        remoteMap.mapUuid = remoteMap.mapUuid or mapUuid
+    end
+
+    local displayName = tostring(entry.map_name or "Untitled Map")
+    return {
+        id = string.format(
+            "%s:%s:%s",
+            MARKETPLACE_REMOTE_SOURCE,
+            tostring(entry.creator_uuid or "unknown"),
+            mapUuid ~= "" and mapUuid or tostring(entry.internal_identifier or "map")
+        ),
+        mapUuid = mapUuid,
+        source = MARKETPLACE_REMOTE_SOURCE,
+        name = displayName,
+        displayName = displayName,
+        mapKind = normalizeMarketplaceMapKind(entry.map_category),
+        savedAt = entry.updated_at,
+        hasEditor = false,
+        hasLevel = type(entry.map) == "table",
+        hasErrors = false,
+        isTemplate = false,
+        previewLevel = remoteMap,
+        previewDescription = remoteMap.previewDescription or remoteMap.description or nil,
+        remoteSourceEntry = entry,
+    }
+end
+
+local function getMarketplaceControlsSummary(descriptor)
+    local labels = {}
+    for _, controlType in ipairs(getMapControlTypes(descriptor)) do
+        labels[#labels + 1] = CONTROL_SHORT_LABELS[controlType] or controlType
+    end
+    if #labels == 0 then
+        return "No control tags"
+    end
+    return table.concat(labels, ", ")
+end
+
+local function buildMarketplaceEntries(game)
+    local entries = {}
+    for _, sourceEntry in ipairs(game:getMarketplaceEntries() or {}) do
+        local descriptor = buildMarketplaceDescriptor(sourceEntry)
+        if descriptor then
+            local displayName = getMapDisplayName(descriptor)
+            local kindLabel = getMapKindLabel(descriptor)
+            local controlsSummary = getMarketplaceControlsSummary(descriptor)
+            entries[#entries + 1] = {
+                descriptor = descriptor,
+                title = displayName,
+                subtitle = string.format("%s  |  %s", kindLabel, controlsSummary),
+                creatorDisplayName = tostring(sourceEntry.creator_display_name or "Unknown"),
+                creatorUuid = tostring(sourceEntry.creator_uuid or ""),
+                favoriteCount = tonumber(sourceEntry.favorite_count or 0) or 0,
+                internalIdentifier = tostring(sourceEntry.internal_identifier or ""),
+                featuredWeight = tonumber(sourceEntry.favorite_count or 0) or 0,
+                randomWeight = getMarketplaceHash(table.concat({
+                    tostring(sourceEntry.map_uuid or ""),
+                    tostring(sourceEntry.internal_identifier or ""),
+                    tostring(sourceEntry.creator_uuid or ""),
+                }, ":")),
+            }
+        end
+    end
+
+    return entries
+end
+
+buildMarketplaceDisplayEntries = function(game)
+    local entries = buildMarketplaceEntries(game)
+    local tabId = game.levelSelectMarketplaceTab or "top"
+    local searchQuery = string.lower((game.levelSelectMarketplaceSearchQuery or ""):gsub("^%s+", ""):gsub("%s+$", ""))
+
+    if tabId == "top" then
+        table.sort(entries, function(a, b)
+            if a.featuredWeight ~= b.featuredWeight then
+                return a.featuredWeight > b.featuredWeight
+            end
+            return a.title < b.title
+        end)
+    elseif tabId == "random" then
+        table.sort(entries, function(a, b)
+            if a.randomWeight ~= b.randomWeight then
+                return a.randomWeight < b.randomWeight
+            end
+            return a.title < b.title
+        end)
+    end
+
+    for index, entry in ipairs(entries) do
+        entry.position = index
+        if tabId == "top" then
+            entry.positionLabel = string.format("#%d", index)
+        elseif tabId == "random" then
+            entry.positionLabel = string.format("Rnd %d", index)
+        else
+            entry.positionLabel = string.format("Hit %d", index)
+        end
+    end
+
+    if tabId == "search" then
+        local limitedEntries = {}
+        for index, entry in ipairs(entries) do
+            if index > MARKETPLACE_LAYOUT.searchResultLimit then
+                break
+            end
+            limitedEntries[#limitedEntries + 1] = entry
+        end
+        return limitedEntries, #entries, searchQuery
+    end
+
+    local limitedEntries = {}
+    for index, entry in ipairs(entries) do
+        if index > MARKETPLACE_LAYOUT.browseResultLimit then
+            break
+        end
+        limitedEntries[#limitedEntries + 1] = entry
+    end
+
+    return limitedEntries, #entries, searchQuery
+end
+
 local function appendUniqueControl(controls, seen, controlType)
     if controlType and not seen[controlType] then
         seen[controlType] = true
@@ -670,7 +923,7 @@ local function appendUniqueControl(controls, seen, controlType)
     end
 end
 
-local function getMapControlTypes(descriptor)
+getMapControlTypes = function(descriptor)
     local controls = {}
     local seen = {}
     local level = descriptor.previewLevel
@@ -823,37 +1076,57 @@ local function drawMapPreview(descriptor, rect)
     end
 end
 
-local function getBadgeWidths(game, descriptor, maxWidth)
+local function buildCardBadges(game, descriptor, maxWidth)
     local controls = getMapControlTypes(descriptor)
     local font = game.fonts.small
-    local widths = {}
+    local badges = {}
     local totalWidth = 0
+    local marketplaceEntry = getMarketplaceEntryForDescriptor(game, descriptor)
 
-    for index, controlType in ipairs(controls) do
-        local label = CONTROL_SHORT_LABELS[controlType] or controlType
-        local badgeWidth = font:getWidth(label) + 22
-        local nextWidth = totalWidth + badgeWidth
-        if index > 1 then
+    local function appendBadge(badge)
+        local nextWidth = totalWidth + badge.width
+        if #badges > 0 then
             nextWidth = nextWidth + 6
         end
         if nextWidth > maxWidth then
-            break
+            return false
         end
-        widths[#widths + 1] = {
-            controlType = controlType,
-            label = label,
-            width = badgeWidth,
-        }
+        badges[#badges + 1] = badge
         totalWidth = nextWidth
+        return true
     end
 
-    return widths, totalWidth
+    if game.levelSelectMode == "marketplace" and game.levelSelectMarketplaceTab == "top" and marketplaceEntry then
+        local rankColors = getMarketplaceIndicatorColors(game, marketplaceEntry)
+        appendBadge({
+            label = marketplaceEntry.positionLabel or "#0",
+            width = font:getWidth(marketplaceEntry.positionLabel or "#0") + 22,
+            fillColor = rankColors.fill,
+            lineColor = rankColors.line,
+            textColor = rankColors.text,
+        })
+    end
+
+    for _, controlType in ipairs(controls) do
+        local label = CONTROL_SHORT_LABELS[controlType] or controlType
+        local appended = appendBadge({
+            controlType = controlType,
+            label = label,
+            width = font:getWidth(label) + 22,
+        })
+        if not appended then
+            break
+        end
+    end
+
+    return badges, totalWidth
 end
 
-local function getLevelSelectBackRect()
+local function getLevelSelectBackRect(game)
+    local chromeRect = getLevelSelectChromeRect(game)
     return {
         x = 24,
-        y = math.floor((LEVEL_SELECT.chromeH - 40) * 0.5 + 0.5),
+        y = chromeRect.y + math.floor((chromeRect.h - 40) * 0.5 + 0.5),
         w = 120,
         h = 40,
     }
@@ -870,7 +1143,7 @@ local function getSettledSelectedCardRect(game)
     }
 end
 
-local function getLevelSelectFilterRect(game)
+getLevelSelectFilterRect = function(game)
     local panelTop = LEVEL_SELECT.bottomBarY
     local selectedCardRect = getSettledSelectedCardRect(game)
     local selectedBottom = selectedCardRect.y + selectedCardRect.h
@@ -884,28 +1157,69 @@ local function getLevelSelectFilterRect(game)
     }
 end
 
-local function getLevelSelectActionRects(game)
-    local startWidth = 170
-    local editWidth = 148
-    local gap = 18
-    local totalWidth = startWidth + editWidth + gap
-    local startX = math.floor(game.viewport.w * 0.5 - totalWidth * 0.5 + 0.5)
-    local buttonY = LEVEL_SELECT.bottomBarY + math.floor((LEVEL_SELECT.bottomBarH - 42) * 0.5 + 0.5)
+getLevelSelectActionButtons = function(game)
+    local bottomBarRect = getLevelSelectBottomBarRect(game)
+    local maps = getLevelSelectMaps(game)
+    local selectedIndex = getSelectedMapIndex(game, maps)
+    local selectedMap = selectedIndex and maps[selectedIndex] or nil
+    local buttonY = bottomBarRect.y + math.floor((bottomBarRect.h - LEVEL_SELECT_ACTION_LAYOUT.buttonH) * 0.5 + 0.5)
+    local buttonSpecs
 
-    return {
-        start = {
-            x = startX,
+    if game.levelSelectMode == "marketplace" then
+        buttonSpecs = {
+            { id = "download_map", label = "Download", w = LEVEL_SELECT_ACTION_LAYOUT.downloadW },
+            { id = "refresh_marketplace", label = "Refresh", w = LEVEL_SELECT_ACTION_LAYOUT.refreshW },
+            { id = "toggle_mode", label = "Local Maps", w = LEVEL_SELECT_ACTION_LAYOUT.toggleW },
+        }
+    else
+        buttonSpecs = {
+            { id = "open_map", label = "Start", w = LEVEL_SELECT_ACTION_LAYOUT.startW },
+            { id = "edit_map", label = "Edit", w = LEVEL_SELECT_ACTION_LAYOUT.editW },
+            { id = "toggle_mode", label = "Online Maps", w = LEVEL_SELECT_ACTION_LAYOUT.toggleW },
+        }
+
+        if selectedMap and game:isUploadSelectedMapAvailable(selectedMap) then
+            buttonSpecs[#buttonSpecs + 1] = {
+                id = "upload_map",
+                label = "Upload",
+                w = LEVEL_SELECT_ACTION_LAYOUT.uploadW,
+            }
+        end
+    end
+
+    local totalWidth = 0
+    for index, spec in ipairs(buttonSpecs) do
+        totalWidth = totalWidth + spec.w
+        if index > 1 then
+            totalWidth = totalWidth + LEVEL_SELECT_ACTION_LAYOUT.buttonGap
+        end
+    end
+
+    local currentX = math.floor(game.viewport.w * 0.5 - totalWidth * 0.5 + 0.5)
+    local buttons = {}
+    for _, spec in ipairs(buttonSpecs) do
+        buttons[#buttons + 1] = {
+            id = spec.id,
+            label = spec.label,
+            x = currentX,
             y = buttonY,
-            w = startWidth,
-            h = 42,
-        },
-        edit = {
-            x = startX + startWidth + gap,
-            y = buttonY,
-            w = editWidth,
-            h = 42,
-        },
-    }
+            w = spec.w,
+            h = LEVEL_SELECT_ACTION_LAYOUT.buttonH,
+        }
+        currentX = currentX + spec.w + LEVEL_SELECT_ACTION_LAYOUT.buttonGap
+    end
+
+    return buttons
+end
+
+local function findLevelSelectActionButton(buttons, buttonId)
+    for _, button in ipairs(buttons or {}) do
+        if button.id == buttonId then
+            return button
+        end
+    end
+
+    return nil
 end
 
 local function getLevelIssueOverlayRects(game)
@@ -1021,7 +1335,7 @@ local function buildLevelSelectCardRects(game)
 
             local badgeGap = 12
             local badgeH = 22
-            local badgeWidths, badgeTotalWidth = getBadgeWidths(game, descriptor, width - 36)
+            local badgeWidths, badgeTotalWidth = buildCardBadges(game, descriptor, width - 36)
             local badgeBottomPadding = 18
             local badgeY = y + height - badgeH - badgeBottomPadding
             local previewTop = y + 18
@@ -1064,17 +1378,19 @@ local function drawControlBadges(game, descriptor, x, y, maxWidth, badgeRow)
         widths = badgeRow.widths
         totalWidth = badgeRow.totalWidth or 0
     else
-        widths, totalWidth = getBadgeWidths(game, descriptor, maxWidth)
+        widths, totalWidth = buildCardBadges(game, descriptor, maxWidth)
     end
 
     local badgeX = x + math.floor((maxWidth - totalWidth) * 0.5 + 0.5)
     for _, badge in ipairs(widths) do
-        local color = PREVIEW_COLORS.control[badge.controlType] or PREVIEW_COLORS.control.direct
-        graphics.setColor(color[1], color[2], color[3], 0.96)
+        local fillColor = badge.fillColor or PREVIEW_COLORS.control[badge.controlType] or PREVIEW_COLORS.control.direct
+        local lineColor = badge.lineColor or { 0.06, 0.08, 0.1, 0.4 }
+        local textColor = badge.textColor or { 0.08, 0.1, 0.14, 1 }
+        graphics.setColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4] or 0.96)
         graphics.rectangle("fill", badgeX, y, badge.width, 22, 11, 11)
-        graphics.setColor(0.06, 0.08, 0.1, 0.4)
+        graphics.setColor(lineColor[1], lineColor[2], lineColor[3], lineColor[4] or 1)
         graphics.rectangle("line", badgeX, y, badge.width, 22, 11, 11)
-        graphics.setColor(0.08, 0.1, 0.14, 1)
+        graphics.setColor(textColor[1], textColor[2], textColor[3], textColor[4] or 1)
         graphics.printf(badge.label, badgeX, y + 3, badge.width, "center")
         badgeX = badgeX + badge.width + 6
     end
@@ -1082,6 +1398,8 @@ end
 
 local function drawLevelSelectChrome(game)
     local graphics = love.graphics
+    local chromeRect = getLevelSelectChromeRect(game)
+    local bottomBarRect = getLevelSelectBottomBarRect(game)
     graphics.setColor(0.08, 0.12, 0.18, 0.82)
     graphics.circle("fill", 164, 188, 168)
     graphics.circle("fill", 1082, 274, 214)
@@ -1091,8 +1409,99 @@ local function drawLevelSelectChrome(game)
     graphics.setLineWidth(2)
     graphics.setLineWidth(1)
 
-    drawMetalPanel({ x = 2, y = 2, w = game.viewport.w - 4, h = LEVEL_SELECT.chromeH }, 0.98)
-    drawMetalPanel({ x = 2, y = LEVEL_SELECT.bottomBarY, w = game.viewport.w - 4, h = LEVEL_SELECT.bottomBarH }, 0.98)
+    drawMetalPanel(chromeRect, 0.98)
+    drawMetalPanel(bottomBarRect, 0.98)
+end
+
+getMarketplaceEntryForDescriptor = function(game, descriptor)
+    if game.levelSelectMode ~= "marketplace" or not descriptor then
+        return nil
+    end
+
+    local entries = buildMarketplaceDisplayEntries(game)
+    for _, entry in ipairs(entries) do
+        if entry.descriptor.id == descriptor.id then
+            return entry
+        end
+    end
+
+    return nil
+end
+
+getMarketplaceIndicatorColors = function(game, marketplaceEntry)
+    local defaultColors = {
+        fill = { 0.12, 0.17, 0.24, 0.98 },
+        line = { 0.56, 0.72, 0.98, 1 },
+        text = PANEL_COLORS.titleText,
+    }
+
+    if game.levelSelectMarketplaceTab ~= "top" or not marketplaceEntry then
+        return defaultColors
+    end
+
+    local position = tonumber(marketplaceEntry.position) or 0
+    if position == 1 then
+        return {
+            fill = { 0.42, 0.31, 0.08, 0.98 },
+            line = { 0.99, 0.83, 0.32, 1 },
+            text = { 1, 0.97, 0.82, 1 },
+        }
+    end
+    if position == 2 then
+        return {
+            fill = { 0.24, 0.28, 0.34, 0.98 },
+            line = { 0.82, 0.88, 0.96, 1 },
+            text = { 0.97, 0.98, 1, 1 },
+        }
+    end
+    if position == 3 then
+        return {
+            fill = { 0.34, 0.18, 0.1, 0.98 },
+            line = { 0.91, 0.58, 0.32, 1 },
+            text = { 1, 0.92, 0.86, 1 },
+        }
+    end
+    if position >= 4 and position <= 10 then
+        return {
+            fill = { 0.14, 0.2, 0.28, 0.98 },
+            line = { 0.48, 0.66, 0.88, 1 },
+            text = { 0.93, 0.96, 1, 1 },
+        }
+    end
+
+    return defaultColors
+end
+
+local function getLevelSelectTitleText(game, selectedMap)
+    if game.levelSelectMode == "marketplace" then
+        local sectionLabel = "Top Maps"
+        local selectedEntry = getMarketplaceEntryForDescriptor(game, selectedMap)
+        local marketplaceState = game.getMarketplaceViewState and game:getMarketplaceViewState() or nil
+        if game.levelSelectMarketplaceTab == "random" then
+            sectionLabel = "Random"
+        elseif game.levelSelectMarketplaceTab == "search" then
+            sectionLabel = "Search"
+        end
+
+        if selectedEntry then
+            return selectedEntry.title, string.format(
+                "Online Maps  |  %s  |  %s votes  |  by %s",
+                selectedEntry.positionLabel or sectionLabel,
+                tostring(selectedEntry.favoriteCount or 0),
+                selectedEntry.creatorDisplayName or "Unknown"
+            )
+        end
+        if marketplaceState and marketplaceState.message and marketplaceState.status ~= "ready" then
+            return "Online Maps", marketplaceState.message
+        end
+        return "Online Maps", string.format("Online Maps  |  %s", sectionLabel)
+    end
+
+    if not selectedMap then
+        return "Level Select", "Pick a map to start or edit."
+    end
+
+    return getMapDisplayName(selectedMap), getMapKindLabel(selectedMap)
 end
 
 local function drawLevelSelectTitleBar(game, selectedMap)
@@ -1113,17 +1522,15 @@ local function drawLevelSelectTitleBar(game, selectedMap)
     graphics.rectangle("line", barRect.x + 4, barRect.y + 4, barRect.w - 8, barRect.h - 8, 10, 10)
     graphics.setLineWidth(1)
 
-    if not selectedMap then
-        return
-    end
+    local titleText, subtitleText = getLevelSelectTitleText(game, selectedMap)
 
     love.graphics.setFont(game.fonts.title)
     graphics.setColor(PANEL_COLORS.titleText[1], PANEL_COLORS.titleText[2], PANEL_COLORS.titleText[3], PANEL_COLORS.titleText[4])
-    graphics.printf(getMapDisplayName(selectedMap), barRect.x + 30, barRect.y + 8, barRect.w - 60, "center")
+    graphics.printf(titleText, barRect.x + 30, barRect.y + 8, barRect.w - 60, "center")
 
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(PANEL_COLORS.bodyText[1], PANEL_COLORS.bodyText[2], PANEL_COLORS.bodyText[3], PANEL_COLORS.bodyText[4])
-    graphics.printf(getMapKindLabel(selectedMap), barRect.x + 30, barRect.y + 48, barRect.w - 60, "center")
+    graphics.printf(subtitleText, barRect.x + 30, barRect.y + MARKETPLACE_LAYOUT.titleMetaTop, barRect.w - 60, "center")
 end
 
 local function isLevelSelectLeaderboardCardFlipped(game, rect)
@@ -1282,11 +1689,46 @@ local function drawLevelSelectEmptyState(game, filterId)
 
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(PANEL_COLORS.bodyText[1], PANEL_COLORS.bodyText[2], PANEL_COLORS.bodyText[3], PANEL_COLORS.bodyText[4])
-    if filterId == "user" then
+    if filterId == "marketplace" then
+        local marketplaceState = game.getMarketplaceViewState and game:getMarketplaceViewState() or nil
+        graphics.printf(
+            (marketplaceState and marketplaceState.message) or "Try a different online tab or broaden the search term.",
+            panel.x + 34,
+            panel.y + 78,
+            panel.w - 68,
+            "center"
+        )
+    elseif filterId == "user" then
         graphics.printf("Open the editor and save a map to have it show up here.", panel.x + 34, panel.y + 78, panel.w - 68, "center")
     else
         graphics.printf("Switch filters or pick All to browse the full level list.", panel.x + 34, panel.y + 78, panel.w - 68, "center")
     end
+end
+
+local function drawMarketplaceSearchField(game)
+    local graphics = love.graphics
+    local searchRect = getMarketplaceSearchRect(game)
+    local query = game.levelSelectMarketplaceSearchQuery or ""
+    local hasQuery = query ~= ""
+
+    graphics.setColor(0.08, 0.1, 0.14, 0.98)
+    graphics.rectangle("fill", searchRect.x, searchRect.y, searchRect.w, searchRect.h, 14, 14)
+    graphics.setColor(0.44, 0.62, 0.78, 1)
+    graphics.rectangle("line", searchRect.x, searchRect.y, searchRect.w, searchRect.h, 14, 14)
+
+    love.graphics.setFont(game.fonts.body)
+    if hasQuery then
+        graphics.setColor(PANEL_COLORS.titleText[1], PANEL_COLORS.titleText[2], PANEL_COLORS.titleText[3], PANEL_COLORS.titleText[4])
+    else
+        graphics.setColor(PANEL_COLORS.mutedText[1], PANEL_COLORS.mutedText[2], PANEL_COLORS.mutedText[3], PANEL_COLORS.mutedText[4])
+    end
+    graphics.printf(
+        hasQuery and query or "Search maps, ids, or tags",
+        searchRect.x + 16,
+        searchRect.y + 11,
+        searchRect.w - 32,
+        "left"
+    )
 end
 
 local function getMenuButtons(game)
@@ -1464,8 +1906,42 @@ function ui.getLevelSelectHit(game, x, y, button)
         return { kind = "issue_blocked" }
     end
 
-    if pointInRect(x, y, getLevelSelectBackRect()) then
+    if pointInRect(x, y, getLevelSelectBackRect(game)) then
         return { kind = "back" }
+    end
+
+    local modeButtonRect = getLevelSelectModeButtonRect(game)
+    if modeButtonRect and pointInRect(x, y, modeButtonRect) then
+        return { kind = "toggle_mode" }
+    end
+
+    if game.levelSelectMode == "marketplace" then
+        local tabsRect = getMarketplaceTabsRect(game)
+        local tabSegments = getMarketplaceTabSegments()
+        if pointInRect(x, y, tabsRect) then
+            for index, segment in ipairs(tabSegments) do
+                if pointInRect(x, y, uiControls.segmentRect(tabsRect, index, #tabSegments)) then
+                    return { kind = "set_marketplace_tab", tab = segment.id }
+                end
+            end
+        end
+        local marketplaceMaps = getLevelSelectMaps(game)
+        local selectedMarketplaceIndex = getSelectedMapIndex(game, marketplaceMaps)
+        local selectedMarketplaceMap = selectedMarketplaceIndex and marketplaceMaps[selectedMarketplaceIndex] or nil
+        for _, buttonRect in ipairs(getLevelSelectActionButtons(game)) do
+            if buttonRect.id ~= "toggle_mode" and pointInRect(x, y, buttonRect) then
+                return {
+                    kind = buttonRect.id,
+                    map = selectedMarketplaceMap,
+                }
+            end
+        end
+        for _, rect in ipairs(buildLevelSelectCardRects(game)) do
+            if pointInRect(x, y, rect) then
+                return { kind = "select_map", map = rect.map }
+            end
+        end
+        return nil
     end
 
     local cardRects = buildLevelSelectCardRects(game)
@@ -1482,13 +1958,13 @@ function ui.getLevelSelectHit(game, x, y, button)
     local maps = getLevelSelectMaps(game)
     local selectedIndex = getSelectedMapIndex(game, maps)
     local selectedMap = selectedIndex and maps[selectedIndex] or nil
-    local actionRects = getLevelSelectActionRects(game)
-
-    if selectedMap and pointInRect(x, y, actionRects.start) then
-        return { kind = "open_map", map = selectedMap }
-    end
-    if selectedMap and pointInRect(x, y, actionRects.edit) then
-        return { kind = "edit_map", map = selectedMap }
+    for _, buttonRect in ipairs(getLevelSelectActionButtons(game)) do
+        if buttonRect.id ~= "toggle_mode" and pointInRect(x, y, buttonRect) then
+            return {
+                kind = buttonRect.id,
+                map = selectedMap,
+            }
+        end
     end
 
     for _, rect in ipairs(cardRects) do
@@ -1506,20 +1982,31 @@ function ui.getLevelSelectHit(game, x, y, button)
     return nil
 end
 
-function ui.getLevelSelectFilterHoverId(game, x, y)
+function ui.getLevelSelectHoverId(game, x, y)
     if game.levelSelectIssue then
         return nil
     end
 
-    local filterRect = getLevelSelectFilterRect(game)
-    if not pointInRect(x, y, filterRect) then
+    if game.levelSelectMode == "marketplace" then
+        local tabsRect = getMarketplaceTabsRect(game)
+        if pointInRect(x, y, tabsRect) then
+            local tabSegments = getMarketplaceTabSegments()
+            for index, segment in ipairs(tabSegments) do
+                if pointInRect(x, y, uiControls.segmentRect(tabsRect, index, #tabSegments)) then
+                    return segment.id
+                end
+            end
+        end
         return nil
     end
 
-    local filterSegments = getLevelSelectFilterSegments()
-    for index, segment in ipairs(filterSegments) do
-        if pointInRect(x, y, uiControls.segmentRect(filterRect, index, #filterSegments)) then
-            return segment.id
+    local filterRect = getLevelSelectFilterRect(game)
+    if pointInRect(x, y, filterRect) then
+        local filterSegments = getLevelSelectFilterSegments()
+        for index, segment in ipairs(filterSegments) do
+            if pointInRect(x, y, uiControls.segmentRect(filterRect, index, #filterSegments)) then
+                return segment.id
+            end
         end
     end
 
@@ -1780,9 +2267,10 @@ function ui.drawLevelSelect(game)
     local selectedIndex = getSelectedMapIndex(game, maps)
     local selectedMap = selectedIndex and maps[selectedIndex] or nil
     local cardRects = buildLevelSelectCardRects(game)
-    local actionRects = getLevelSelectActionRects(game)
-    local filterRect = getLevelSelectFilterRect(game)
-    local filterSegments = getLevelSelectFilterSegments()
+    local actionButtons = getLevelSelectActionButtons(game)
+    local selectionRect = game.levelSelectMode == "marketplace" and getMarketplaceTabsRect(game) or getLevelSelectFilterRect(game)
+    local selectionSegments = game.levelSelectMode == "marketplace" and getMarketplaceTabSegments() or getLevelSelectFilterSegments()
+    local selectionValue = game.levelSelectMode == "marketplace" and (game.levelSelectMarketplaceTab or "top") or (game.levelSelectFilter or "all")
 
     graphics.setColor(PANEL_COLORS.background[1], PANEL_COLORS.background[2], PANEL_COLORS.background[3], PANEL_COLORS.background[4])
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -1790,21 +2278,21 @@ function ui.drawLevelSelect(game)
     drawLevelSelectChrome(game)
     drawLevelSelectTitleBar(game, selectedMap)
 
-    drawButton(getLevelSelectBackRect(), "Back", { 0.12, 0.15, 0.19, 0.98 }, { 0.3, 0.42, 0.54, 1 }, game.fonts.small)
+    drawButton(getLevelSelectBackRect(game), "Back", { 0.12, 0.15, 0.19, 0.98 }, { 0.3, 0.42, 0.54, 1 }, game.fonts.small)
 
     for _, cardRect in ipairs(cardRects) do
         drawLevelCard(game, cardRect)
     end
 
     if #maps == 0 then
-        drawLevelSelectEmptyState(game, game.levelSelectFilter or "all")
+        drawLevelSelectEmptyState(game, game.levelSelectMode == "marketplace" and "marketplace" or (game.levelSelectFilter or "all"))
     end
 
     uiControls.drawSegmentedToggle(
-        filterRect,
-        filterSegments,
-        game.levelSelectFilter or "all",
-        game.levelSelectFilterHoverId,
+        selectionRect,
+        selectionSegments,
+        selectionValue,
+        game.levelSelectHoverId,
         game.fonts.small,
         {
             backgroundColor = { 0.08, 0.1, 0.14, 0.98 },
@@ -1817,12 +2305,60 @@ function ui.drawLevelSelect(game)
         }
     )
 
-    if selectedMap then
-        drawButton(actionRects.start, "Start", { 0.12, 0.17, 0.2, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
-        drawButton(actionRects.edit, "Edit", { 0.12, 0.17, 0.2, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.body)
-    else
-        drawButton(actionRects.start, "Start", { 0.1, 0.12, 0.15, 0.98 }, { 0.24, 0.3, 0.36, 1 }, game.fonts.body)
-        drawButton(actionRects.edit, "Edit", { 0.1, 0.12, 0.15, 0.98 }, { 0.24, 0.3, 0.36, 1 }, game.fonts.body)
+    if game.levelSelectMode == "marketplace" then
+        if game.levelSelectMarketplaceTab == "search" then
+            drawMarketplaceSearchField(game)
+        end
+    end
+
+    for _, buttonRect in ipairs(actionButtons) do
+        local fillColor = { 0.1, 0.12, 0.15, 0.98 }
+        local strokeColor = { 0.24, 0.3, 0.36, 1 }
+        local font = game.fonts.body
+
+        if buttonRect.id == "open_map" and selectedMap then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.48, 0.92, 0.62, 1 }
+        elseif buttonRect.id == "edit_map" and selectedMap then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.99, 0.78, 0.32, 1 }
+        elseif buttonRect.id == "toggle_mode" then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.56, 0.72, 0.98, 1 }
+            font = game.fonts.small
+        elseif buttonRect.id == "upload_map" then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.48, 0.72, 0.92, 1 }
+        elseif buttonRect.id == "download_map" and selectedMap then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.48, 0.92, 0.62, 1 }
+        elseif buttonRect.id == "refresh_marketplace" then
+            fillColor = { 0.12, 0.17, 0.2, 0.98 }
+            strokeColor = { 0.56, 0.72, 0.98, 1 }
+        end
+
+        drawButton(buttonRect, buttonRect.label, fillColor, strokeColor, font)
+    end
+
+    if game.levelSelectActionState and game.levelSelectActionState.message then
+        local bottomBarRect = getLevelSelectBottomBarRect(game)
+        local actionStatus = game.levelSelectActionState
+        local statusColor = PANEL_COLORS.bodyText
+        if actionStatus.status == "success" then
+            statusColor = { 0.48, 0.92, 0.62, 1 }
+        elseif actionStatus.status == "error" then
+            statusColor = { 0.99, 0.78, 0.32, 1 }
+        end
+
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(statusColor[1], statusColor[2], statusColor[3], statusColor[4] or 1)
+        graphics.printf(
+            actionStatus.message,
+            0,
+            bottomBarRect.y - 26,
+            game.viewport.w,
+            "center"
+        )
     end
 
     if game.levelSelectIssue then

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -977,6 +977,68 @@ local function drawLevelSelectEmptyState(game, filterId)
     end
 end
 
+local function getMenuButtons(game)
+    local centerX = game.viewport.w * 0.5 - 160
+    return {
+        {
+            id = "play",
+            x = centerX,
+            y = 248,
+            w = 320,
+            h = 56,
+            label = "Level Select",
+        },
+        {
+            id = "leaderboard",
+            x = centerX,
+            y = 320,
+            w = 320,
+            h = 56,
+            label = "Online Leaderboard",
+        },
+        {
+            id = "editor",
+            x = centerX,
+            y = 392,
+            w = 320,
+            h = 56,
+            label = "Map Editor",
+        },
+        {
+            id = "debug",
+            x = centerX,
+            y = 464,
+            w = 320,
+            h = 56,
+            label = game:isDebugModeEnabled() and "Debug Mode: On" or "Debug Mode: Off",
+        },
+        {
+            id = "quit",
+            x = centerX,
+            y = 536,
+            w = 320,
+            h = 56,
+            label = "Quit",
+        },
+    }
+end
+
+local function getProfileSetupConfirmRect(game)
+    return {
+        x = game.viewport.w * 0.5 - 110,
+        y = 430,
+        w = 220,
+        h = 52,
+    }
+end
+
+local function getLeaderboardActionRects(game)
+    return {
+        back = { x = 42, y = 38, w = 148, h = 42 },
+        refresh = { x = game.viewport.w - 190, y = 38, w = 148, h = 42 },
+    }
+end
+
 function ui.getLevelSelectMapDescriptors(game)
     return getLevelSelectMaps(game)
 end
@@ -994,12 +1056,7 @@ function ui.scrollLevelSelectToMap(_, _, currentScroll)
 end
 
 function ui.getMenuActionAt(game, x, y)
-    local centerX = game.viewport.w * 0.5 - 160
-    local buttons = {
-        { id = "play", x = centerX, y = 280, w = 320, h = 56 },
-        { id = "editor", x = centerX, y = 352, w = 320, h = 56 },
-        { id = "quit", x = centerX, y = 424, w = 320, h = 56 },
-    }
+    local buttons = getMenuButtons(game)
 
     for _, rect in ipairs(buttons) do
         if pointInRect(x, y, rect) then
@@ -1007,6 +1064,24 @@ function ui.getMenuActionAt(game, x, y)
         end
     end
 
+    return nil
+end
+
+function ui.getProfileSetupActionAt(game, x, y)
+    if pointInRect(x, y, getProfileSetupConfirmRect(game)) then
+        return "confirm"
+    end
+    return nil
+end
+
+function ui.getLeaderboardActionAt(game, x, y)
+    local buttons = getLeaderboardActionRects(game)
+    if pointInRect(x, y, buttons.back) then
+        return "back"
+    end
+    if pointInRect(x, y, buttons.refresh) then
+        return "refresh"
+    end
     return nil
 end
 
@@ -1094,12 +1169,13 @@ function ui.getPlayBackHit(_, x, y)
 end
 
 local function getResultsButtonRects(game)
-    local panelX = game.viewport.w * 0.5 - 250
+    local panelX = game.viewport.w * 0.5 - 240
     local buttonY = game.viewport.h - 72
     return {
-        replay = { x = panelX, y = buttonY, w = 150, h = 42 },
-        editor = { x = panelX + 175, y = buttonY, w = 150, h = 42 },
-        menu = { x = panelX + 350, y = buttonY, w = 150, h = 42 },
+        replay = { x = panelX, y = buttonY, w = 112, h = 42 },
+        leaderboard = { x = panelX + 128, y = buttonY, w = 112, h = 42 },
+        editor = { x = panelX + 256, y = buttonY, w = 112, h = 42 },
+        menu = { x = panelX + 384, y = buttonY, w = 112, h = 42 },
     }
 end
 
@@ -1107,6 +1183,9 @@ function ui.getResultsHit(game, x, y)
     local buttons = getResultsButtonRects(game)
     if pointInRect(x, y, buttons.replay) then
         return "replay"
+    end
+    if pointInRect(x, y, buttons.leaderboard) then
+        return "leaderboard"
     end
     if pointInRect(x, y, buttons.menu) then
         return "menu"
@@ -1119,33 +1198,7 @@ end
 
 function ui.drawMenu(game)
     local graphics = love.graphics
-    local centerX = game.viewport.w * 0.5 - 160
-    local buttons = {
-        {
-            id = "play",
-            x = centerX,
-            y = 280,
-            w = 320,
-            h = 56,
-            label = "Level Select",
-        },
-        {
-            id = "editor",
-            x = centerX,
-            y = 352,
-            w = 320,
-            h = 56,
-            label = "Map Editor",
-        },
-        {
-            id = "quit",
-            x = centerX,
-            y = 424,
-            w = 320,
-            h = 56,
-            label = "Quit",
-        },
-    }
+    local buttons = getMenuButtons(game)
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -1161,20 +1214,188 @@ function ui.drawMenu(game)
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.84, 0.88, 0.92, 1)
     graphics.printf(
-        "Route trains through lever-controlled merges, or build your own maps and save them for later.",
+        "Route trains through lever-controlled merges, upload cleared scores, and compare runs online.",
         game.viewport.w * 0.5 - 280,
         188,
         560,
         "center"
     )
 
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.72, 0.78, 0.84, 1)
+    graphics.printf(
+        string.format("Signed in as %s", game.profile and game.profile.playerDisplayName or "Unknown"),
+        0,
+        220,
+        game.viewport.w,
+        "center"
+    )
+
+    local onlineText = game.onlineConfig and game.onlineConfig.isConfigured and "Online sync ready" or "Online sync needs API_KEY + LEADERBOARD_ID in .env"
+    local onlineColor = game.onlineConfig and game.onlineConfig.isConfigured and { 0.48, 0.92, 0.62, 1 } or { 0.99, 0.78, 0.32, 1 }
+    graphics.setColor(onlineColor[1], onlineColor[2], onlineColor[3], onlineColor[4])
+    graphics.printf(onlineText, 0, 238, game.viewport.w, "center")
+
     for _, rect in ipairs(buttons) do
-        drawButton(rect, rect.label, { 0.09, 0.11, 0.15, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
+        local strokeColor = rect.id == "debug"
+            and (game:isDebugModeEnabled() and { 0.99, 0.78, 0.32, 1 } or { 0.3, 0.42, 0.54, 1 })
+            or { 0.48, 0.92, 0.62, 1 }
+        drawButton(rect, rect.label, { 0.09, 0.11, 0.15, 0.98 }, strokeColor, game.fonts.body)
     end
 
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(0.72, 0.78, 0.84, 1)
-    graphics.printf("Enter opens level select. E opens the editor directly. Esc quits.", 0, 620, game.viewport.w, "center")
+    graphics.printf("Enter starts. L opens the leaderboard. D toggles debug mode. Esc quits.", 0, 654, game.viewport.w, "center")
+end
+
+function ui.drawProfileSetup(game)
+    local graphics = love.graphics
+    local panel = {
+        x = game.viewport.w * 0.5 - 280,
+        y = game.viewport.h * 0.5 - 150,
+        w = 560,
+        h = 300,
+    }
+    local inputRect = {
+        x = panel.x + 56,
+        y = panel.y + 126,
+        w = panel.w - 112,
+        h = 56,
+    }
+    local confirmRect = getProfileSetupConfirmRect(game)
+
+    graphics.setColor(0.05, 0.07, 0.1, 1)
+    graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    drawMetalPanel(panel, 0.98)
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf("Choose Name", panel.x + 24, panel.y + 34, panel.w - 48, "center")
+
+    love.graphics.setFont(game.fonts.body)
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf("Enter the name to use in the leaderboard.", panel.x + 42, panel.y + 84, panel.w - 84, "center")
+
+    graphics.setColor(0.48, 0.92, 0.62, 0.12)
+    graphics.rectangle("fill", inputRect.x - 4, inputRect.y - 4, inputRect.w + 8, inputRect.h + 8, 16, 16)
+    graphics.setColor(0.08, 0.1, 0.14, 0.98)
+    graphics.rectangle("fill", inputRect.x, inputRect.y, inputRect.w, inputRect.h, 14, 14)
+    graphics.setColor(0.48, 0.92, 0.62, 1)
+    graphics.rectangle("line", inputRect.x, inputRect.y, inputRect.w, inputRect.h, 14, 14)
+    graphics.setColor(0.48, 0.92, 0.62, 0.24)
+    graphics.rectangle("line", inputRect.x - 4, inputRect.y - 4, inputRect.w + 8, inputRect.h + 8, 16, 16)
+
+    love.graphics.setFont(game.fonts.body)
+    local typedText = game.profileSetupNameBuffer or ""
+    local hasTypedText = typedText ~= ""
+    local nameText = hasTypedText and typedText or "Type a name..."
+    if hasTypedText then
+        graphics.setColor(0.97, 0.98, 1, 1)
+    else
+        graphics.setColor(0.5, 0.58, 0.66, 1)
+    end
+    graphics.printf(nameText, inputRect.x + 18, inputRect.y + 16, inputRect.w - 36, "left")
+
+    if math.floor((love.timer.getTime() or 0) * 2) % 2 == 0 then
+        local textWidth = game.fonts.body:getWidth(typedText)
+        local caretX = hasTypedText
+            and math.min(inputRect.x + inputRect.w - 24, inputRect.x + 18 + textWidth + 2)
+            or (inputRect.x + 12)
+        graphics.setColor(0.48, 0.92, 0.62, 1)
+        graphics.rectangle("fill", caretX, inputRect.y + 12, 3, inputRect.h - 24, 1, 1)
+    end
+
+    love.graphics.setFont(game.fonts.small)
+    if game.profileSetupError then
+        graphics.setColor(0.99, 0.78, 0.32, 1)
+        graphics.printf(game.profileSetupError, panel.x + 42, panel.y + 194, panel.w - 84, "center")
+    end
+
+    drawButton(confirmRect, "Continue", { 0.09, 0.11, 0.15, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
+end
+
+function ui.drawLeaderboard(game)
+    local graphics = love.graphics
+    local panel = {
+        x = 36,
+        y = 100,
+        w = game.viewport.w - 72,
+        h = game.viewport.h - 148,
+    }
+    local buttons = getLeaderboardActionRects(game)
+    local state = game.leaderboardState or { status = "idle", entries = {} }
+    local contentX = panel.x + 28
+    local contentW = panel.w - 56
+
+    graphics.setColor(0.05, 0.07, 0.1, 1)
+    graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    drawMetalPanel(panel, 0.98)
+
+    drawButton(buttons.back, "Back", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.42, 0.54, 1 }, game.fonts.small)
+    drawButton(buttons.refresh, "Refresh", { 0.1, 0.14, 0.18, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.small)
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(game.leaderboardTitle or "Online Leaderboard", panel.x + 24, panel.y + 24, panel.w - 48, "center")
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    local subtitle = game.leaderboardMapUuid and "Filtered to the current map's UUID." or "Showing all downloaded SimpleBoards entries."
+    graphics.printf(subtitle, panel.x + 24, panel.y + 70, panel.w - 48, "center")
+
+    if state.status ~= "ready" then
+        love.graphics.setFont(game.fonts.body)
+        graphics.setColor(0.99, 0.78, 0.32, 1)
+        graphics.printf(state.message or "The leaderboard is not ready.", contentX, panel.y + 180, contentW, "center")
+        return
+    end
+
+    if #(state.entries or {}) == 0 then
+        love.graphics.setFont(game.fonts.body)
+        graphics.setColor(0.84, 0.88, 0.92, 1)
+        graphics.printf(state.message or "No entries are available yet.", contentX, panel.y + 180, contentW, "center")
+        return
+    end
+
+    local headerY = panel.y + 116
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.68, 0.74, 0.8, 1)
+    graphics.print("#", contentX, headerY)
+    graphics.print("Player", contentX + 52, headerY)
+    graphics.printf("Score", contentX + contentW - 180, headerY, 80, "right")
+    graphics.printf(game.leaderboardMapUuid and "Created" or "Map UUID", contentX + contentW - 96, headerY, 96, "right")
+
+    local rowY = headerY + 28
+    local maxEntries = math.min(12, #(state.entries or {}))
+    for index = 1, maxEntries do
+        local entry = state.entries[index]
+        graphics.setColor(0.1, 0.13, 0.17, 0.94)
+        graphics.rectangle("fill", contentX, rowY - 6, contentW, 34, 10, 10)
+        graphics.setColor(0.26, 0.34, 0.42, 1)
+        graphics.rectangle("line", contentX, rowY - 6, contentW, 34, 10, 10)
+
+        graphics.setColor(0.97, 0.98, 1, 1)
+        graphics.print(tostring(index), contentX + 12, rowY + 2)
+        graphics.printf(entry.playerDisplayName or "Unknown", contentX + 52, rowY + 2, contentW - 260, "left")
+        graphics.printf(formatScore(entry.score or 0), contentX + contentW - 180, rowY + 2, 80, "right")
+
+        local tailText = game.leaderboardMapUuid and (entry.createdAt or "-") or ((entry.mapUuid and entry.mapUuid:sub(1, 8)) or "-")
+        graphics.setColor(0.72, 0.78, 0.84, 1)
+        graphics.printf(tailText, contentX + contentW - 96, rowY + 2, 96, "right")
+
+        rowY = rowY + 42
+    end
+
+    if #(state.entries or {}) > maxEntries then
+        graphics.setColor(0.68, 0.74, 0.8, 1)
+        graphics.printf(
+            string.format("%d more entry/entries hidden. Refresh later to compare again.", #(state.entries or {}) - maxEntries),
+            contentX,
+            panel.y + panel.h - 44,
+            contentW,
+            "center"
+        )
+    end
 end
 
 function ui.drawLevelSelect(game)
@@ -1366,9 +1587,19 @@ function ui.drawResults(game)
     graphics.printf(string.format("Score %s", formatScore(summary.finalScore or 0)), panel.x, panel.y + 108, panel.w, "center")
 
     love.graphics.setFont(game.fonts.small)
+    local onlineState = game.resultsOnlineState or {}
+    local onlineColor = { 0.72, 0.78, 0.84, 1 }
+    if onlineState.status == "submitted" then
+        onlineColor = { 0.48, 0.92, 0.62, 1 }
+    elseif onlineState.status == "error" or onlineState.status == "disabled" then
+        onlineColor = { 0.99, 0.78, 0.32, 1 }
+    end
+    graphics.setColor(onlineColor[1], onlineColor[2], onlineColor[3], onlineColor[4])
+    graphics.printf(onlineState.message or "Online sync pending.", panel.x + 38, panel.y + 158, panel.w - 76, "center")
+
     local breakdownX = panel.x + 58
     local valueX = panel.x + panel.w - 58
-    local lineY = panel.y + 192
+    local lineY = panel.y + 220
     local rows = {
         { "On-time clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.onTimeClears) or 0)) },
         { "Late clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.lateClears) or 0)) },
@@ -1391,9 +1622,7 @@ function ui.drawResults(game)
         string.format("Wrong destinations: %d", summary.wrongDestinationCount or 0),
         string.format("Elapsed time: %.1fs", summary.elapsedSeconds or 0),
         string.format("Interactions: %d", summary.interactionCount or 0),
-        string.format("Driven distance: %.1fm", summary.actualDrivenDistance or 0),
-        string.format("Minimum distance: %.1fm", summary.minimumRequiredDistance or 0),
-        string.format("Extra distance: %.1fm", summary.extraDistance or 0),
+        string.format("Map UUID: %s", summary.mapUuid or "n/a"),
     }
 
     for _, stat in ipairs(stats) do
@@ -1403,6 +1632,7 @@ function ui.drawResults(game)
     end
 
     drawButton(buttons.replay, "Replay", { 0.1, 0.14, 0.18, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.small)
+    drawButton(buttons.leaderboard, "Leaderboard", { 0.1, 0.14, 0.18, 0.98 }, { 0.56, 0.72, 0.98, 1 }, game.fonts.small)
     drawButton(buttons.editor, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
     drawButton(buttons.menu, "Main Menu", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
 end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -109,6 +109,22 @@ local LEADERBOARD_LAYOUT = {
     filterBadgeMaxWidth = 460,
 }
 
+local LEVEL_SELECT_LEADERBOARD_CARD = {
+    inset = 18,
+    titleTop = 20,
+    maxRows = 5,
+    rowTop = 56,
+    rowHeight = 24,
+    rowGap = 6,
+    rowRadius = 10,
+    rowPaddingX = 10,
+    rankWidth = 32,
+    scoreWidth = 76,
+    pinnedGap = 12,
+    statusPaddingX = 20,
+    statusWidthMargin = 40,
+}
+
 local function pointInRect(x, y, rect)
     return x >= rect.x
         and x <= rect.x + rect.w
@@ -1110,6 +1126,113 @@ local function drawLevelSelectTitleBar(game, selectedMap)
     graphics.printf(getMapKindLabel(selectedMap), barRect.x + 30, barRect.y + 48, barRect.w - 60, "center")
 end
 
+local function isLevelSelectLeaderboardCardFlipped(game, rect)
+    local mapUuid = rect and rect.map and rect.map.mapUuid or nil
+    return rect
+        and rect.selected
+        and mapUuid
+        and mapUuid ~= ""
+        and game.levelSelectLeaderboardFlipMapUuid == mapUuid
+end
+
+local function drawLevelSelectLeaderboardRow(game, rowRect, entry, isHighlighted)
+    local graphics = love.graphics
+    local fillColor = isHighlighted and { 0.16, 0.28, 0.38, 0.98 } or { 0.08, 0.11, 0.15, 0.96 }
+    local lineColor = isHighlighted and { 0.48, 0.72, 0.92, 1 } or { 0.24, 0.32, 0.4, 1 }
+
+    graphics.setColor(fillColor[1], fillColor[2], fillColor[3], fillColor[4])
+    graphics.rectangle("fill", rowRect.x, rowRect.y, rowRect.w, rowRect.h, LEVEL_SELECT_LEADERBOARD_CARD.rowRadius, LEVEL_SELECT_LEADERBOARD_CARD.rowRadius)
+    graphics.setColor(lineColor[1], lineColor[2], lineColor[3], lineColor[4])
+    graphics.rectangle("line", rowRect.x, rowRect.y, rowRect.w, rowRect.h, LEVEL_SELECT_LEADERBOARD_CARD.rowRadius, LEVEL_SELECT_LEADERBOARD_CARD.rowRadius)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(PANEL_COLORS.bodyText[1], PANEL_COLORS.bodyText[2], PANEL_COLORS.bodyText[3], PANEL_COLORS.bodyText[4])
+    graphics.printf(
+        tostring(entry.rank or "-"),
+        rowRect.x + LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX,
+        rowRect.y + 4,
+        LEVEL_SELECT_LEADERBOARD_CARD.rankWidth,
+        "left"
+    )
+
+    local nameX = rowRect.x + LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX + LEVEL_SELECT_LEADERBOARD_CARD.rankWidth
+    local nameWidth = rowRect.w - LEVEL_SELECT_LEADERBOARD_CARD.rankWidth - LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth - (LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX * 2)
+    graphics.printf(
+        tostring(entry.playerDisplayName or "Unknown"),
+        nameX,
+        rowRect.y + 4,
+        math.max(0, nameWidth),
+        "left"
+    )
+
+    graphics.printf(
+        formatScore(entry.score or 0),
+        rowRect.x + rowRect.w - LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth - LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX,
+        rowRect.y + 4,
+        LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth,
+        "right"
+    )
+end
+
+local function drawLevelSelectLeaderboardBack(game, rect)
+    local graphics = love.graphics
+    local contentRect = {
+        x = rect.x + LEVEL_SELECT_LEADERBOARD_CARD.inset,
+        y = rect.y + LEVEL_SELECT_LEADERBOARD_CARD.inset,
+        w = rect.w - (LEVEL_SELECT_LEADERBOARD_CARD.inset * 2),
+        h = rect.h - (LEVEL_SELECT_LEADERBOARD_CARD.inset * 2),
+    }
+    local previewState = game:getLevelSelectPreviewDisplayState(rect.map.mapUuid)
+    local topEntries = previewState.topEntries or {}
+    local pinnedPlayerEntry = previewState.pinnedPlayerEntry
+    local rowY = contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.rowTop
+
+    love.graphics.setFont(game.fonts.body)
+    graphics.setColor(PANEL_COLORS.titleText[1], PANEL_COLORS.titleText[2], PANEL_COLORS.titleText[3], PANEL_COLORS.titleText[4])
+    graphics.printf("Leaderboard", contentRect.x, contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.titleTop, contentRect.w, "center")
+
+    for index, entry in ipairs(topEntries) do
+        local rowRect = {
+            x = contentRect.x,
+            y = rowY,
+            w = contentRect.w,
+            h = LEVEL_SELECT_LEADERBOARD_CARD.rowHeight,
+        }
+        local isPlayerEntry = tostring(entry.playerUuid or "") == tostring(game.profile and game.profile.playerId or "")
+        drawLevelSelectLeaderboardRow(game, rowRect, entry, isPlayerEntry)
+        rowY = rowY + LEVEL_SELECT_LEADERBOARD_CARD.rowHeight + LEVEL_SELECT_LEADERBOARD_CARD.rowGap
+        if index >= LEVEL_SELECT_LEADERBOARD_CARD.maxRows then
+            break
+        end
+    end
+
+    if pinnedPlayerEntry then
+        local pinnedRowRect = {
+            x = contentRect.x,
+            y = contentRect.y + contentRect.h - LEVEL_SELECT_LEADERBOARD_CARD.rowHeight,
+            w = contentRect.w,
+            h = LEVEL_SELECT_LEADERBOARD_CARD.rowHeight,
+        }
+        drawLevelSelectLeaderboardRow(game, pinnedRowRect, pinnedPlayerEntry, true)
+    elseif previewState.isLoading and #topEntries == 0 then
+        drawLoadingSpinner(
+            contentRect.x + math.floor(contentRect.w * 0.5 + 0.5),
+            contentRect.y + math.floor(contentRect.h * 0.56 + 0.5),
+            { 0.48, 0.92, 0.62, 1 }
+        )
+    elseif previewState.message then
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(PANEL_COLORS.mutedText[1], PANEL_COLORS.mutedText[2], PANEL_COLORS.mutedText[3], PANEL_COLORS.mutedText[4])
+        graphics.printf(
+            previewState.message,
+            contentRect.x + LEVEL_SELECT_LEADERBOARD_CARD.statusPaddingX,
+            contentRect.y + math.floor(contentRect.h * 0.52 + 0.5),
+            math.max(0, contentRect.w - LEVEL_SELECT_LEADERBOARD_CARD.statusWidthMargin),
+            "center"
+        )
+    end
+end
+
 local function drawLevelCard(game, rect)
     local graphics = love.graphics
     local descriptor = rect.map
@@ -1132,10 +1255,14 @@ local function drawLevelCard(game, rect)
         graphics.rectangle("line", rect.x - 6, rect.y - 6, rect.w + 12, rect.h + 12, 22, 22)
     end
 
-    drawMapPreview(descriptor, rect.previewRect)
+    if isLevelSelectLeaderboardCardFlipped(game, rect) then
+        drawLevelSelectLeaderboardBack(game, rect)
+    else
+        drawMapPreview(descriptor, rect.previewRect)
 
-    local badgeY = rect.badgeRow and rect.badgeRow.y or (rect.y + rect.h - 40)
-    drawControlBadges(game, descriptor, rect.x + 18, badgeY, rect.w - 36, rect.badgeRow)
+        local badgeY = rect.badgeRow and rect.badgeRow.y or (rect.y + rect.h - 40)
+        drawControlBadges(game, descriptor, rect.x + 18, badgeY, rect.w - 36, rect.badgeRow)
+    end
 end
 
 local function drawLevelSelectEmptyState(game, filterId)
@@ -1322,7 +1449,7 @@ function ui.getLeaderboardMapHitAt(game, x, y)
     return nil
 end
 
-function ui.getLevelSelectHit(game, x, y)
+function ui.getLevelSelectHit(game, x, y, button)
     if game.levelSelectIssue then
         local overlay = getLevelIssueOverlayRects(game)
         if pointInRect(x, y, overlay.edit) then
@@ -1366,6 +1493,9 @@ function ui.getLevelSelectHit(game, x, y)
 
     for _, rect in ipairs(cardRects) do
         if pointInRect(x, y, rect) then
+            if button == 2 and rect.selected then
+                return { kind = "toggle_leaderboard_card", map = rect.map }
+            end
             if rect.selected then
                 return { kind = "open_map", map = rect.map }
             end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -61,16 +61,6 @@ local PLAY_OVERLAY = {
     sectionGap = 14,
 }
 
-local PLAY_HEADER = {
-    x = 22,
-    y = 20,
-    paddingX = 18,
-    paddingY = 12,
-    titleGap = 14,
-    rowGap = 8,
-    radius = 18,
-}
-
 local function pointInRect(x, y, rect)
     return x >= rect.x
         and x <= rect.x + rect.w
@@ -266,6 +256,7 @@ local function buildPlayHelpSections(game)
 end
 
 local function buildPlayDebugSections(game)
+    local runSummary = game.world:getRunSummary()
     local sections = {
         {
             title = "Junction State",
@@ -274,6 +265,14 @@ local function buildPlayDebugSections(game)
         {
             title = "Train Queue",
             lines = {},
+        },
+        {
+            title = "Run Stats",
+            lines = {
+                string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #(game.world.trains or {})),
+                string.format("Interactions: %d", runSummary.interactionCount or 0),
+                string.format("Score: %s", formatScore(runSummary.finalScore or 0)),
+            },
         },
     }
     local worldState = game.world
@@ -1289,81 +1288,26 @@ end
 
 function ui.drawPlay(game)
     local graphics = love.graphics
-    local level = game.world:getLevel()
     local runSummary = game.world:getRunSummary()
-    local gameTitleText = "Out of Signal"
-    local levelTitleText = level.title or ""
-    local titleFont = game.fonts.title
-    local levelFont = game.fonts.body
-    local timerFont = game.fonts.small
-    local timerText = game.world.timeRemaining and string.format("Time left: %.1fs", game.world.timeRemaining) or nil
-    local titleRowWidth = titleFont:getWidth(gameTitleText)
-    local levelRowWidth = 0
-    local timerRowWidth = timerText and timerFont:getWidth(timerText) or 0
-    local titleRowHeight = math.max(titleFont:getHeight(), levelFont:getHeight())
-    local headerHeight = titleRowHeight + PLAY_HEADER.paddingY * 2
-
-    if levelTitleText ~= "" then
-        levelRowWidth = PLAY_HEADER.titleGap + levelFont:getWidth(levelTitleText)
-    end
-
-    if timerText then
-        headerHeight = headerHeight + PLAY_HEADER.rowGap + timerFont:getHeight()
-    end
-
-    local playHeaderRect = {
-        x = PLAY_HEADER.x,
-        y = PLAY_HEADER.y,
-        w = math.max(titleRowWidth + levelRowWidth, timerRowWidth) + PLAY_HEADER.paddingX * 2,
-        h = headerHeight,
+    local scorePanel = {
+        x = math.floor(game.viewport.w - 274 + 0.5),
+        y = math.floor(game.viewport.h * 0.5 - 52 + 0.5),
+        w = 236,
+        h = 104,
     }
-    local titleRowY = playHeaderRect.y + PLAY_HEADER.paddingY
-    local textX = playHeaderRect.x + PLAY_HEADER.paddingX
 
-    graphics.setColor(0, 0, 0, 0.34)
-    graphics.rectangle("fill", playHeaderRect.x, playHeaderRect.y, playHeaderRect.w, playHeaderRect.h, PLAY_HEADER.radius, PLAY_HEADER.radius)
-
-    love.graphics.setFont(titleFont)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.print(gameTitleText, textX, titleRowY)
-
-    if levelTitleText ~= "" then
-        love.graphics.setFont(levelFont)
-        graphics.setColor(0.84, 0.88, 0.92, 1)
-        graphics.print(
-            levelTitleText,
-            textX + titleRowWidth + PLAY_HEADER.titleGap,
-            titleRowY + math.floor((titleRowHeight - levelFont:getHeight()) * 0.5 + 0.5)
-        )
-    end
-
-    if timerText then
-        love.graphics.setFont(timerFont)
-        graphics.setColor(0.99, 0.83, 0.44, 1)
-        graphics.print(timerText, textX, titleRowY + titleRowHeight + PLAY_HEADER.rowGap)
-    end
+    graphics.setColor(0.08, 0.1, 0.13, 0.94)
+    graphics.rectangle("fill", scorePanel.x, scorePanel.y, scorePanel.w, scorePanel.h, 18, 18)
+    graphics.setColor(0.3, 0.36, 0.42, 1)
+    graphics.rectangle("line", scorePanel.x, scorePanel.y, scorePanel.w, scorePanel.h, 18, 18)
 
     love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.48, 0.92, 0.62, 1)
-    graphics.print(game.world:getActiveRouteSummary(), 42, 152)
+    graphics.setColor(0.8, 0.84, 0.9, 0.95)
+    graphics.printf("Score", scorePanel.x + 20, scorePanel.y + 18, scorePanel.w - 40, "left")
 
-    local trainsText = string.format("Trains cleared: %d / %d", game.world:countCompletedTrains(), #game.world.trains)
-    graphics.setColor(0.84, 0.88, 0.92, 0.95)
-    graphics.print(trainsText, 42, 174)
-    graphics.print(string.format("Interactions: %d", runSummary.interactionCount or 0), 42, 196)
-    graphics.print(string.format("Score: %s", formatScore(runSummary.finalScore or 0)), 220, 196)
-
-    local nextTrain = game.world:getNextQueuedTrain()
-    if nextTrain then
-        graphics.setColor(0.72, 0.78, 0.84, 1)
-        graphics.print(string.format("Next spawn: %s at %.1fs", game.world:getTrainSummary(nextTrain), nextTrain.spawnTime or 0), 42, 220)
-    end
-
-    local nextDeadline = game.world:getNearestPendingDeadline()
-    if nextDeadline then
-        graphics.setColor(0.99, 0.78, 0.32, 1)
-        graphics.print(string.format("Nearest deadline: %s by %.1fs", game.world:getTrainSummary(nextDeadline), nextDeadline.deadline), 360, 220)
-    end
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf(formatScore(runSummary.finalScore or 0), scorePanel.x + 20, scorePanel.y + 44, scorePanel.w - 40, "left")
 
     drawButton(
         { x = 1114, y = 28, w = 134, h = 38 },
@@ -1373,10 +1317,6 @@ function ui.drawPlay(game)
         game.fonts.small
     )
 
-    graphics.setColor(0, 0, 0, 0.3)
-    graphics.rectangle("fill", game.viewport.w - 286, game.viewport.h - 54, 250, 30, 15, 15)
-    graphics.setColor(0.8, 0.84, 0.9, 0.82)
-    graphics.printf("Press F2 for help, F3 for debug, M for menu, E for editor, or R to restart", 0, game.viewport.h - 42, game.viewport.w, "center")
 
     drawPlayInfoOverlay(game)
 end

--- a/src/game/uuid.lua
+++ b/src/game/uuid.lua
@@ -35,7 +35,7 @@ function uuid.generateV4()
 end
 
 function uuid.generatePlayerId()
-    return "player-" .. uuid.generateV4()
+    return uuid.generateV4()
 end
 
 return uuid

--- a/src/game/uuid.lua
+++ b/src/game/uuid.lua
@@ -1,0 +1,42 @@
+local uuid = {}
+
+local seeded = false
+
+local function ensureSeeded()
+    if seeded then
+        return
+    end
+
+    local seed = os.time()
+    if love and love.timer and love.timer.getTime then
+        seed = seed + math.floor(love.timer.getTime() * 1000000)
+    end
+
+    math.randomseed(seed)
+    math.random()
+    math.random()
+    math.random()
+    seeded = true
+end
+
+local function randomHexDigit(maxValue)
+    ensureSeeded()
+    return string.format("%x", math.random(0, maxValue or 15))
+end
+
+function uuid.generateV4()
+    local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+    return (template:gsub("[xy]", function(token)
+        if token == "x" then
+            return randomHexDigit(15)
+        end
+        return string.format("%x", math.random(8, 11))
+    end))
+end
+
+function uuid.generatePlayerId()
+    return "player-" .. uuid.generateV4()
+end
+
+return uuid
+

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1,5 +1,8 @@
 local world = {}
 world.__index = world
+local roadTypes = require("src.game.road_types")
+local ROAD_PATTERN_OUTLINE = { 0.04, 0.05, 0.07, 0.98 }
+local ROAD_PATTERN_FILL = { 0.97, 0.98, 1.0, 0.94 }
 
 local function clamp(value, minValue, maxValue)
     if value < minValue then
@@ -53,6 +56,48 @@ local function darkerColor(color)
         color[2] * 0.42,
         color[3] * 0.42,
     }
+end
+
+local function getRoadTypeScale(roadType, explicitScale)
+    if explicitScale then
+        return explicitScale
+    end
+
+    return roadTypes.getConfig(roadType).speedScale
+end
+
+local function normalizeStyleSections(styleSections, totalLength, fallbackRoadType, fallbackSpeedScale)
+    local normalizedSections = {}
+    local clampedLength = math.max(0, totalLength or 0)
+
+    for _, section in ipairs(styleSections or {}) do
+        local roadTypeId = roadTypes.normalizeRoadType(section.roadType or fallbackRoadType)
+        local startDistance = section.startRatio and (section.startRatio * clampedLength) or section.startDistance or 0
+        local endDistance = section.endRatio and (section.endRatio * clampedLength) or section.endDistance or clampedLength
+        startDistance = clamp(startDistance, 0, clampedLength)
+        endDistance = clamp(endDistance, 0, clampedLength)
+
+        if endDistance > startDistance + 0.0001 then
+            normalizedSections[#normalizedSections + 1] = {
+                roadType = roadTypeId,
+                speedScale = getRoadTypeScale(roadTypeId, section.speedScale),
+                startDistance = startDistance,
+                endDistance = endDistance,
+            }
+        end
+    end
+
+    if #normalizedSections == 0 then
+        local roadTypeId = roadTypes.normalizeRoadType(fallbackRoadType)
+        normalizedSections[1] = {
+            roadType = roadTypeId,
+            speedScale = getRoadTypeScale(roadTypeId, fallbackSpeedScale),
+            startDistance = 0,
+            endDistance = clampedLength,
+        }
+    end
+
+    return normalizedSections
 end
 
 local function denormalizePoints(points, viewportW, viewportH)
@@ -299,6 +344,9 @@ function world:normalizeLevel(sourceLevel)
                 color = color,
                 darkColor = edgeDefinition.darkColor and copyColor(edgeDefinition.darkColor) or darkerColor(color),
                 adoptInputColor = edgeDefinition.adoptInputColor == true,
+                roadType = roadTypes.normalizeRoadType(edgeDefinition.roadType),
+                speedScale = getRoadTypeScale(edgeDefinition.roadType, edgeDefinition.speedScale),
+                styleSections = edgeDefinition.styleSections or {},
                 points = edgeDefinition.points or {},
                 sourceType = edgeDefinition.sourceType,
                 sourceId = edgeDefinition.sourceId,
@@ -405,6 +453,9 @@ function world:normalizeLevel(sourceLevel)
                 color = inputColor,
                 darkColor = copyColor(inputDefinition.darkColor or darkerColor(inputColor)),
                 adoptInputColor = false,
+                roadType = roadTypes.DEFAULT_ID,
+                speedScale = roadTypes.getConfig(roadTypes.DEFAULT_ID).speedScale,
+                styleSections = {},
                 points = inputDefinition.inputPoints or {},
                 sourceType = "start",
                 sourceId = edgeId .. "_start",
@@ -424,6 +475,9 @@ function world:normalizeLevel(sourceLevel)
                 color = outputColor,
                 darkColor = copyColor(outputDefinition.darkColor or darkerColor(outputColor)),
                 adoptInputColor = outputDefinition.adoptInputColor == true,
+                roadType = roadTypes.DEFAULT_ID,
+                speedScale = roadTypes.getConfig(roadTypes.DEFAULT_ID).speedScale,
+                styleSections = {},
                 points = outputDefinition.outputPoints or {},
                 sourceType = "junction",
                 sourceId = definition.id,
@@ -458,6 +512,9 @@ function world:buildEdge(edgeDefinition)
     local stopDistance = math.max(signalDistance - (self.carriageLength + 12), 0)
     local stopX, stopY = pointOnPath(path, stopDistance)
     local signalX, signalY = pointOnPath(path, signalDistance)
+    local roadTypeId = roadTypes.normalizeRoadType(edgeDefinition.roadType)
+    local speedScale = getRoadTypeScale(roadTypeId, edgeDefinition.speedScale)
+    local styleSections = normalizeStyleSections(edgeDefinition.styleSections, path.length, roadTypeId, speedScale)
 
     return {
         id = edgeDefinition.id,
@@ -466,6 +523,9 @@ function world:buildEdge(edgeDefinition)
         color = color,
         darkColor = copyColor(edgeDefinition.darkColor or darkerColor(color)),
         adoptInputColor = edgeDefinition.adoptInputColor == true,
+        roadType = roadTypeId,
+        speedScale = speedScale,
+        styleSections = styleSections,
         sourceType = edgeDefinition.sourceType,
         sourceId = edgeDefinition.sourceId,
         targetType = edgeDefinition.targetType,
@@ -800,6 +860,18 @@ function world:getDesiredLeadDistance(train)
     return nil
 end
 
+function world:getEdgeSpeedScaleAtDistance(edge, distance)
+    local clampedDistance = clamp(distance or 0, 0, edge.path.length)
+
+    for _, section in ipairs(edge.styleSections or {}) do
+        if clampedDistance >= section.startDistance and clampedDistance <= section.endDistance then
+            return section.speedScale
+        end
+    end
+
+    return edge.speedScale or 1
+end
+
 function world:advanceTrainToNextEdge(train, junction, overflow)
     local outputEdge = junction.outputs[clamp(junction.activeOutputIndex, 1, math.max(1, #junction.outputs))]
     if not outputEdge then
@@ -824,7 +896,7 @@ function world:updateTrain(train, dt)
     end
 
     local desiredStopDistance = self:getDesiredLeadDistance(train)
-    local targetSpeed = train.speed
+    local targetSpeed = train.speed * self:getEdgeSpeedScaleAtDistance(currentEdge, localProgress)
     local localProgress = self:getHeadLocalProgress(train)
 
     if desiredStopDistance then
@@ -837,7 +909,7 @@ function world:updateTrain(train, dt)
             train.headDistance = previousLength + desiredStopDistance
             localProgress = desiredStopDistance
         else
-            targetSpeed = train.speed * clamp(remainingDistance / brakingWindow, 0, 1)
+            targetSpeed = train.speed * self:getEdgeSpeedScaleAtDistance(currentEdge, localProgress) * clamp(remainingDistance / brakingWindow, 0, 1)
         end
     end
 
@@ -1045,7 +1117,7 @@ function world:getOutputDisplayColor(junction, outputIndex, isActive)
     return isActive and outputTrack.color or outputTrack.darkColor, outputTrack.darkColor
 end
 
-function world:getRenderedTrackPoints(track)
+function world:getRenderedTrackWindow(track)
     local trimStartDistance = 0
     local trimEndDistance = track.path.length
 
@@ -1057,7 +1129,66 @@ function world:getRenderedTrackPoints(track)
         trimEndDistance = math.max(track.path.length - self.junctionTrackClearance, 0)
     end
 
+    return trimStartDistance, trimEndDistance
+end
+
+function world:getRenderedTrackPoints(track)
+    local trimStartDistance, trimEndDistance = self:getRenderedTrackWindow(track)
     return buildPathSlice(track.path, trimStartDistance, trimEndDistance)
+end
+
+function world:drawTrackPatternSegment(startX, startY, endX, endY, alpha, outlineWidth, fillWidth)
+    local graphics = love.graphics
+    graphics.setColor(ROAD_PATTERN_OUTLINE[1], ROAD_PATTERN_OUTLINE[2], ROAD_PATTERN_OUTLINE[3], alpha)
+    graphics.setLineWidth(outlineWidth)
+    graphics.line(startX, startY, endX, endY)
+    graphics.setColor(ROAD_PATTERN_FILL[1], ROAD_PATTERN_FILL[2], ROAD_PATTERN_FILL[3], alpha)
+    graphics.setLineWidth(fillWidth)
+    graphics.line(startX, startY, endX, endY)
+end
+
+function world:drawTrackRoadTypeMarkers(track, isActive)
+    local startDistance, endDistance = self:getRenderedTrackWindow(track)
+    local alpha = isActive and 0.95 or 0.78
+
+    for _, section in ipairs(track.styleSections or {}) do
+        local roadTypeConfig = roadTypes.getConfig(section.roadType)
+        if roadTypeConfig.pattern ~= "plain" then
+            local sectionStartDistance = math.max(startDistance, section.startDistance)
+            local sectionEndDistance = math.min(endDistance, section.endDistance)
+            local markerDistance = sectionStartDistance + roadTypeConfig.markerSpacing * 0.5
+            local markerSize = roadTypeConfig.markerSize
+            local outlineWidth = roadTypeConfig.markerWidth + 2
+            local fillWidth = roadTypeConfig.markerWidth
+
+            while markerDistance < sectionEndDistance do
+                local markerX, markerY, angle = pointOnPath(track.path, markerDistance)
+                local directionX = math.cos(angle)
+                local directionY = math.sin(angle)
+                local normalX = -directionY
+                local normalY = directionX
+
+                if roadTypeConfig.pattern == "chevron" then
+                    local tipX = markerX + directionX * markerSize
+                    local tipY = markerY + directionY * markerSize
+                    local leftX = markerX - normalX * markerSize * 0.7
+                    local leftY = markerY - normalY * markerSize * 0.7
+                    local rightX = markerX + normalX * markerSize * 0.7
+                    local rightY = markerY + normalY * markerSize * 0.7
+                    self:drawTrackPatternSegment(leftX, leftY, tipX, tipY, alpha, outlineWidth, fillWidth)
+                    self:drawTrackPatternSegment(rightX, rightY, tipX, tipY, alpha, outlineWidth, fillWidth)
+                elseif roadTypeConfig.pattern == "crossbar" then
+                    local startX = markerX - normalX * markerSize
+                    local startY = markerY - normalY * markerSize
+                    local endX = markerX + normalX * markerSize
+                    local endY = markerY + normalY * markerSize
+                    self:drawTrackPatternSegment(startX, startY, endX, endY, alpha, outlineWidth, fillWidth)
+                end
+
+                markerDistance = markerDistance + roadTypeConfig.markerSpacing
+            end
+        end
+    end
 end
 
 function world:getInputTrackAngle(track)
@@ -1088,6 +1219,8 @@ function world:drawInputTrack(track, isActive)
     graphics.setColor(trackColor[1], trackColor[2], trackColor[3], trackAlpha)
     graphics.setLineWidth(self.trackWidth)
     graphics.line(points)
+
+    self:drawTrackRoadTypeMarkers(track, isActive)
 end
 
 function world:drawOutputTrack(junction, outputIndex, isActive)
@@ -1108,6 +1241,8 @@ function world:drawOutputTrack(junction, outputIndex, isActive)
     graphics.setColor(color[1], color[2], color[3], isActive and 0.98 or 0.7)
     graphics.setLineWidth(self.sharedWidth)
     graphics.line(points)
+
+    self:drawTrackRoadTypeMarkers(outputTrack, isActive)
 end
 
 function world:drawControlOverlay(junction)

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -402,6 +402,7 @@ end
 function world:normalizeLevel(sourceLevel)
     local normalized = {
         id = sourceLevel.id,
+        mapUuid = sourceLevel.mapUuid or sourceLevel.id,
         title = sourceLevel.title,
         description = sourceLevel.description,
         hint = sourceLevel.hint,
@@ -1501,6 +1502,8 @@ function world:getRunSummary()
     local scoring = self:getScoringConstants()
     local summary = {
         endReason = self:getRunEndReason(),
+        mapUuid = self.level and (self.level.mapUuid or self.level.id) or nil,
+        mapTitle = self.level and self.level.title or nil,
         correctOnTimeCount = 0,
         correctLateCount = 0,
         wrongDestinationCount = 0,


### PR DESCRIPTION
Online config/bootstrap: adds .env support and docs for the backend API in .env.example, .gitignore, API_REQUESTS.md, and src/game/env_loader.lua.
Player profile support: persistent player UUID + display name + debug flag via src/game/profile_storage.lua and src/game/uuid.lua.
Leaderboards: score submission, leaderboard fetching in a worker thread, preview caching, and UI/screens for lobby/results leaderboard flow in src/game/leaderboard_client.lua, src/game/leaderboard_fetch_thread.lua, src/game/leaderboard_preview_cache.lua, src/game/game.lua, and src/game/ui.lua.
Online map marketplace: upload local maps, browse/search/fetch online maps, and import them into local storage through src/game/game.lua, src/game/ui.lua, and src/game/map_storage.lua.
Road-type/editor work inherited into this branch: adds normal / fast / slow road types and per-segment styling support in src/game/road_types.lua, src/game/map_editor.lua, src/game/authored_map.lua, src/game/world.lua, plus tutorial map updates.