### PR TITLE
Fix leaderboard refresh and cache flow

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -4,6 +4,8 @@ local mapStorage = require("src.game.map_storage")
 local profileStorage = require("src.game.profile_storage")
 local leaderboardClient = require("src.game.leaderboard_client")
 local leaderboardPreviewCache = require("src.game.leaderboard_preview_cache")
+local levelSelectPreviewLogic = require("src.game.level_select_preview_logic")
+local refreshIndicatorLogic = require("src.game.refresh_indicator_logic")
 local world = require("src.game.world")
 local ui = require("src.game.ui")
 local json = require("src.game.json")
@@ -40,6 +42,7 @@ local LEVEL_SELECT_PREVIEW_STATUS_ERROR = "error"
 local LEVEL_SELECT_PREVIEW_MESSAGE_LOADING = "Loading leaderboard..."
 local LEVEL_SELECT_PREVIEW_MESSAGE_EMPTY = "No scores yet."
 local LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA = "No local leaderboard data."
+local LEVEL_SELECT_PREVIEW_DISPLAY_SWAP_DELAY_FRAMES = 1
 local LEVEL_SELECT_MODE_LIBRARY = "library"
 local LEVEL_SELECT_MODE_MARKETPLACE = "marketplace"
 local LEVEL_SELECT_MARKETPLACE_TAB_TOP = "top"
@@ -274,6 +277,13 @@ function Game.new()
         mapUuid = nil,
         status = LEVEL_SELECT_PREVIEW_STATUS_IDLE,
         message = nil,
+        forceImmediateFetch = false,
+        showCachedWhileLoading = false,
+        hasResolvedInitialRemoteAttempt = false,
+        clearVisibleEntries = false,
+        pendingPayload = nil,
+        pendingFetchedAt = nil,
+        pendingDelayFrames = 0,
     }
     self.levelSelectPreviewRequestSequence = 0
     self.activeLevelSelectPreviewRequestId = nil
@@ -357,6 +367,7 @@ end
 function Game:buildLeaderboardState(status, message, rawEntries, fetchedAt)
     local filteredEntries = self:getFilteredLeaderboardEntries(rawEntries)
     local resolvedMessage = message
+    local scopeKey = getLeaderboardScopeKey(self.leaderboardMapUuid)
 
     if status == LEADERBOARD_STATUS_READY and #filteredEntries == 0 then
         resolvedMessage = LEADERBOARD_MESSAGE_EMPTY
@@ -368,6 +379,11 @@ function Game:buildLeaderboardState(status, message, rawEntries, fetchedAt)
         entries = filteredEntries,
         totalEntries = #filteredEntries,
         fetchedAt = fetchedAt,
+        nextRefreshAt = refreshIndicatorLogic.getDisplayNextRefreshAt(
+            fetchedAt,
+            self.leaderboardNextFetchAtByScope[scopeKey],
+            LEADERBOARD_CACHE_DURATION_SECONDS
+        ),
         scope = type(rawEntries) == "table" and rawEntries.scope or (self.leaderboardMapUuid and LEADERBOARD_SCOPE_MAP or LEADERBOARD_SCOPE_GLOBAL),
     }
 end
@@ -515,12 +531,38 @@ function Game:isMarketplaceFetchAllowed(scopeKey)
     return getNowSeconds() >= (self.marketplaceNextFetchAtByScope[scopeKey] or 0)
 end
 
-function Game:setLevelSelectPreviewState(mapUuid, status, message)
+function Game:setLevelSelectPreviewState(mapUuid, status, message, options)
+    local resolvedOptions = options or {}
     self.levelSelectPreviewState = {
         mapUuid = mapUuid,
         status = status or LEVEL_SELECT_PREVIEW_STATUS_IDLE,
         message = message,
+        forceImmediateFetch = resolvedOptions.forceImmediateFetch or false,
+        showCachedWhileLoading = resolvedOptions.showCachedWhileLoading or false,
+        hasResolvedInitialRemoteAttempt = resolvedOptions.hasResolvedInitialRemoteAttempt or false,
+        clearVisibleEntries = resolvedOptions.clearVisibleEntries or false,
+        pendingPayload = resolvedOptions.pendingPayload,
+        pendingFetchedAt = resolvedOptions.pendingFetchedAt,
+        pendingDelayFrames = resolvedOptions.pendingDelayFrames or 0,
     }
+end
+
+local function buildLevelSelectPreviewCacheEntry(mapUuid, payload, fetchedAt)
+    return {
+        map_uuid = mapUuid,
+        top_entries = type(payload.top_entries) == "table" and payload.top_entries or {},
+        player_entry = type(payload.player_entry) == "table" and payload.player_entry or nil,
+        target_rank = tonumber(payload.target_rank) or nil,
+        fetched_at = fetchedAt,
+    }
+end
+
+local function levelSelectPreviewPayloadHasData(payload)
+    if type(payload) ~= "table" then
+        return false
+    end
+
+    return #(payload.top_entries or {}) > 0 or type(payload.player_entry) == "table"
 end
 
 function Game:getLevelSelectPreviewCacheEntry(mapUuid)
@@ -589,11 +631,16 @@ end
 
 function Game:getLevelSelectPreviewDisplayState(mapUuid)
     local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    local previewState = self.levelSelectPreviewState or {}
+    local shouldShowCachedEntries = levelSelectPreviewLogic.shouldShowCachedEntries(previewState, mapUuid, cacheEntry ~= nil)
     local topEntries = normalizeLeaderboardEntries({
-        entries = cacheEntry and cacheEntry.top_entries or {},
+        entries = shouldShowCachedEntries and cacheEntry and cacheEntry.top_entries or {},
         map_uuid = mapUuid,
     })
-    local playerEntry = normalizeLeaderboardEntry(cacheEntry and cacheEntry.player_entry or nil, mapUuid)
+    local playerEntry = normalizeLeaderboardEntry(
+        shouldShowCachedEntries and cacheEntry and cacheEntry.player_entry or nil,
+        mapUuid
+    )
 
     for _, entry in ipairs(topEntries) do
         entry.mapName = self:getMapNameByUuid(entry.mapUuid)
@@ -617,18 +664,17 @@ function Game:getLevelSelectPreviewDisplayState(mapUuid)
         end
     end
 
-    local previewState = self.levelSelectPreviewState or {}
     local hasCache = cacheEntry ~= nil
     local hasVisibleEntries = #topEntries > 0 or pinnedPlayerEntry ~= nil
     local isLoading = self.activeLevelSelectPreviewRequestId ~= nil and self.activeLevelSelectPreviewRequestMapUuid == mapUuid
-    local shouldShowSpinner = isLoading or (previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_LOADING and not hasCache)
+    local shouldShowSpinner = isLoading or (previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_LOADING)
     local message = nil
 
-    if shouldShowSpinner and not hasCache then
+    if shouldShowSpinner and not shouldShowCachedEntries then
         message = LEVEL_SELECT_PREVIEW_MESSAGE_LOADING
-    elseif hasCache and not hasVisibleEntries and not playerEntry then
+    elseif shouldShowCachedEntries and hasCache and not hasVisibleEntries and not playerEntry then
         message = LEVEL_SELECT_PREVIEW_MESSAGE_EMPTY
-    elseif previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_ERROR and not hasCache then
+    elseif previewState.mapUuid == mapUuid and previewState.status == LEVEL_SELECT_PREVIEW_STATUS_ERROR and not shouldShowCachedEntries then
         message = previewState.message or LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA
     end
 
@@ -636,7 +682,13 @@ function Game:getLevelSelectPreviewDisplayState(mapUuid)
         topEntries = topEntries,
         pinnedPlayerEntry = pinnedPlayerEntry,
         hasCache = hasCache,
+        showCachedEntries = shouldShowCachedEntries,
         isLoading = shouldShowSpinner,
+        nextRefreshAt = refreshIndicatorLogic.getDisplayNextRefreshAt(
+            shouldShowCachedEntries and tonumber(cacheEntry and cacheEntry.fetched_at) or nil,
+            self.levelSelectPreviewNextFetchAtByMap[mapUuid],
+            LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
+        ),
         message = message,
     }
 end
@@ -748,11 +800,20 @@ function Game:beginLevelSelectPreviewFetch(onlineConfig, mapUuid)
     end
 
     self:ensureLeaderboardWorker()
+    local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    local previewState = self.levelSelectPreviewState or {}
+    local showCachedWhileLoading = previewState.mapUuid == mapUuid
+        and previewState.hasResolvedInitialRemoteAttempt
+        and cacheEntry ~= nil
     self.levelSelectPreviewRequestSequence = self.levelSelectPreviewRequestSequence + 1
     self.activeLevelSelectPreviewRequestId = self.levelSelectPreviewRequestSequence
     self.activeLevelSelectPreviewRequestStartedAt = getNowSeconds()
     self.activeLevelSelectPreviewRequestMapUuid = mapUuid
-    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil)
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil, {
+        forceImmediateFetch = false,
+        showCachedWhileLoading = showCachedWhileLoading,
+        hasResolvedInitialRemoteAttempt = previewState.mapUuid == mapUuid and previewState.hasResolvedInitialRemoteAttempt or false,
+    })
     self.leaderboardRequestChannel:push(json.encode({
         kind = "preview",
         requestId = self.activeLevelSelectPreviewRequestId,
@@ -797,27 +858,46 @@ function Game:applyLevelSelectPreviewFetchResult(response, mapUuid)
     end
 
     local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
+    local previewState = self.levelSelectPreviewState or {}
     if response.ok and type(response.payload) == "table" then
         local fetchedAt = getNowUnixSeconds()
-        self:setLevelSelectPreviewCacheEntry(mapUuid, {
-            map_uuid = mapUuid,
-            top_entries = type(response.payload.top_entries) == "table" and response.payload.top_entries or {},
-            player_entry = type(response.payload.player_entry) == "table" and response.payload.player_entry or nil,
-            target_rank = tonumber(response.payload.target_rank) or nil,
-            fetched_at = fetchedAt,
-        })
         self.levelSelectPreviewNextFetchAtByMap[mapUuid] = fetchedAt + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
-        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+        if not levelSelectPreviewPayloadHasData(response.payload) and cacheEntry ~= nil then
+            self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+                hasResolvedInitialRemoteAttempt = true,
+            })
+            return
+        end
+
+        if previewState.mapUuid == mapUuid and previewState.showCachedWhileLoading and cacheEntry ~= nil then
+            self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil, {
+                hasResolvedInitialRemoteAttempt = true,
+                clearVisibleEntries = true,
+                pendingPayload = response.payload,
+                pendingFetchedAt = fetchedAt,
+                pendingDelayFrames = LEVEL_SELECT_PREVIEW_DISPLAY_SWAP_DELAY_FRAMES,
+            })
+            return
+        end
+
+        self:setLevelSelectPreviewCacheEntry(mapUuid, buildLevelSelectPreviewCacheEntry(mapUuid, response.payload, fetchedAt))
+        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+            hasResolvedInitialRemoteAttempt = true,
+        })
         return
     end
 
     self.levelSelectPreviewNextFetchAtByMap[mapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
     if cacheEntry then
-        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+        self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+            hasResolvedInitialRemoteAttempt = true,
+        })
         return
     end
 
-    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
+        hasResolvedInitialRemoteAttempt = true,
+    })
 end
 
 function Game:beginMarketplaceFetch(onlineConfig, scopeDetails)
@@ -866,7 +946,32 @@ function Game:applyMarketplaceFetchResult(response, scopeKey)
     )
 end
 
+function Game:applyPendingLevelSelectPreviewSwap()
+    local previewState = self.levelSelectPreviewState or {}
+    if not previewState.pendingPayload or not previewState.mapUuid or previewState.mapUuid == "" then
+        return false
+    end
+
+    if (previewState.pendingDelayFrames or 0) > 0 then
+        previewState.pendingDelayFrames = previewState.pendingDelayFrames - 1
+        if previewState.pendingDelayFrames > 0 then
+            self.levelSelectPreviewState = previewState
+            return false
+        end
+    end
+
+    local mapUuid = previewState.mapUuid
+    local fetchedAt = tonumber(previewState.pendingFetchedAt) or getNowUnixSeconds()
+    self:setLevelSelectPreviewCacheEntry(mapUuid, buildLevelSelectPreviewCacheEntry(mapUuid, previewState.pendingPayload, fetchedAt))
+    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+        hasResolvedInitialRemoteAttempt = true,
+    })
+    return true
+end
+
 function Game:updateLeaderboardFetchState()
+    self:applyPendingLevelSelectPreviewSwap()
+
     local requestScopeKey = self.activeLeaderboardRequestScopeKey or getLeaderboardScopeKey(self.leaderboardMapUuid)
     local cacheEntry = self:getLeaderboardCacheEntry(requestScopeKey)
     local activePreviewMapUuid = self.activeLevelSelectPreviewRequestMapUuid
@@ -901,9 +1006,13 @@ function Game:updateLeaderboardFetchState()
                 if activePreviewMapUuid and activePreviewMapUuid ~= "" then
                     self.levelSelectPreviewNextFetchAtByMap[activePreviewMapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
                     if previewCacheEntry then
-                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+                            hasResolvedInitialRemoteAttempt = true,
+                        })
                     else
-                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+                        self:setLevelSelectPreviewState(activePreviewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
+                            hasResolvedInitialRemoteAttempt = true,
+                        })
                     end
                 end
                 self.activeLevelSelectPreviewRequestMapUuid = nil
@@ -953,9 +1062,13 @@ function Game:updateLeaderboardFetchState()
             if previewMapUuid and previewMapUuid ~= "" then
                 self.levelSelectPreviewNextFetchAtByMap[previewMapUuid] = getNowUnixSeconds() + LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
                 if self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
-                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+                        hasResolvedInitialRemoteAttempt = true,
+                    })
                 else
-                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+                    self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
+                        hasResolvedInitialRemoteAttempt = true,
+                    })
                 end
             end
             self.activeLevelSelectPreviewRequestMapUuid = nil
@@ -1019,14 +1132,24 @@ function Game:updateLeaderboardFetchState()
     end
 
     local previewMapUuid = self:getActiveLevelSelectPreviewMapUuid()
-    if previewMapUuid and self.activeLevelSelectPreviewRequestId == nil and not self:isLevelSelectPreviewCacheFresh(previewMapUuid) and self:isLevelSelectPreviewFetchAllowed(previewMapUuid) then
+    if levelSelectPreviewLogic.shouldStartFetch(
+        self.levelSelectPreviewState,
+        previewMapUuid,
+        self.activeLevelSelectPreviewRequestId ~= nil,
+        previewMapUuid and self:isLevelSelectPreviewCacheFresh(previewMapUuid) or false,
+        previewMapUuid and self:isLevelSelectPreviewFetchAllowed(previewMapUuid) or false
+    ) then
         local onlineConfig = self:getActiveOnlineConfig()
         if onlineConfig.isConfigured then
             self:beginLevelSelectPreviewFetch(onlineConfig, previewMapUuid)
         elseif self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
-            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil)
+            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+                hasResolvedInitialRemoteAttempt = true,
+            })
         else
-            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA)
+            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
+                hasResolvedInitialRemoteAttempt = true,
+            })
         end
     end
 
@@ -1729,7 +1852,11 @@ function Game:toggleLevelSelectLeaderboardFlip(mapDescriptor)
     self.levelSelectSelectedId = mapDescriptor.id
     self.levelSelectScroll = 0
     self.levelSelectLeaderboardFlipMapUuid = mapUuid
-    self:setLevelSelectPreviewState(mapUuid, LEVEL_SELECT_PREVIEW_STATUS_LOADING, nil)
+    local openStateOptions = levelSelectPreviewLogic.buildOpenStateOptions(self:isLevelSelectPreviewCacheFresh(mapUuid))
+    self:setLevelSelectPreviewState(mapUuid, openStateOptions.status, nil, {
+        forceImmediateFetch = openStateOptions.forceImmediateFetch,
+        hasResolvedInitialRemoteAttempt = openStateOptions.hasResolvedInitialRemoteAttempt,
+    })
 end
 
 function Game:getBuiltinShortcutMap(index)

--- a/src/game/level_select_preview_logic.lua
+++ b/src/game/level_select_preview_logic.lua
@@ -1,0 +1,53 @@
+local previewLogic = {}
+
+function previewLogic.buildOpenStateOptions(isCacheFresh)
+    if isCacheFresh then
+        return {
+            status = "ready",
+            forceImmediateFetch = false,
+            hasResolvedInitialRemoteAttempt = true,
+        }
+    end
+
+    return {
+        status = "loading",
+        forceImmediateFetch = true,
+        hasResolvedInitialRemoteAttempt = false,
+    }
+end
+
+function previewLogic.shouldStartFetch(previewState, mapUuid, isRequestActive, isCacheFresh, isFetchAllowed)
+    if not mapUuid or mapUuid == "" or isRequestActive then
+        return false
+    end
+
+    local resolvedState = previewState or {}
+    if resolvedState.mapUuid == mapUuid and resolvedState.forceImmediateFetch then
+        return true
+    end
+
+    return (not isCacheFresh) and isFetchAllowed
+end
+
+function previewLogic.shouldShowCachedEntries(previewState, mapUuid, hasCache)
+    if not hasCache then
+        return false
+    end
+
+    local resolvedState = previewState or {}
+    if resolvedState.mapUuid ~= mapUuid then
+        return true
+    end
+
+    if resolvedState.clearVisibleEntries then
+        return false
+    end
+
+    if resolvedState.status == "loading" and not resolvedState.showCachedWhileLoading then
+        return false
+    end
+
+    return true
+end
+
+return previewLogic

--- a/src/game/refresh_indicator_logic.lua
+++ b/src/game/refresh_indicator_logic.lua
@@ -1,0 +1,11 @@
+local refreshIndicatorLogic = {}
+
+function refreshIndicatorLogic.getDisplayNextRefreshAt(fetchedAt, scheduledNextRefreshAt, cacheDurationSeconds)
+    if type(fetchedAt) == "number" then
+        return fetchedAt + (cacheDurationSeconds or 0)
+    end
+
+    return scheduledNextRefreshAt
+end
+
+return refreshIndicatorLogic

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -113,6 +113,12 @@ local LEADERBOARD_LOADING = {
     emptySpinnerYOffset = 34,
     emptyTextYOffset = 68,
 }
+local LEADERBOARD_SCORE_DECIMAL_PLACES = 3
+local LEVEL_SELECT_LEADERBOARD_PLAYER_NAME_MAX_CHARACTERS = 14
+local LEADERBOARD_REFRESH_INDICATOR_RIGHT_PADDING = 28
+local LEADERBOARD_REFRESH_INDICATOR_BOTTOM_PADDING = 18
+local REFRESH_LOADING_ANIMATION_STEP_SECONDS = 0.4
+local REFRESH_LOADING_ANIMATION_FRAME_COUNT = 3
 
 local LEADERBOARD_LAYOUT = {
     panelX = 36,
@@ -154,6 +160,8 @@ local LEVEL_SELECT_LEADERBOARD_CARD = {
     pinnedGap = 12,
     statusPaddingX = 20,
     statusWidthMargin = 40,
+    refreshPaddingRight = 8,
+    refreshPaddingBottom = 2,
 }
 
 local function pointInRect(x, y, rect)
@@ -233,6 +241,84 @@ local function formatScore(value)
     return formatted
 end
 
+local function formatLeaderboardScore(value)
+    return string.format("%." .. tostring(LEADERBOARD_SCORE_DECIMAL_PLACES) .. "f", value or 0)
+end
+
+local function getNowSeconds()
+    if love and love.timer and love.timer.getTime then
+        return love.timer.getTime()
+    end
+
+    return os.clock()
+end
+
+local function getNowUnixSeconds()
+    if os and os.time then
+        return os.time()
+    end
+
+    return math.floor(getNowSeconds())
+end
+
+local function truncateText(text, maxCharacters)
+    local resolvedText = tostring(text or "")
+    local resolvedMaxCharacters = math.max(0, maxCharacters or 0)
+
+    if resolvedText == "" then
+        return resolvedText
+    end
+
+    if utf8 and utf8.len and utf8.offset then
+        local characterCount = utf8.len(resolvedText)
+        if characterCount and characterCount > resolvedMaxCharacters then
+            local endByte = utf8.offset(resolvedText, resolvedMaxCharacters + 1)
+            if endByte then
+                return resolvedText:sub(1, endByte - 1)
+            end
+        end
+        return resolvedText
+    end
+
+    if #resolvedText > resolvedMaxCharacters then
+        return resolvedText:sub(1, resolvedMaxCharacters)
+    end
+
+    return resolvedText
+end
+
+local function formatLevelSelectLeaderboardPlayerName(value)
+    local displayName = tostring(value or "Unknown")
+    if displayName == "" then
+        displayName = "Unknown"
+    end
+    return truncateText(displayName, LEVEL_SELECT_LEADERBOARD_PLAYER_NAME_MAX_CHARACTERS)
+end
+
+local function formatLoadingLabel(baseLabel, animationTime)
+    local resolvedAnimationTime = animationTime or getNowSeconds()
+    local animationFrame = math.floor(resolvedAnimationTime / REFRESH_LOADING_ANIMATION_STEP_SECONDS) % REFRESH_LOADING_ANIMATION_FRAME_COUNT
+    return baseLabel .. string.rep(".", animationFrame + 1)
+end
+
+local function formatLeaderboardRefreshLabel(nextRefreshAt, nowSeconds, isLoading, animationTime)
+    if isLoading then
+        return formatLoadingLabel("Refreshing", animationTime)
+    end
+
+    local resolvedNowSeconds = nowSeconds or getNowSeconds()
+    if type(nextRefreshAt) ~= "number" then
+        return "Refresh in 0s"
+    end
+
+    local remainingSeconds = math.max(0, math.ceil(nextRefreshAt - resolvedNowSeconds))
+    return string.format("Refresh in %ds", remainingSeconds)
+end
+
+local function formatLevelSelectLeaderboardRefreshLabel(nextRefreshAt, nowUnixSeconds, isLoading, animationTime)
+    return formatLeaderboardRefreshLabel(nextRefreshAt, nowUnixSeconds or getNowUnixSeconds(), isLoading, animationTime)
+end
+
 local function drawMetalPanel(rect, innerAlpha)
     local graphics = love.graphics
     local alpha = innerAlpha or 0.98
@@ -257,6 +343,40 @@ local function drawLoadingSpinner(centerX, centerY, color)
     graphics.setLineWidth(LEADERBOARD_LOADING.spinnerThickness)
     graphics.arc("line", "open", centerX, centerY, LEADERBOARD_LOADING.spinnerRadius, startAngle, endAngle)
     graphics.setLineWidth(1)
+end
+
+local function drawLeaderboardRefreshIndicator(game, panel, state)
+    local graphics = love.graphics
+    local label = formatLeaderboardRefreshLabel(
+        state and state.nextRefreshAt or nil,
+        getNowSeconds(),
+        state and state.status == "loading" or false,
+        getNowSeconds()
+    )
+    local textWidth = game.fonts.small:getWidth(label)
+    local textX = panel.x + panel.w - LEADERBOARD_REFRESH_INDICATOR_RIGHT_PADDING - textWidth
+    local textY = panel.y + panel.h - LEADERBOARD_REFRESH_INDICATOR_BOTTOM_PADDING - game.fonts.small:getHeight()
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.68, 0.74, 0.8, 1)
+    graphics.print(label, textX, textY)
+end
+
+local function drawLevelSelectLeaderboardRefreshIndicator(game, contentRect, previewState)
+    local graphics = love.graphics
+    local label = formatLevelSelectLeaderboardRefreshLabel(
+        previewState and previewState.nextRefreshAt or nil,
+        getNowUnixSeconds(),
+        previewState and previewState.isLoading or false,
+        getNowSeconds()
+    )
+    local textWidth = game.fonts.small:getWidth(label)
+    local textX = contentRect.x + contentRect.w - LEVEL_SELECT_LEADERBOARD_CARD.refreshPaddingRight - textWidth
+    local textY = contentRect.y + contentRect.h - LEVEL_SELECT_LEADERBOARD_CARD.refreshPaddingBottom - game.fonts.small:getHeight()
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(PANEL_COLORS.mutedText[1], PANEL_COLORS.mutedText[2], PANEL_COLORS.mutedText[3], PANEL_COLORS.mutedText[4])
+    graphics.print(label, textX, textY)
 end
 
 local function getLeaderboardPanelRect(game)
@@ -1621,7 +1741,7 @@ local function drawLevelSelectLeaderboardRow(game, rowRect, entry, isHighlighted
     local nameX = rowRect.x + LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX + LEVEL_SELECT_LEADERBOARD_CARD.rankWidth
     local nameWidth = rowRect.w - LEVEL_SELECT_LEADERBOARD_CARD.rankWidth - LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth - (LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX * 2)
     graphics.printf(
-        tostring(entry.playerDisplayName or "Unknown"),
+        formatLevelSelectLeaderboardPlayerName(entry.playerDisplayName or "Unknown"),
         nameX,
         rowRect.y + 4,
         math.max(0, nameWidth),
@@ -1629,7 +1749,7 @@ local function drawLevelSelectLeaderboardRow(game, rowRect, entry, isHighlighted
     )
 
     graphics.printf(
-        formatScore(entry.score or 0),
+        formatLeaderboardScore(entry.score or 0),
         rowRect.x + rowRect.w - LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth - LEVEL_SELECT_LEADERBOARD_CARD.rowPaddingX,
         rowRect.y + 4,
         LEVEL_SELECT_LEADERBOARD_CARD.scoreWidth,
@@ -1694,6 +1814,8 @@ local function drawLevelSelectLeaderboardBack(game, rect)
             "center"
         )
     end
+
+    drawLevelSelectLeaderboardRefreshIndicator(game, contentRect, previewState)
 end
 
 local function drawLevelCard(game, rect)
@@ -2594,6 +2716,7 @@ function ui.drawLeaderboard(game)
             contentW,
             "center"
         )
+        drawLeaderboardRefreshIndicator(game, panel, state)
         return
     end
 
@@ -2601,6 +2724,7 @@ function ui.drawLeaderboard(game)
         love.graphics.setFont(game.fonts.body)
         graphics.setColor(0.84, 0.88, 0.92, 1)
         graphics.printf(state.message or "No entries are available yet.", contentX, panel.y + 180, contentW, "center")
+        drawLeaderboardRefreshIndicator(game, panel, state)
         return
     end
 
@@ -2626,7 +2750,7 @@ function ui.drawLeaderboard(game)
         graphics.setColor(0.97, 0.98, 1, 1)
         graphics.print(tostring(entry.rank or 0), contentX + 12, rowY + 2)
         graphics.printf(entry.playerDisplayName or "Unknown", rowRect.player.x, rowY + 2, rowRect.player.w, "left")
-        graphics.printf(formatScore(entry.score or 0), layout.scoreX, rowY + 2, LEADERBOARD_LAYOUT.scoreWidth, "center")
+        graphics.printf(formatLeaderboardScore(entry.score or 0), layout.scoreX, rowY + 2, LEADERBOARD_LAYOUT.scoreWidth, "center")
         if rowRect.map then
             graphics.setColor(0.72, 0.78, 0.84, 1)
             graphics.printf(entry.mapName or "Unknown Map", rowRect.map.x, rowY + 2, rowRect.map.w, "left")
@@ -2644,6 +2768,7 @@ function ui.drawLeaderboard(game)
         )
     end
 
+    drawLeaderboardRefreshIndicator(game, panel, state)
     drawLeaderboardTooltip(game, game.leaderboardHoverInfo)
 end
 
@@ -2969,5 +3094,10 @@ function ui.drawResults(game)
     drawButton(buttons.editor, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
     drawButton(buttons.menu, "Main Menu", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
 end
+
+ui.formatLeaderboardScore = formatLeaderboardScore
+ui.formatLevelSelectLeaderboardPlayerName = formatLevelSelectLeaderboardPlayerName
+ui.formatLeaderboardRefreshLabel = formatLeaderboardRefreshLabel
+ui.formatLevelSelectLeaderboardRefreshLabel = formatLevelSelectLeaderboardRefreshLabel
 
 return ui

--- a/tests/level_select_preview_logic_test.lua
+++ b/tests/level_select_preview_logic_test.lua
@@ -1,0 +1,77 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local previewLogic = require("src.game.level_select_preview_logic")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local freshCacheOpenState = previewLogic.buildOpenStateOptions(true)
+assertEqual(
+    freshCacheOpenState.status,
+    "ready",
+    "opening level select leaderboard with fresh cache stays on the cached data"
+)
+assertEqual(
+    freshCacheOpenState.forceImmediateFetch,
+    false,
+    "opening level select leaderboard with fresh cache does not force an immediate remote fetch"
+)
+
+local staleCacheOpenState = previewLogic.buildOpenStateOptions(false)
+assertEqual(
+    staleCacheOpenState.status,
+    "loading",
+    "opening level select leaderboard without fresh cache starts a remote first load"
+)
+assertEqual(
+    staleCacheOpenState.forceImmediateFetch,
+    true,
+    "opening level select leaderboard without fresh cache forces an immediate remote fetch"
+)
+
+assertEqual(
+    previewLogic.shouldStartFetch(
+        { mapUuid = "map-1", forceImmediateFetch = true },
+        "map-1",
+        false,
+        true,
+        false
+    ),
+    true,
+    "forced remote fetch still starts immediately when the state requests it"
+)
+
+assertEqual(
+    previewLogic.shouldShowCachedEntries(
+        { mapUuid = "map-1", status = "loading", showCachedWhileLoading = false },
+        "map-1",
+        true
+    ),
+    false,
+    "initial remote first load hides cached leaderboard entries"
+)
+
+assertEqual(
+    previewLogic.shouldShowCachedEntries(
+        { mapUuid = "map-1", status = "loading", showCachedWhileLoading = true },
+        "map-1",
+        true
+    ),
+    true,
+    "background refresh keeps cached leaderboard entries visible"
+)
+
+assertEqual(
+    previewLogic.shouldShowCachedEntries(
+        { mapUuid = "map-1", status = "loading", showCachedWhileLoading = false, clearVisibleEntries = true },
+        "map-1",
+        true
+    ),
+    false,
+    "remote swap clears cached leaderboard entries before new data is shown"
+)
+
+print("level select preview logic tests passed")

--- a/tests/refresh_indicator_logic_test.lua
+++ b/tests/refresh_indicator_logic_test.lua
@@ -1,0 +1,23 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local refreshIndicatorLogic = require("src.game.refresh_indicator_logic")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+assertEqual(
+    refreshIndicatorLogic.getDisplayNextRefreshAt(100, 180, 60),
+    160,
+    "display refresh time stays tied to the visible data timestamp"
+)
+
+assertEqual(
+    refreshIndicatorLogic.getDisplayNextRefreshAt(nil, 180, 60),
+    180,
+    "display refresh time falls back to the scheduled retry when no visible data timestamp exists"
+)
+
+print("refresh indicator logic tests passed")

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -1,0 +1,79 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local ui = require("src.game.ui")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+assert(type(ui.formatLeaderboardScore) == "function", "ui.formatLeaderboardScore should exist")
+assertEqual(ui.formatLeaderboardScore(70.3), "70.300", "leaderboard score keeps trailing zeroes")
+assertEqual(ui.formatLeaderboardScore(70.013), "70.013", "leaderboard score keeps thousandths")
+assertEqual(ui.formatLeaderboardScore(70), "70.000", "leaderboard score shows three decimals for integers")
+
+assert(type(ui.formatLevelSelectLeaderboardPlayerName) == "function", "ui.formatLevelSelectLeaderboardPlayerName should exist")
+assertEqual(
+    ui.formatLevelSelectLeaderboardPlayerName("ABCDEFGHIJKLMN"),
+    "ABCDEFGHIJKLMN",
+    "level select leaderboard keeps fourteen character names"
+)
+assertEqual(
+    ui.formatLevelSelectLeaderboardPlayerName("ABCDEFGHIJKLMNO"),
+    "ABCDEFGHIJKLMN",
+    "level select leaderboard truncates names above fourteen characters"
+)
+
+assert(type(ui.formatLeaderboardRefreshLabel) == "function", "ui.formatLeaderboardRefreshLabel should exist")
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(nil, 100),
+    "Refresh in 0s",
+    "leaderboard refresh label falls back to zero seconds without a cooldown"
+)
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(109, 100, true, 0),
+    "Refreshing.",
+    "leaderboard refresh label starts animated loading state with one dot"
+)
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(109, 100, true, 0.4),
+    "Refreshing..",
+    "leaderboard refresh label advances animated loading state to two dots"
+)
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(109, 100, true, 0.8),
+    "Refreshing...",
+    "leaderboard refresh label advances animated loading state to three dots"
+)
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(142, 100),
+    "Refresh in 42s",
+    "leaderboard refresh label shows seconds remaining"
+)
+assertEqual(
+    ui.formatLeaderboardRefreshLabel(100, 100),
+    "Refresh in 0s",
+    "leaderboard refresh label clamps to zero when cooldown expires"
+)
+
+assert(type(ui.formatLevelSelectLeaderboardRefreshLabel) == "function", "ui.formatLevelSelectLeaderboardRefreshLabel should exist")
+assertEqual(
+    ui.formatLevelSelectLeaderboardRefreshLabel(170, 100),
+    "Refresh in 70s",
+    "level select leaderboard refresh label shows seconds remaining"
+)
+assertEqual(
+    ui.formatLevelSelectLeaderboardRefreshLabel(109, 100, true, 0.8),
+    "Refreshing...",
+    "level select leaderboard refresh label shows animated loading state while a fetch is active"
+)
+assertEqual(
+    ui.formatLevelSelectLeaderboardRefreshLabel(nil, 100),
+    "Refresh in 0s",
+    "level select leaderboard refresh label clamps to zero without a cooldown"
+)
+
+print("ui formatting tests passed")


### PR DESCRIPTION
## Requested Behavior
Using the current thread context and the commit and pull request contexts below, generate one git commit message plus one pull request title and body.

## Summary
- Keep leaderboard scores at three decimal places in both leaderboard views.
- Show a refresh indicator in the full leaderboard and level select leaderboard.
- Make level select leaderboard refresh behavior cache aware, so fresh local data displays immediately and background retries do not reset the visible refresh window.
- Add animated loading dots while remote data is actively fetching.

## Testing
- `lua tests/refresh_indicator_logic_test.lua`
- `lua tests/level_select_preview_logic_test.lua`
- `lua tests/ui_formatting_test.lua`
- `lua -e "assert(loadfile('src/game/game.lua'))"`