### PR TITLE
Fix level select leaderboard row placement

### DIFF
--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -1951,6 +1951,45 @@ local function drawLevelSelectLeaderboardRow(game, rowRect, entry, isHighlighted
     )
 end
 
+local function getLevelSelectLeaderboardVisibleEntries(topEntries, pinnedPlayerEntry, maxRows)
+    local resolvedMaxRows = math.max(0, tonumber(maxRows) or LEVEL_SELECT_LEADERBOARD_CARD.maxRows)
+    local visibleTopEntries = {}
+    local visiblePinnedPlayerEntry = pinnedPlayerEntry
+    local visibleTopEntryLimit = resolvedMaxRows
+
+    if visiblePinnedPlayerEntry and visibleTopEntryLimit > 0 then
+        visibleTopEntryLimit = visibleTopEntryLimit - 1
+    end
+
+    for index, entry in ipairs(topEntries or {}) do
+        if index > visibleTopEntryLimit then
+            break
+        end
+
+        visibleTopEntries[#visibleTopEntries + 1] = entry
+    end
+
+    if resolvedMaxRows <= 0 then
+        visiblePinnedPlayerEntry = nil
+    end
+
+    return visibleTopEntries, visiblePinnedPlayerEntry
+end
+
+local function getLevelSelectLeaderboardPinnedRowY(contentRect, visibleEntryCount)
+    local resolvedVisibleEntryCount = math.max(0, tonumber(visibleEntryCount) or 0)
+    local baseRowY = contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.rowTop
+
+    if resolvedVisibleEntryCount == 0 then
+        return baseRowY
+    end
+
+    return baseRowY
+        + (resolvedVisibleEntryCount * LEVEL_SELECT_LEADERBOARD_CARD.rowHeight)
+        + ((resolvedVisibleEntryCount - 1) * LEVEL_SELECT_LEADERBOARD_CARD.rowGap)
+        + LEVEL_SELECT_LEADERBOARD_CARD.pinnedGap
+end
+
 local function drawLevelSelectLeaderboardBack(game, rect)
     local graphics = love.graphics
     local contentRect = {
@@ -1960,8 +1999,11 @@ local function drawLevelSelectLeaderboardBack(game, rect)
         h = rect.h - (LEVEL_SELECT_LEADERBOARD_CARD.inset * 2),
     }
     local previewState = game:getLevelSelectPreviewDisplayState(rect.map.mapUuid)
-    local topEntries = previewState.topEntries or {}
-    local pinnedPlayerEntry = previewState.pinnedPlayerEntry
+    local topEntries, pinnedPlayerEntry = getLevelSelectLeaderboardVisibleEntries(
+        previewState.topEntries or {},
+        previewState.pinnedPlayerEntry,
+        LEVEL_SELECT_LEADERBOARD_CARD.maxRows
+    )
     local rowY = contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.rowTop
 
     love.graphics.setFont(game.fonts.body)
@@ -1987,7 +2029,7 @@ local function drawLevelSelectLeaderboardBack(game, rect)
     if pinnedPlayerEntry then
         local pinnedRowRect = {
             x = contentRect.x,
-            y = contentRect.y + contentRect.h - LEVEL_SELECT_LEADERBOARD_CARD.rowHeight,
+            y = getLevelSelectLeaderboardPinnedRowY(contentRect, #topEntries),
             w = contentRect.w,
             h = LEVEL_SELECT_LEADERBOARD_CARD.rowHeight,
         }
@@ -3314,5 +3356,7 @@ ui.formatLeaderboardScore = formatLeaderboardScore
 ui.formatLevelSelectLeaderboardPlayerName = formatLevelSelectLeaderboardPlayerName
 ui.formatLeaderboardRefreshLabel = formatLeaderboardRefreshLabel
 ui.formatLevelSelectLeaderboardRefreshLabel = formatLevelSelectLeaderboardRefreshLabel
+ui.getLevelSelectLeaderboardVisibleEntries = getLevelSelectLeaderboardVisibleEntries
+ui.getLevelSelectLeaderboardPinnedRowY = getLevelSelectLeaderboardPinnedRowY
 
 return ui

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -76,4 +76,35 @@ assertEqual(
     "level select leaderboard refresh label clamps to zero without a cooldown"
 )
 
+assert(type(ui.getLevelSelectLeaderboardVisibleEntries) == "function", "ui.getLevelSelectLeaderboardVisibleEntries should exist")
+
+local visibleTopEntriesOnly, visiblePinnedEntryOnly = ui.getLevelSelectLeaderboardVisibleEntries(
+    { { rank = 1 }, { rank = 2 }, { rank = 3 }, { rank = 4 }, { rank = 5 }, { rank = 6 } },
+    nil,
+    5
+)
+assertEqual(#visibleTopEntriesOnly, 5, "level select leaderboard shows at most five top rows without a pinned player")
+assertEqual(visiblePinnedEntryOnly, nil, "level select leaderboard keeps pinned player empty when none exists")
+
+local pinnedPlayerEntry = { rank = 12 }
+local visibleTopEntriesWithPinned, visiblePinnedEntryWithPinned = ui.getLevelSelectLeaderboardVisibleEntries(
+    { { rank = 1 }, { rank = 2 }, { rank = 3 }, { rank = 4 }, { rank = 5 } },
+    pinnedPlayerEntry,
+    5
+)
+assertEqual(#visibleTopEntriesWithPinned, 4, "level select leaderboard reserves one slot for the pinned player")
+assertEqual(visiblePinnedEntryWithPinned, pinnedPlayerEntry, "level select leaderboard keeps the pinned player visible")
+
+assert(type(ui.getLevelSelectLeaderboardPinnedRowY) == "function", "ui.getLevelSelectLeaderboardPinnedRowY should exist")
+assertEqual(
+    ui.getLevelSelectLeaderboardPinnedRowY({ y = 100 }, 0),
+    156,
+    "level select leaderboard places a pinned row in the first slot when no top rows exist"
+)
+assertEqual(
+    ui.getLevelSelectLeaderboardPinnedRowY({ y = 100 }, 4),
+    282,
+    "level select leaderboard places a pinned row directly below the visible entries"
+)
+
 print("ui formatting tests passed")


### PR DESCRIPTION
## Requested Behavior
We have the problem, there are no five entries, but I'm on the same place with someone else, and I'm not on the right line. I'm in the line where the refreshing is, so the refreshing text, and I'm not under the latest robot.

## Summary
- Keep the level select leaderboard to five visible rows total.
- Place the pinned player row in the normal stack instead of anchoring it to the refresh area.
- Add unit coverage for the visible-row cap and pinned-row placement math.

## Testing
- `lua tests/ui_formatting_test.lua`
- `lua tests/level_select_preview_logic_test.lua`