### PR TITLE
Remove default API base URL and require explicit config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 API_KEY=replace-with-your-backend-api-key
-API_BASE_URL=https://signal-leaderboard.just2dev-signal.workers.dev
+API_BASE_URL=https://replace-with-your-backend-base-url.example

--- a/build.ps1
+++ b/build.ps1
@@ -11,6 +11,14 @@ $ErrorActionPreference = "Stop"
 Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
+$envFileName = ".env"
+$buildEnvFileName = "build.env"
+$envKeys = @(
+    "API_KEY",
+    "API_BASE_URL",
+    "HMAC_SECRET"
+)
+
 $projectRoot = $PSScriptRoot
 if ([string]::IsNullOrWhiteSpace($projectRoot)) {
     $projectRoot = (Get-Location).Path
@@ -27,6 +35,7 @@ $loveFile = Join-Path $buildDir ($buildName + ".love")
 $exeFile = Join-Path $buildDir ($buildName + ".exe")
 $zipFile = Join-Path $OutputRoot ($buildName + "_windows.zip")
 $loveExe = Join-Path $LoveRoot "love.exe"
+$projectEnvFile = Join-Path $projectRoot $envFileName
 
 if (-not (Test-Path -LiteralPath $loveExe)) {
     throw "LOVE executable not found at '$loveExe'."
@@ -144,6 +153,31 @@ function Create-ZipFromDirectory {
     }
 }
 
+function Get-BuildEnvContent {
+    param(
+        [string]$ProjectEnvFilePath
+    )
+
+    if (Test-Path -LiteralPath $ProjectEnvFilePath) {
+        return Get-Content -LiteralPath $ProjectEnvFilePath -Raw
+    }
+
+    $envLines = New-Object System.Collections.Generic.List[string]
+
+    foreach ($envKey in $envKeys) {
+        $envValue = [Environment]::GetEnvironmentVariable($envKey)
+        if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+            [void]$envLines.Add(($envKey + "=" + $envValue))
+        }
+    }
+
+    if ($envLines.Count -eq 0) {
+        throw "No build environment source was found. Create '$envFileName' in the project root or set one of these process environment variables: $($envKeys -join ', ')."
+    }
+
+    return ($envLines -join [Environment]::NewLine) + [Environment]::NewLine
+}
+
 if (Test-Path -LiteralPath $buildDir) {
     Remove-Item -LiteralPath $buildDir -Recurse -Force
 }
@@ -188,6 +222,11 @@ foreach ($file in $filesToStage) {
 
     Copy-Item -LiteralPath $file.FullName -Destination $targetPath -Force
 }
+
+$buildEnvContent = Get-BuildEnvContent -ProjectEnvFilePath $projectEnvFile
+$stageEnvFile = Join-Path $stageDir $buildEnvFileName
+$utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($stageEnvFile, $buildEnvContent, $utf8WithoutBom)
 
 $zipArchive = [System.IO.Compression.ZipFile]::Open($loveFile, [System.IO.Compression.ZipArchiveMode]::Create)
 try {

--- a/src/game/env_loader.lua
+++ b/src/game/env_loader.lua
@@ -1,21 +1,28 @@
 local envLoader = {}
 
 local ENV_FILE = ".env"
-local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
+local BUILD_ENV_FILE = "build.env"
 local MIN_QUOTED_LENGTH = 2
 local DIRECTORY_SEPARATOR = package.config:sub(1, 1)
+local UTF8_BOM_FIRST_BYTE = 239
+local UTF8_BOM_SECOND_BYTE = 187
+local UTF8_BOM_THIRD_BYTE = 191
 local REQUIRED_KEYS = {
     "API_KEY",
+    "API_BASE_URL",
 }
 local OPTIONAL_KEYS = {
-    "API_BASE_URL",
     "HMAC_SECRET",
 }
 local SOURCE_WORKING_DIRECTORY = "working directory .env"
+local SOURCE_WORKING_DIRECTORY_BUILD = "working directory build.env"
 local SOURCE_LOVE_FILESYSTEM = "project .env"
+local SOURCE_LOVE_FILESYSTEM_BUILD = "project build.env"
+local SOURCE_SOURCE_DIRECTORY = "source directory .env"
+local SOURCE_SOURCE_DIRECTORY_BUILD = "source directory build.env"
 local SOURCE_SAVE_DIRECTORY = "save directory .env"
+local SOURCE_SAVE_DIRECTORY_BUILD = "save directory build.env"
 local SOURCE_PROCESS_ENVIRONMENT = "process environment"
-local SOURCE_DEFAULT = "built-in default"
 
 local function trim(value)
     return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
@@ -29,6 +36,20 @@ local function stripQuotes(value)
         return trimmed:sub(2, -2)
     end
     return trimmed
+end
+
+local function stripUtf8Bom(value)
+    if type(value) ~= "string" then
+        return value
+    end
+
+    if value:byte(1) == UTF8_BOM_FIRST_BYTE
+        and value:byte(2) == UTF8_BOM_SECOND_BYTE
+        and value:byte(3) == UTF8_BOM_THIRD_BYTE then
+        return value:sub(4)
+    end
+
+    return value
 end
 
 local function readFile(path)
@@ -49,7 +70,9 @@ local function parseEnvContent(content)
         return values
     end
 
-    for line in content:gmatch("[^\r\n]+") do
+    local normalizedContent = stripUtf8Bom(content)
+
+    for line in normalizedContent:gmatch("[^\r\n]+") do
         local trimmedLine = trim(line)
         if trimmedLine ~= "" and trimmedLine:sub(1, 1) ~= "#" then
             local key, value = trimmedLine:match("^([%w_]+)%s*=%s*(.*)$")
@@ -76,19 +99,50 @@ local function mergeValues(target, sourceByKey, source, sourceName)
     end
 end
 
-local function readLoveEnvFile()
+local function readLoveProjectFile(fileName)
     if not (love and love.filesystem and love.filesystem.getInfo) then
         return nil
     end
 
-    if not love.filesystem.getInfo(ENV_FILE, "file") then
+    if not love.filesystem.getInfo(fileName, "file") then
         return nil
     end
 
-    return love.filesystem.read(ENV_FILE)
+    return love.filesystem.read(fileName)
 end
 
-local function readSaveDirectoryEnvFile()
+local function readLoveEnvFile()
+    return readLoveProjectFile(ENV_FILE), SOURCE_LOVE_FILESYSTEM
+end
+
+local function readLoveBuildEnvFile()
+    return readLoveProjectFile(BUILD_ENV_FILE), SOURCE_LOVE_FILESYSTEM_BUILD
+end
+
+local function readSourceDirectoryFile(fileName)
+    if not (love and love.filesystem and love.filesystem.getSourceBaseDirectory and love.filesystem.getSource) then
+        return nil
+    end
+
+    local sourceBaseDirectory = love.filesystem.getSourceBaseDirectory()
+    local sourceName = love.filesystem.getSource()
+    if not sourceBaseDirectory or sourceBaseDirectory == "" or not sourceName or sourceName == "" then
+        return nil
+    end
+
+    local sourceFilePath = sourceBaseDirectory .. DIRECTORY_SEPARATOR .. sourceName .. DIRECTORY_SEPARATOR .. fileName
+    return readFile(sourceFilePath)
+end
+
+local function readSourceDirectoryEnvFile()
+    return readSourceDirectoryFile(ENV_FILE), SOURCE_SOURCE_DIRECTORY
+end
+
+local function readSourceDirectoryBuildEnvFile()
+    return readSourceDirectoryFile(BUILD_ENV_FILE), SOURCE_SOURCE_DIRECTORY_BUILD
+end
+
+local function readSaveDirectoryFile(fileName)
     if not (love and love.filesystem and love.filesystem.getSaveDirectory) then
         return nil
     end
@@ -98,7 +152,15 @@ local function readSaveDirectoryEnvFile()
         return nil
     end
 
-    return readFile(saveDirectory .. DIRECTORY_SEPARATOR .. ENV_FILE)
+    return readFile(saveDirectory .. DIRECTORY_SEPARATOR .. fileName)
+end
+
+local function readSaveDirectoryEnvFile()
+    return readSaveDirectoryFile(ENV_FILE), SOURCE_SAVE_DIRECTORY
+end
+
+local function readSaveDirectoryBuildEnvFile()
+    return readSaveDirectoryFile(BUILD_ENV_FILE), SOURCE_SAVE_DIRECTORY_BUILD
 end
 
 local function readEnvValues()
@@ -106,22 +168,43 @@ local function readEnvValues()
     local sourceByKey = {}
     local loadedSourceCount = 0
 
-    local loveContent = readLoveEnvFile()
-    if loveContent then
-        mergeValues(values, sourceByKey, parseEnvContent(loveContent), SOURCE_LOVE_FILESYSTEM)
-        loadedSourceCount = loadedSourceCount + 1
-    end
+    local fileReaders = {
+        {
+            read = readLoveBuildEnvFile,
+        },
+        {
+            read = readLoveEnvFile,
+        },
+        {
+            read = function()
+                return readFile(BUILD_ENV_FILE), SOURCE_WORKING_DIRECTORY_BUILD
+            end,
+        },
+        {
+            read = function()
+                return readFile(ENV_FILE), SOURCE_WORKING_DIRECTORY
+            end,
+        },
+        {
+            read = readSourceDirectoryBuildEnvFile,
+        },
+        {
+            read = readSourceDirectoryEnvFile,
+        },
+        {
+            read = readSaveDirectoryBuildEnvFile,
+        },
+        {
+            read = readSaveDirectoryEnvFile,
+        },
+    }
 
-    local workingDirectoryContent = readFile(ENV_FILE)
-    if workingDirectoryContent then
-        mergeValues(values, sourceByKey, parseEnvContent(workingDirectoryContent), SOURCE_WORKING_DIRECTORY)
-        loadedSourceCount = loadedSourceCount + 1
-    end
-
-    local saveDirectoryContent = readSaveDirectoryEnvFile()
-    if saveDirectoryContent then
-        mergeValues(values, sourceByKey, parseEnvContent(saveDirectoryContent), SOURCE_SAVE_DIRECTORY)
-        loadedSourceCount = loadedSourceCount + 1
+    for _, fileReader in ipairs(fileReaders) do
+        local content, sourceName = fileReader.read()
+        if content then
+            mergeValues(values, sourceByKey, parseEnvContent(content), sourceName)
+            loadedSourceCount = loadedSourceCount + 1
+        end
     end
 
     return values, sourceByKey, loadedSourceCount
@@ -150,19 +233,19 @@ function envLoader.load()
     applyProcessEnvironment(values, sourceByKey)
 
     if loadedSourceCount == 0 and not os.getenv("API_KEY") and not os.getenv("API_BASE_URL") then
-        errors[#errors + 1] = string.format("%s was not found. Set API_KEY in process environment variables or a local %s file.", ENV_FILE, ENV_FILE)
+        errors[#errors + 1] = string.format("%s was not found. Set API_KEY and API_BASE_URL in process environment variables or a local %s file.", ENV_FILE, ENV_FILE)
     end
 
     local apiKey = values.API_KEY or ""
-    local apiBaseUrl = values.API_BASE_URL or DEFAULT_API_BASE_URL
+    local apiBaseUrl = values.API_BASE_URL or ""
     local hmacSecret = values.HMAC_SECRET or ""
-
-    if apiBaseUrl == DEFAULT_API_BASE_URL and not sourceByKey.API_BASE_URL then
-        sourceByKey.API_BASE_URL = SOURCE_DEFAULT
-    end
 
     if apiKey == "" then
         errors[#errors + 1] = "API_KEY is missing. Set it in the process environment or in .env."
+    end
+
+    if apiBaseUrl == "" then
+        errors[#errors + 1] = "API_BASE_URL is missing. Set it in the process environment or in .env."
     end
 
     return {

--- a/src/game/leaderboard_fetch_thread.lua
+++ b/src/game/leaderboard_fetch_thread.lua
@@ -6,7 +6,6 @@ local REQUEST_KIND_FETCH = "fetch"
 local REQUEST_KIND_PREVIEW = "preview"
 local REQUEST_KIND_MARKETPLACE = "marketplace"
 local CURL_STATUS_PREFIX = "__STATUS__"
-local DEFAULT_API_BASE_URL = "https://signal-leaderboard.just2dev-signal.workers.dev"
 local DEFAULT_LEADERBOARD_LIMIT = 50
 local DEFAULT_PREVIEW_LIMIT = 5
 local DEFAULT_MARKETPLACE_LIMIT = 10
@@ -44,7 +43,19 @@ local function splitCurlOutput(output)
 end
 
 local function normalizeBaseUrl(baseUrl)
-    return tostring(baseUrl or DEFAULT_API_BASE_URL):gsub("/+$", "")
+    return tostring(baseUrl or ""):gsub("/+$", "")
+end
+
+local function validateConfig(config)
+    if tostring(config.apiKey or "") == "" then
+        return nil, "API_KEY is missing."
+    end
+
+    if normalizeBaseUrl(config.apiBaseUrl) == "" then
+        return nil, "API_BASE_URL is missing."
+    end
+
+    return true
 end
 
 local function urlEncode(value)
@@ -123,6 +134,11 @@ local function fetchJson(uri, apiKey)
 end
 
 local function fetchLeaderboardEntries(config)
+    local _, validationError = validateConfig(config)
+    if validationError then
+        return nil, validationError
+    end
+
     local uri = buildLeaderboardUri(config.apiBaseUrl, config.mapUuid, config.limit)
     return fetchJson(uri, config.apiKey)
 end
@@ -144,6 +160,11 @@ local function extractPlayerPreviewEntry(aroundPayload, playerUuid)
 end
 
 local function fetchLeaderboardPreview(config)
+    local _, validationError = validateConfig(config)
+    if validationError then
+        return nil, validationError
+    end
+
     local mapUuid = tostring(config.mapUuid or "")
     if mapUuid == "" then
         return nil, "Leaderboard preview could not be loaded because the map UUID is missing."
@@ -186,6 +207,11 @@ local function fetchLeaderboardPreview(config)
 end
 
 local function fetchMarketplaceEntries(config)
+    local _, validationError = validateConfig(config)
+    if validationError then
+        return nil, validationError
+    end
+
     local mode = tostring(config.mode or MARKETPLACE_MODE_FAVORITES)
     local uri
 


### PR DESCRIPTION
## Requested Behavior
- Remove the hardcoded default API base URL from the build and runtime config.
- Keep `.env` embedded during builds, but require `API_BASE_URL` to be provided explicitly instead of falling back to a built-in endpoint.

## Summary
- Removed the default backend URL from env loading and leaderboard fetch code.
- Made `API_BASE_URL` a required config value alongside `API_KEY`.
- Updated the build pipeline to keep embedding env data without reintroducing the old backend default.
- Updated `.env.example` to point at a placeholder backend URL instead of the production endpoint.

## Testing
- Verified the config loader fails when `API_BASE_URL` is missing.
- Verified the config loader succeeds when both `API_KEY` and `API_BASE_URL` are present.
- Verified `build.ps1` still produces the `.love`, `.exe`, and zip outputs.