### PR TITLE
Fix crossbar minimum distance lookup

### DIFF
--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -812,6 +812,38 @@ function world:doesEdgeAcceptGoalColor(inputEdge, outputEdge, goalColor)
     return outputEdge and nearestColorId(outputEdge.color) == goalColor or false
 end
 
+function world:getReachableOutputEdgesForInput(junction, inputEdgeId)
+    if not junction or not inputEdgeId or #((junction and junction.outputs) or {}) <= 0 then
+        return {}
+    end
+
+    local inputIndex = nil
+    for candidateIndex, inputEdge in ipairs(junction.inputs or {}) do
+        if inputEdge.id == inputEdgeId then
+            inputIndex = candidateIndex
+            break
+        end
+    end
+
+    if not inputIndex then
+        return {}
+    end
+
+    local controlType = junction.control and junction.control.type or "direct"
+    if controlType == "relay" then
+        local relayOutput = junction.outputs[clamp(inputIndex, 1, #junction.outputs)]
+        return relayOutput and { relayOutput } or {}
+    end
+
+    if controlType == "crossbar" then
+        local mirroredOutputIndex = clamp(#junction.outputs - inputIndex + 1, 1, #junction.outputs)
+        local crossbarOutput = junction.outputs[mirroredOutputIndex]
+        return crossbarOutput and { crossbarOutput } or {}
+    end
+
+    return junction.outputs
+end
+
 function world:buildMinimumDistanceLookup()
     self.minimumDistanceByTrainId = {}
 
@@ -859,7 +891,7 @@ function world:buildMinimumDistanceLookup()
                 end
 
                 local junction = self.junctions[currentEdge.targetId]
-                for _, outputEdge in ipairs(junction and junction.outputs or {}) do
+                for _, outputEdge in ipairs(self:getReachableOutputEdgesForInput(junction, currentEdge.id)) do
                     if self:doesEdgeAcceptGoalColor(currentEdge, outputEdge, goalColor) then
                         local nextDistance = current.distance + outputEdge.path.length
                         if outputEdge.targetType == "exit" then

--- a/tests/world_minimum_distance_crossbar_test.lua
+++ b/tests/world_minimum_distance_crossbar_test.lua
@@ -1,0 +1,110 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local world = require("src.game.world")
+
+local function assertNear(actual, expected, tolerance, label)
+    if math.abs(actual - expected) > tolerance then
+        error(string.format("%s expected %.6f but got %.6f", label, expected, actual), 2)
+    end
+end
+
+local simulation = world.new(100, 100, {
+    junctions = {
+        {
+            id = "crossbar_test",
+            label = "Crossbar Test",
+            control = { type = "crossbar" },
+            activeInputIndex = 1,
+            inputs = {
+                {
+                    id = "input_blue",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    inputPoints = {
+                        { x = 0.10, y = 0.00 },
+                        { x = 0.10, y = 0.30 },
+                        { x = 0.50, y = 0.50 },
+                    },
+                },
+                {
+                    id = "input_mint",
+                    color = { 0.40, 0.92, 0.76 },
+                    colors = { "mint" },
+                    inputPoints = {
+                        { x = 0.30, y = 0.00 },
+                        { x = 0.30, y = 0.30 },
+                        { x = 0.50, y = 0.50 },
+                    },
+                },
+                {
+                    id = "input_yellow",
+                    color = { 0.98, 0.82, 0.34 },
+                    colors = { "yellow" },
+                    inputPoints = {
+                        { x = 0.50, y = 0.00 },
+                        { x = 0.50, y = 0.30 },
+                        { x = 0.50, y = 0.50 },
+                    },
+                },
+            },
+            outputs = {
+                {
+                    id = "blue_short_exit",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    outputPoints = {
+                        { x = 0.50, y = 0.50 },
+                        { x = 0.60, y = 0.50 },
+                    },
+                },
+                {
+                    id = "blue_mid_exit",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    outputPoints = {
+                        { x = 0.50, y = 0.50 },
+                        { x = 0.70, y = 0.50 },
+                    },
+                },
+                {
+                    id = "blue_long_exit",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    outputPoints = {
+                        { x = 0.50, y = 0.50 },
+                        { x = 0.80, y = 0.50 },
+                    },
+                },
+            },
+        },
+    },
+    trains = {
+        {
+            id = "blue_train",
+            junctionId = "crossbar_test",
+            inputIndex = 1,
+            goalColor = "blue",
+        },
+    },
+})
+
+local train = simulation.trains[1]
+local startEdge = simulation.edges[train.startEdgeId]
+local reachableCrossbarExit = simulation.junctions.crossbar_test.outputs[3]
+local unreachableShorterExit = simulation.junctions.crossbar_test.outputs[1]
+local expectedMinimumDistance = startEdge.path.length + reachableCrossbarExit.path.length
+
+assertNear(
+    train.minimumDistance,
+    expectedMinimumDistance,
+    0.0001,
+    "crossbar minimum distance uses the mirrored reachable output"
+)
+
+if math.abs(train.minimumDistance - (startEdge.path.length + unreachableShorterExit.path.length)) <= 0.0001 then
+    error("crossbar minimum distance incorrectly used the globally shortest unreachable exit", 2)
+end
+
+print("world minimum distance crossbar tests passed")


### PR DESCRIPTION
## Requested Behavior
Crossbar map optimal distance is not correctly calculated (always only from shortest path that is not possible for all trians).
We should only calculate based on the actual shortest path that is reachable for that train.

## What Changed
- constrain minimum-distance lookup to outputs that are actually reachable from the train's incoming edge
- respect crossbar mirrored routing and relay input-to-output locking during score path evaluation
- add a regression test covering the crossbar case where the globally shortest matching exit is unreachable

## Verification
- ran the new crossbar minimum-distance regression test with a temporary LÖVE console harness
- confirmed the test passes and the reachable mirrored output is used for scoring