### PR TITLE
Update leaderboard copy for missing config

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -29,6 +29,7 @@ local LEADERBOARD_MESSAGE_LOADING = "Loading leaderboard..."
 local LEADERBOARD_MESSAGE_EMPTY = "No entries were found for this leaderboard yet."
 local LEADERBOARD_MESSAGE_FETCH_FAILED = "The leaderboard could not be loaded."
 local LEADERBOARD_MESSAGE_NO_DATA = "No data right now."
+local LEADERBOARD_MESSAGE_UNAVAILABLE = "Leaderboard unavailable."
 local LEADERBOARD_MAP_NAME_UNKNOWN = "Unknown Map"
 local LEVEL_SELECT_PREVIEW_ENTRY_LIMIT = 5
 local LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS = 60
@@ -224,6 +225,19 @@ local function logOnlineConfig(onlineConfig)
     for _, errorMessage in ipairs(config.errors or {}) do
         print(string.format("%s config error: %s", ONLINE_CONFIG_LOG_PREFIX, errorMessage))
     end
+end
+
+local function getLeaderboardUnavailableMessage()
+    return LEADERBOARD_MESSAGE_UNAVAILABLE
+end
+
+local function normalizeLeaderboardErrorMessage(message)
+    local text = tostring(message or "")
+    if text:find("API_KEY", 1, true) or text:find("API_BASE_URL", 1, true) or text:find(".env", 1, true) then
+        return getLeaderboardUnavailableMessage()
+    end
+
+    return text ~= "" and text or LEADERBOARD_MESSAGE_FETCH_FAILED
 end
 
 function Game.new()
@@ -780,7 +794,7 @@ function Game:applyLeaderboardFetchResult(response)
     end
 
     self.leaderboardNextFetchAtByScope[requestScopeKey] = getNowSeconds() + LEADERBOARD_CACHE_DURATION_SECONDS
-    local fetchMessage = response.error or LEADERBOARD_MESSAGE_FETCH_FAILED
+    local fetchMessage = normalizeLeaderboardErrorMessage(response.error)
     if requestScopeKey == getLeaderboardScopeKey(self.leaderboardMapUuid) then
         self.leaderboardState = self:buildLeaderboardState(
             LEADERBOARD_STATUS_ERROR,
@@ -1008,7 +1022,7 @@ function Game:updateLeaderboardFetchState()
         if not onlineConfig.isConfigured then
             self.leaderboardState = self:buildLeaderboardState(
                 LEADERBOARD_STATUS_DISABLED,
-                table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
+                getLeaderboardUnavailableMessage(),
                 cacheEntry.payload,
                 cacheEntry.fetchedAt
             )
@@ -1130,7 +1144,7 @@ function Game:submitResultsScore()
     if not onlineConfig.isConfigured then
         self.resultsOnlineState = {
             status = "disabled",
-            message = table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
+            message = getLeaderboardUnavailableMessage(),
         }
         return
     end
@@ -1378,7 +1392,7 @@ function Game:refreshLeaderboard()
     if not onlineConfig.isConfigured then
         self.leaderboardState = self:buildLeaderboardState(
             LEADERBOARD_STATUS_DISABLED,
-            table.concat(onlineConfig.errors or { "The online leaderboard is not configured." }, " "),
+            getLeaderboardUnavailableMessage(),
             cacheEntry.payload,
             cacheEntry.fetchedAt
         )

--- a/src/game/leaderboard_fetch_thread.lua
+++ b/src/game/leaderboard_fetch_thread.lua
@@ -12,6 +12,7 @@ local DEFAULT_MARKETPLACE_LIMIT = 10
 local DEFAULT_REQUEST_TIMEOUT_SECONDS = 5
 local MARKETPLACE_MODE_FAVORITES = "favorites"
 local MARKETPLACE_MODE_SEARCH = "search"
+local LEADERBOARD_UNAVAILABLE_MESSAGE = "Leaderboard unavailable."
 
 local requestChannel = love.thread.getChannel(REQUEST_CHANNEL_NAME)
 local responseChannel = love.thread.getChannel(RESPONSE_CHANNEL_NAME)
@@ -48,11 +49,11 @@ end
 
 local function validateConfig(config)
     if tostring(config.apiKey or "") == "" then
-        return nil, "API_KEY is missing."
+        return nil, LEADERBOARD_UNAVAILABLE_MESSAGE
     end
 
     if normalizeBaseUrl(config.apiBaseUrl) == "" then
-        return nil, "API_BASE_URL is missing."
+        return nil, LEADERBOARD_UNAVAILABLE_MESSAGE
     end
 
     return true


### PR DESCRIPTION
## Requested Behavior
When `.env` is missing or the project cannot load it, the leaderboard screen should not show the full config error text. It should show only a short player-facing message that says the leaderboard or prediction is unavailable, without exposing API key or regression details.

## Summary
- Replaced verbose missing-config text with a short `Leaderboard unavailable.` message in leaderboard and results UI paths.
- Normalized leaderboard fetch errors so `.env`, `API_KEY`, and `API_BASE_URL` details stay out of the scoreboard.
- Kept the detailed config diagnostics in internal logging and backend-facing paths.

## Testing
- Not run (not requested)