### PR TITLE
Update offline mode and profile setup dialog behavior

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -385,6 +385,7 @@ function Game.new()
     self.profileSetupNameBuffer = profile.playerDisplayName or ""
     self.profileSetupError = nil
     self.profileModeSelection = getProfilePlayMode(profile) ~= "" and getProfilePlayMode(profile) or PLAY_MODE_OFFLINE
+    self.profileModeHoverId = nil
     self.profileModeSetupError = nil
     self.playOverlayMode = nil
     self.leaderboardState = {
@@ -584,7 +585,7 @@ function Game:buildLocalLeaderboardEntry(mapUuid, scoreEntry, rank)
 end
 
 function Game:buildLocalLeaderboardPayload(mapUuid)
-    local latestUpdatedAt = nil
+    local latestRecordedAt = nil
     local payload = {
         entries = {},
         map_uuid = mapUuid,
@@ -600,7 +601,7 @@ function Game:buildLocalLeaderboardPayload(mapUuid)
 
         local localEntry = self:buildLocalLeaderboardEntry(mapUuid, scoreEntry, 1)
         payload.entries[1] = localEntry
-        return payload, tonumber(scoreEntry.updated_at or 0) or 0
+        return payload, tonumber(scoreEntry.recorded_at or scoreEntry.recordedAt or scoreEntry.updated_at or scoreEntry.updatedAt or 0) or 0
     end
 
     local entriesByMap = self.localScoreboard and (self.localScoreboard.entries_by_map or self.localScoreboard.entriesByMap) or {}
@@ -608,9 +609,9 @@ function Game:buildLocalLeaderboardPayload(mapUuid)
         local localEntry = self:buildLocalLeaderboardEntry(entryMapUuid, scoreEntry)
         if localEntry then
             payload.entries[#payload.entries + 1] = localEntry
-            local updatedAt = tonumber(scoreEntry.updated_at or 0) or 0
-            if latestUpdatedAt == nil or updatedAt > latestUpdatedAt then
-                latestUpdatedAt = updatedAt
+            local recordedAt = tonumber(scoreEntry.recorded_at or scoreEntry.recordedAt or scoreEntry.updated_at or scoreEntry.updatedAt or 0) or 0
+            if latestRecordedAt == nil or recordedAt > latestRecordedAt then
+                latestRecordedAt = recordedAt
             end
         end
     end
@@ -620,10 +621,10 @@ function Game:buildLocalLeaderboardPayload(mapUuid)
             return a.score > b.score
         end
 
-        local aUpdatedAt = tonumber(a.updated_at or 0) or 0
-        local bUpdatedAt = tonumber(b.updated_at or 0) or 0
-        if aUpdatedAt ~= bUpdatedAt then
-            return aUpdatedAt > bUpdatedAt
+        local aRecordedAt = tonumber(a.recorded_at or a.recordedAt or a.updated_at or a.updatedAt or 0) or 0
+        local bRecordedAt = tonumber(b.recorded_at or b.recordedAt or b.updated_at or b.updatedAt or 0) or 0
+        if aRecordedAt ~= bRecordedAt then
+            return aRecordedAt > bRecordedAt
         end
 
         return tostring(a.map_uuid or "") < tostring(b.map_uuid or "")
@@ -633,7 +634,7 @@ function Game:buildLocalLeaderboardPayload(mapUuid)
         entry.rank = index
     end
 
-    return payload, latestUpdatedAt
+    return payload, latestRecordedAt
 end
 
 function Game:getLocalLevelSelectPreviewDisplayState(mapUuid)
@@ -3235,6 +3236,12 @@ function Game:mousemoved(x, y)
     if self.screen == "leaderboard" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
         self.leaderboardHoverInfo = ui.getLeaderboardHoverInfoAt(self, viewportX, viewportY)
+        return
+    end
+
+    if self.screen == "profile_mode_setup" then
+        local viewportX, viewportY = self:toViewportPosition(x, y)
+        self.profileModeHoverId = ui.getProfileModeSetupActionAt(self, viewportX, viewportY)
         return
     end
 

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -221,6 +221,7 @@ local function normalizeLeaderboardEntry(entry, fallbackMapUuid, fallbackRank)
         score = tonumber(entry.score or 0) or 0,
         rank = tonumber(entry.rank) or fallbackRank or 0,
         mapUuid = entry.map_uuid or entry.last_map_uuid or fallbackMapUuid,
+        recordedAt = entry.recorded_at or entry.recordedAt or entry.updated_at or entry.updatedAt,
         updatedAt = entry.updated_at or entry.updatedAt,
     }
 end
@@ -578,7 +579,7 @@ function Game:buildLocalLeaderboardEntry(mapUuid, scoreEntry, rank)
         score = tonumber(scoreEntry.score or 0) or 0,
         rank = rank or 1,
         map_uuid = mapUuid,
-        updated_at = tonumber(scoreEntry.updated_at or 0) or 0,
+        recorded_at = tonumber(scoreEntry.recorded_at or scoreEntry.recordedAt or scoreEntry.updated_at or scoreEntry.updatedAt or 0) or 0,
     }
 end
 

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -1,6 +1,7 @@
 local input = require("src.game.input")
 local mapEditor = require("src.game.map_editor")
 local mapStorage = require("src.game.map_storage")
+local localScoreStorage = require("src.game.local_score_storage")
 local profileStorage = require("src.game.profile_storage")
 local leaderboardClient = require("src.game.leaderboard_client")
 local leaderboardPreviewCache = require("src.game.leaderboard_preview_cache")
@@ -74,6 +75,20 @@ local ONLINE_WRITE_TIMEOUT_SECONDS = 5
 local LEVEL_SELECT_ACTION_STATUS_INFO = "info"
 local LEVEL_SELECT_ACTION_STATUS_SUCCESS = "success"
 local LEVEL_SELECT_ACTION_STATUS_ERROR = "error"
+local PLAY_MODE_ONLINE = "online"
+local PLAY_MODE_OFFLINE = "offline"
+local PROFILE_NAME_MAX_LENGTH = 24
+local LEADERBOARD_REFRESH_LABEL_LOCAL_ONLY = "Local Only"
+local LEADERBOARD_MESSAGE_NO_LOCAL_SCORES = "No local personal scores yet."
+local LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_BEST = "No local personal best yet."
+local LEVEL_SELECT_PREVIEW_TITLE_PERSONAL_BEST = "Personal Best"
+local LEADERBOARD_TITLE_ONLINE = "Online Leaderboard"
+local LEADERBOARD_TITLE_PERSONAL = "Personal Scores"
+local LEADERBOARD_TITLE_MAP = "Map Leaderboard"
+local LEADERBOARD_TITLE_MAP_PERSONAL = "Personal Best"
+local RESULTS_MESSAGE_LOCAL_BEST_SAVED = "Saved a new local personal best."
+local RESULTS_MESSAGE_LOCAL_BEST_KEPT = "Your local personal best stays higher."
+local RESULTS_MESSAGE_LOCAL_SAVE_FAILED = "The local personal score could not be saved."
 
 local function getNowSeconds()
     if love and love.timer and love.timer.getTime then
@@ -171,6 +186,14 @@ local function getProfilePlayerUuid(profile)
     end
 
     return tostring(profile.player_uuid or profile.playerId or profile.playerUuid or "")
+end
+
+local function getProfilePlayMode(profile)
+    if type(profile) ~= "table" then
+        return ""
+    end
+
+    return tostring(profile.playMode or "")
 end
 
 local function deepCopy(value)
@@ -290,9 +313,17 @@ function Game.new()
     }
 
     self.profile = profile
+    self.localScoreboard = localScoreStorage.load()
     self.onlineConfig = leaderboardClient.getConfig()
     logOnlineConfig(self.onlineConfig)
-    self.screen = trim(profile.playerDisplayName) ~= "" and "menu" or "profile_setup"
+    self.screen = "profile_setup"
+    if trim(profile.playerDisplayName) ~= "" then
+        if getProfilePlayMode(profile) == PLAY_MODE_ONLINE or getProfilePlayMode(profile) == PLAY_MODE_OFFLINE then
+            self.screen = "menu"
+        else
+            self.screen = "profile_mode_setup"
+        end
+    end
     self.levelComplete = false
     self.failureReason = nil
     self.world = nil
@@ -352,6 +383,8 @@ function Game.new()
     self.resultsOnlineState = nil
     self.profileSetupNameBuffer = profile.playerDisplayName or ""
     self.profileSetupError = nil
+    self.profileModeSelection = getProfilePlayMode(profile) ~= "" and getProfilePlayMode(profile) or PLAY_MODE_OFFLINE
+    self.profileModeSetupError = nil
     self.playOverlayMode = nil
     self.leaderboardState = {
         status = LEADERBOARD_STATUS_IDLE,
@@ -362,7 +395,7 @@ function Game.new()
     }
     self.leaderboardReturnScreen = "menu"
     self.leaderboardMapUuid = nil
-    self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardTitle = self:getLeaderboardTitle(nil)
     self.leaderboardHoverInfo = nil
     self.leaderboardCacheByScope = {}
     self.leaderboardNextFetchAtByScope = {}
@@ -437,6 +470,7 @@ function Game:buildLeaderboardState(status, message, rawEntries, fetchedAt)
             LEADERBOARD_CACHE_DURATION_SECONDS
         ),
         scope = type(rawEntries) == "table" and rawEntries.scope or (self.leaderboardMapUuid and LEADERBOARD_SCOPE_MAP or LEADERBOARD_SCOPE_GLOBAL),
+        refreshLabel = type(rawEntries) == "table" and rawEntries.refreshLabel or nil,
     }
 end
 
@@ -454,6 +488,13 @@ function Game:isLeaderboardFetchAllowed()
 end
 
 function Game:getActiveOnlineConfig()
+    if not self:isOnlineMode() then
+        return {
+            isConfigured = false,
+            errors = { "Offline mode is enabled." },
+        }
+    end
+
     local resolvedConfig = self:reloadOnlineConfig()
     if resolvedConfig and resolvedConfig.isConfigured then
         return resolvedConfig
@@ -464,6 +505,236 @@ function Game:getActiveOnlineConfig()
     end
 
     return resolvedConfig
+end
+
+function Game:isPlayModeConfigured()
+    local playMode = getProfilePlayMode(self.profile)
+    return playMode == PLAY_MODE_ONLINE or playMode == PLAY_MODE_OFFLINE
+end
+
+function Game:isOfflineMode()
+    return getProfilePlayMode(self.profile) == PLAY_MODE_OFFLINE
+end
+
+function Game:isOnlineMode()
+    return getProfilePlayMode(self.profile) == PLAY_MODE_ONLINE
+end
+
+function Game:getLeaderboardButtonLabel()
+    if self:isOfflineMode() then
+        return "Personal Scores"
+    end
+
+    return LEADERBOARD_TITLE_ONLINE
+end
+
+function Game:getLeaderboardTitle(mapUuid)
+    if mapUuid and mapUuid ~= "" then
+        if self:isOfflineMode() then
+            return LEADERBOARD_TITLE_MAP_PERSONAL
+        end
+
+        return LEADERBOARD_TITLE_MAP
+    end
+
+    if self:isOfflineMode() then
+        return LEADERBOARD_TITLE_PERSONAL
+    end
+
+    return LEADERBOARD_TITLE_ONLINE
+end
+
+function Game:getPlayModeButtonLabel()
+    if self:isOfflineMode() then
+        return "Mode: Offline"
+    end
+
+    return "Mode: Online"
+end
+
+function Game:getLocalScoreEntry(mapUuid)
+    if not mapUuid or mapUuid == "" then
+        return nil
+    end
+
+    local scoreboard = self.localScoreboard or {}
+    local entriesByMap = scoreboard.entries_by_map or scoreboard.entriesByMap or {}
+    local entry = entriesByMap[mapUuid]
+    if type(entry) ~= "table" then
+        return nil
+    end
+
+    return entry
+end
+
+function Game:buildLocalLeaderboardEntry(mapUuid, scoreEntry, rank)
+    if not mapUuid or mapUuid == "" or type(scoreEntry) ~= "table" then
+        return nil
+    end
+
+    return {
+        display_name = self.profile.playerDisplayName or "Unknown",
+        player_uuid = getProfilePlayerUuid(self.profile),
+        score = tonumber(scoreEntry.score or 0) or 0,
+        rank = rank or 1,
+        map_uuid = mapUuid,
+        updated_at = tonumber(scoreEntry.updated_at or 0) or 0,
+    }
+end
+
+function Game:buildLocalLeaderboardPayload(mapUuid)
+    local latestUpdatedAt = nil
+    local payload = {
+        entries = {},
+        map_uuid = mapUuid,
+        scope = mapUuid and LEADERBOARD_SCOPE_MAP or LEADERBOARD_SCOPE_GLOBAL,
+        refreshLabel = LEADERBOARD_REFRESH_LABEL_LOCAL_ONLY,
+    }
+
+    if mapUuid and mapUuid ~= "" then
+        local scoreEntry = self:getLocalScoreEntry(mapUuid)
+        if not scoreEntry then
+            return payload, nil
+        end
+
+        local localEntry = self:buildLocalLeaderboardEntry(mapUuid, scoreEntry, 1)
+        payload.entries[1] = localEntry
+        return payload, tonumber(scoreEntry.updated_at or 0) or 0
+    end
+
+    local entriesByMap = self.localScoreboard and (self.localScoreboard.entries_by_map or self.localScoreboard.entriesByMap) or {}
+    for entryMapUuid, scoreEntry in pairs(entriesByMap or {}) do
+        local localEntry = self:buildLocalLeaderboardEntry(entryMapUuid, scoreEntry)
+        if localEntry then
+            payload.entries[#payload.entries + 1] = localEntry
+            local updatedAt = tonumber(scoreEntry.updated_at or 0) or 0
+            if latestUpdatedAt == nil or updatedAt > latestUpdatedAt then
+                latestUpdatedAt = updatedAt
+            end
+        end
+    end
+
+    table.sort(payload.entries, function(a, b)
+        if a.score ~= b.score then
+            return a.score > b.score
+        end
+
+        local aUpdatedAt = tonumber(a.updated_at or 0) or 0
+        local bUpdatedAt = tonumber(b.updated_at or 0) or 0
+        if aUpdatedAt ~= bUpdatedAt then
+            return aUpdatedAt > bUpdatedAt
+        end
+
+        return tostring(a.map_uuid or "") < tostring(b.map_uuid or "")
+    end)
+
+    for index, entry in ipairs(payload.entries) do
+        entry.rank = index
+    end
+
+    return payload, latestUpdatedAt
+end
+
+function Game:getLocalLevelSelectPreviewDisplayState(mapUuid)
+    local localScoreEntry = self:getLocalScoreEntry(mapUuid)
+    if not localScoreEntry then
+        return {
+            topEntries = {},
+            pinnedPlayerEntry = nil,
+            hasCache = false,
+            showCachedEntries = true,
+            isLoading = false,
+            nextRefreshAt = nil,
+            message = LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_BEST,
+            refreshLabel = LEADERBOARD_REFRESH_LABEL_LOCAL_ONLY,
+            title = LEVEL_SELECT_PREVIEW_TITLE_PERSONAL_BEST,
+        }
+    end
+
+    local localEntry = normalizeLeaderboardEntry(
+        self:buildLocalLeaderboardEntry(mapUuid, localScoreEntry, 1),
+        mapUuid,
+        1
+    )
+    if localEntry then
+        localEntry.mapName = self:getMapNameByUuid(localEntry.mapUuid)
+    end
+
+    return {
+        topEntries = localEntry and { localEntry } or {},
+        pinnedPlayerEntry = nil,
+        hasCache = localEntry ~= nil,
+        showCachedEntries = true,
+        isLoading = false,
+        nextRefreshAt = nil,
+        message = localEntry and nil or LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_BEST,
+        refreshLabel = LEADERBOARD_REFRESH_LABEL_LOCAL_ONLY,
+        title = LEVEL_SELECT_PREVIEW_TITLE_PERSONAL_BEST,
+    }
+end
+
+function Game:updateLocalScoreboard(summary)
+    local updatedScoreboard, isNewBest = localScoreStorage.updateBestScore(self.localScoreboard or {}, summary or {})
+    self.localScoreboard = updatedScoreboard
+
+    if not isNewBest then
+        return true, false
+    end
+
+    local savedScoreboard, saveError = localScoreStorage.save(updatedScoreboard)
+    if not savedScoreboard then
+        return false, true, saveError
+    end
+
+    self.localScoreboard = savedScoreboard
+    return true, true
+end
+
+function Game:clearOnlineRequestState()
+    self.activeLeaderboardRequestId = nil
+    self.activeLeaderboardRequestStartedAt = nil
+    self.activeLeaderboardRequestScopeKey = nil
+    self.activeLevelSelectPreviewRequestId = nil
+    self.activeLevelSelectPreviewRequestStartedAt = nil
+    self.activeLevelSelectPreviewRequestMapUuid = nil
+    self.activeMarketplaceRequestId = nil
+    self.activeMarketplaceRequestStartedAt = nil
+    self.activeMarketplaceRequestScopeKey = nil
+    self.activeFavoriteMapRequestId = nil
+    self.activeFavoriteMapRequestStartedAt = nil
+    self.activeFavoriteMapMapUuid = nil
+    self.activeUploadMapRequestId = nil
+    self.activeUploadMapRequestStartedAt = nil
+    self.activeScoreSubmitRequestId = nil
+    self.activeScoreSubmitRequestStartedAt = nil
+end
+
+function Game:setPlayMode(playMode)
+    if playMode ~= PLAY_MODE_ONLINE and playMode ~= PLAY_MODE_OFFLINE then
+        return false, "Select online or offline mode before continuing."
+    end
+
+    local previousPlayMode = self.profile.playMode
+    self.profile.playMode = playMode
+    local ok, saveError = self:saveProfile()
+    if not ok then
+        self.profile.playMode = previousPlayMode
+        return false, saveError or "The play mode could not be saved."
+    end
+
+    self.profileModeSelection = playMode
+    self.profileModeSetupError = nil
+    self:clearOnlineRequestState()
+    self:clearLevelSelectLeaderboardFlip()
+    if self:isOfflineMode() then
+        self.levelSelectMode = LEVEL_SELECT_MODE_LIBRARY
+    end
+    return true
+end
+
+function Game:togglePlayMode()
+    local nextPlayMode = self:isOfflineMode() and PLAY_MODE_ONLINE or PLAY_MODE_OFFLINE
+    return self:setPlayMode(nextPlayMode)
 end
 
 function Game:setLevelSelectActionState(status, message)
@@ -682,6 +953,10 @@ function Game:clearLevelSelectLeaderboardFlip()
 end
 
 function Game:getLevelSelectPreviewDisplayState(mapUuid)
+    if self:isOfflineMode() then
+        return self:getLocalLevelSelectPreviewDisplayState(mapUuid)
+    end
+
     local cacheEntry = self:getLevelSelectPreviewCacheEntry(mapUuid)
     local previewState = self.levelSelectPreviewState or {}
     local shouldShowCachedEntries = levelSelectPreviewLogic.shouldShowCachedEntries(previewState, mapUuid, cacheEntry ~= nil)
@@ -742,6 +1017,8 @@ function Game:getLevelSelectPreviewDisplayState(mapUuid)
             LEVEL_SELECT_PREVIEW_CACHE_DURATION_SECONDS
         ),
         message = message,
+        refreshLabel = nil,
+        title = "Leaderboard",
     }
 end
 
@@ -1363,7 +1640,12 @@ function Game:updateLeaderboardFetchState()
         end
     end
 
-    if self.screen == "leaderboard" and self.activeLeaderboardRequestId == nil and not self:isLeaderboardCacheFresh() and self:isLeaderboardFetchAllowed() then
+    if self:isOnlineMode()
+        and self.screen == "leaderboard"
+        and self.activeLeaderboardRequestId == nil
+        and not self:isLeaderboardCacheFresh()
+        and self:isLeaderboardFetchAllowed()
+    then
         local onlineConfig = self:getActiveOnlineConfig()
         if not onlineConfig.isConfigured then
             self.leaderboardState = self:buildLeaderboardState(
@@ -1386,21 +1668,23 @@ function Game:updateLeaderboardFetchState()
         previewMapUuid and self:isLevelSelectPreviewCacheFresh(previewMapUuid) or false,
         previewMapUuid and self:isLevelSelectPreviewFetchAllowed(previewMapUuid) or false
     ) then
-        local onlineConfig = self:getActiveOnlineConfig()
-        if onlineConfig.isConfigured then
-            self:beginLevelSelectPreviewFetch(onlineConfig, previewMapUuid)
-        elseif self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
-            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
-                hasResolvedInitialRemoteAttempt = true,
-            })
-        else
-            self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
-                hasResolvedInitialRemoteAttempt = true,
-            })
+        if self:isOnlineMode() then
+            local onlineConfig = self:getActiveOnlineConfig()
+            if onlineConfig.isConfigured then
+                self:beginLevelSelectPreviewFetch(onlineConfig, previewMapUuid)
+            elseif self:getLevelSelectPreviewCacheEntry(previewMapUuid) then
+                self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_READY, nil, {
+                    hasResolvedInitialRemoteAttempt = true,
+                })
+            else
+                self:setLevelSelectPreviewState(previewMapUuid, LEVEL_SELECT_PREVIEW_STATUS_ERROR, LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_DATA, {
+                    hasResolvedInitialRemoteAttempt = true,
+                })
+            end
         end
     end
 
-    if self.screen == "level_select" and self:isLevelSelectMarketplaceMode() then
+    if self:isOnlineMode() and self.screen == "level_select" and self:isLevelSelectMarketplaceMode() then
         local scopeDetails = self:getMarketplaceScopeDetails()
         local scopeKey = scopeDetails.scopeKey
         local onlineConfig = self:getActiveOnlineConfig()
@@ -1462,7 +1746,7 @@ function Game:appendProfileNameInput(text)
     end
 
     local nextValue = self.profileSetupNameBuffer .. cleanText
-    if #nextValue <= 24 then
+    if #nextValue <= PROFILE_NAME_MAX_LENGTH then
         self.profileSetupNameBuffer = nextValue
         self.profileSetupError = nil
     end
@@ -1489,21 +1773,37 @@ function Game:confirmProfileSetup()
     end
 
     self.profileSetupError = nil
+    self.profileModeSetupError = nil
+    self.screen = "profile_mode_setup"
+    return true
+end
+
+function Game:cycleProfileModeSelection(direction)
+    if direction == nil or direction == 0 then
+        return
+    end
+
+    if self.profileModeSelection == PLAY_MODE_OFFLINE then
+        self.profileModeSelection = PLAY_MODE_ONLINE
+    else
+        self.profileModeSelection = PLAY_MODE_OFFLINE
+    end
+    self.profileModeSetupError = nil
+end
+
+function Game:confirmProfileModeSelection()
+    local ok, saveError = self:setPlayMode(self.profileModeSelection)
+    if not ok then
+        self.profileModeSetupError = saveError or "The play mode could not be saved."
+        return false, self.profileModeSetupError
+    end
+
     self:openMenu()
     return true
 end
 
 function Game:submitResultsScore()
     self.resultsOnlineState = nil
-
-    local onlineConfig = self:reloadOnlineConfig()
-    if not onlineConfig.isConfigured then
-        self.resultsOnlineState = {
-            status = "disabled",
-            message = getLeaderboardUnavailableMessage(),
-        }
-        return
-    end
 
     if not self.levelComplete then
         self.resultsOnlineState = {
@@ -1513,10 +1813,36 @@ function Game:submitResultsScore()
         return
     end
 
+    local localScoreSaved, isNewLocalBest, localSaveError = self:updateLocalScoreboard(self.resultsSummary or {})
+    if not localScoreSaved then
+        self.resultsOnlineState = {
+            status = "error",
+            message = localSaveError or RESULTS_MESSAGE_LOCAL_SAVE_FAILED,
+        }
+        return
+    end
+
+    if self:isOfflineMode() then
+        self.resultsOnlineState = {
+            status = isNewLocalBest and "submitted" or "kept",
+            message = isNewLocalBest and RESULTS_MESSAGE_LOCAL_BEST_SAVED or RESULTS_MESSAGE_LOCAL_BEST_KEPT,
+        }
+        return
+    end
+
+    local onlineConfig = self:reloadOnlineConfig()
+    if not onlineConfig.isConfigured then
+        self.resultsOnlineState = {
+            status = "disabled",
+            message = "Saved locally. " .. getLeaderboardUnavailableMessage(),
+        }
+        return
+    end
+
     if self:isDebugModeEnabled() then
         self.resultsOnlineState = {
             status = "skipped",
-            message = "Debug mode is enabled, so the online score upload was skipped.",
+            message = "Saved locally. Debug mode is enabled, so the online score upload was skipped.",
         }
         return
     end
@@ -1536,7 +1862,8 @@ function Game:canUploadMapDescriptor(mapDescriptor)
 end
 
 function Game:isUploadSelectedMapAvailable(mapDescriptor)
-    return self.levelSelectMode == LEVEL_SELECT_MODE_LIBRARY
+    return self:isOnlineMode()
+        and self.levelSelectMode == LEVEL_SELECT_MODE_LIBRARY
         and self.levelSelectFilter == "user"
         and self:canUploadMapDescriptor(mapDescriptor or self:getSelectedLevelMap())
 end
@@ -1786,6 +2113,15 @@ function Game:refreshMarketplaceData()
 end
 
 function Game:refreshLeaderboard()
+    if self:isOfflineMode() then
+        local payload, fetchedAt = self:buildLocalLeaderboardPayload(self.leaderboardMapUuid)
+        self.leaderboardState = self:buildLeaderboardState(LEADERBOARD_STATUS_READY, nil, payload, fetchedAt)
+        if self.leaderboardState.totalEntries == 0 then
+            self.leaderboardState.message = self.leaderboardMapUuid and LEVEL_SELECT_PREVIEW_MESSAGE_NO_LOCAL_BEST or LEADERBOARD_MESSAGE_NO_LOCAL_SCORES
+        end
+        return
+    end
+
     local onlineConfig = self:getActiveOnlineConfig()
     local cacheEntry = self:getLeaderboardCacheEntry()
     if not onlineConfig.isConfigured then
@@ -1827,7 +2163,7 @@ function Game:openLeaderboard(options)
     self.screen = "leaderboard"
     self.leaderboardReturnScreen = openOptions.returnScreen or "menu"
     self.leaderboardMapUuid = openOptions.mapUuid
-    self.leaderboardTitle = openOptions.title or (self.leaderboardMapUuid and "Map Leaderboard" or "Online Leaderboard")
+    self.leaderboardTitle = openOptions.title or self:getLeaderboardTitle(self.leaderboardMapUuid)
     self.leaderboardHoverInfo = nil
     self:refreshLeaderboard()
 end
@@ -1838,7 +2174,7 @@ function Game:openLeaderboardForMap(mapUuid, mapName)
     end
 
     self.leaderboardMapUuid = mapUuid
-    self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardTitle = self:getLeaderboardTitle(mapUuid)
     self.leaderboardHoverInfo = nil
     self:refreshLeaderboard()
 end
@@ -1882,7 +2218,7 @@ end
 
 function Game:clearLeaderboardMapFilter()
     self.leaderboardMapUuid = nil
-    self.leaderboardTitle = "Online Leaderboard"
+    self.leaderboardTitle = self:getLeaderboardTitle(nil)
     self.leaderboardHoverInfo = nil
     self:refreshLeaderboard()
 end
@@ -1965,6 +2301,10 @@ function Game:isLevelSelectMarketplaceMode()
 end
 
 function Game:isOnlineMapsAvailable()
+    if not self:isOnlineMode() then
+        return false
+    end
+
     local onlineConfig = self:getActiveOnlineConfig()
     return onlineConfig and onlineConfig.isConfigured == true
 end
@@ -2037,6 +2377,11 @@ function Game:setLevelSelectMode(mode)
 end
 
 function Game:toggleLevelSelectMode()
+    if not self:isOnlineMode() then
+        self:setLevelSelectMode(LEVEL_SELECT_MODE_LIBRARY)
+        return
+    end
+
     if self:isLevelSelectMarketplaceMode() then
         self:setLevelSelectMode(LEVEL_SELECT_MODE_LIBRARY)
         return
@@ -2230,6 +2575,11 @@ end
 function Game:openMenu()
     if not self:isProfileComplete() then
         self.screen = "profile_setup"
+        return
+    end
+
+    if not self:isPlayModeConfigured() then
+        self.screen = "profile_mode_setup"
         return
     end
 
@@ -2456,6 +2806,8 @@ function Game:draw()
         ui.drawMenu(self)
     elseif self.screen == "profile_setup" then
         ui.drawProfileSetup(self)
+    elseif self.screen == "profile_mode_setup" then
+        ui.drawProfileModeSetup(self)
     elseif self.screen == "level_select" then
         ui.drawLevelSelect(self)
     elseif self.screen == "leaderboard" then
@@ -2480,7 +2832,7 @@ end
 
 function Game:keypressed(key)
     if key == "escape" then
-        if self.screen == "profile_setup" or self.screen == "menu" then
+        if self.screen == "profile_setup" or self.screen == "profile_mode_setup" or self.screen == "menu" then
             love.event.quit()
         elseif self.screen == "leaderboard" then
             self:returnFromLeaderboard()
@@ -2507,6 +2859,17 @@ function Game:keypressed(key)
         return
     end
 
+    if self.screen == "profile_mode_setup" then
+        if key == "left" or key == "up" then
+            self:cycleProfileModeSelection(-1)
+        elseif key == "right" or key == "down" then
+            self:cycleProfileModeSelection(1)
+        elseif key == "return" then
+            self:confirmProfileModeSelection()
+        end
+        return
+    end
+
     if self.screen == "menu" then
         if key == "return" or key == "space" then
             self:openLevelSelect()
@@ -2515,7 +2878,9 @@ function Game:keypressed(key)
         elseif key == "d" then
             self:toggleDebugMode()
         elseif key == "l" then
-            self:openLeaderboard({ returnScreen = "menu", title = "Online Leaderboard" })
+            self:openLeaderboard({ returnScreen = "menu" })
+        elseif key == "o" then
+            self:togglePlayMode()
         end
         return
     end
@@ -2638,7 +3003,6 @@ function Game:keypressed(key)
             self:openLeaderboard({
                 returnScreen = "results",
                 mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
-                title = "Online Leaderboard",
             })
             return
         end
@@ -2717,12 +3081,25 @@ function Game:mousepressed(x, y, button)
         return
     end
 
+    if self.screen == "profile_mode_setup" then
+        local action = ui.getProfileModeSetupActionAt(self, viewportX, viewportY)
+        if action == PLAY_MODE_ONLINE or action == PLAY_MODE_OFFLINE then
+            self.profileModeSelection = action
+            self:confirmProfileModeSelection()
+        elseif action == "confirm_mode" then
+            self:confirmProfileModeSelection()
+        end
+        return
+    end
+
     if self.screen == "menu" then
         local action = ui.getMenuActionAt(self, viewportX, viewportY)
         if action == "play" then
             self:openLevelSelect()
         elseif action == "leaderboard" then
-            self:openLeaderboard({ returnScreen = "menu", title = "Online Leaderboard" })
+            self:openLeaderboard({ returnScreen = "menu" })
+        elseif action == "toggle_play_mode" then
+            self:togglePlayMode()
         elseif action == "editor" then
             self:openEditorBlank()
         elseif action == "debug" then
@@ -2823,7 +3200,6 @@ function Game:mousepressed(x, y, button)
             self:openLeaderboard({
                 returnScreen = "results",
                 mapUuid = self.resultsSummary and self.resultsSummary.mapUuid or nil,
-                title = "Online Leaderboard",
             })
         elseif hit == "menu" then
             self:openMenu()

--- a/src/game/local_score_storage.lua
+++ b/src/game/local_score_storage.lua
@@ -94,7 +94,10 @@ function localScoreStorage.updateBestScore(store, summary)
     end
 
     local score = tonumber(summary and (summary.finalScore or summary.score) or 0) or 0
-    local recordedAt = tonumber(summary and (summary.recorded_at or summary.recordedAt or summary.updated_at or summary.updatedAt) or 0) or os.time() or 0
+    local recordedAt = tonumber(summary and (summary.recorded_at or summary.recordedAt or summary.updated_at or summary.updatedAt))
+    if not recordedAt or recordedAt <= 0 then
+        recordedAt = os.time() or 0
+    end
     local existingEntry = sanitized.entries_by_map[mapUuid]
 
     if existingEntry and score <= (tonumber(existingEntry.score) or 0) then

--- a/src/game/local_score_storage.lua
+++ b/src/game/local_score_storage.lua
@@ -3,7 +3,7 @@ local json = require("src.game.json")
 local localScoreStorage = {}
 
 local SCOREBOARD_FILE = "local_scoreboard.json"
-local STORAGE_VERSION = 1
+local STORAGE_VERSION = 2
 
 local function sanitizeEntry(mapUuid, entry)
     local resolvedMapUuid = tostring(mapUuid or entry and entry.map_uuid or "")
@@ -14,7 +14,7 @@ local function sanitizeEntry(mapUuid, entry)
     return {
         map_uuid = resolvedMapUuid,
         score = tonumber(entry and entry.score or 0) or 0,
-        updated_at = tonumber(entry and entry.updated_at or 0) or 0,
+        recorded_at = tonumber(entry and (entry.recorded_at or entry.recordedAt or entry.updated_at or entry.updatedAt) or 0) or 0,
     }
 end
 
@@ -94,7 +94,7 @@ function localScoreStorage.updateBestScore(store, summary)
     end
 
     local score = tonumber(summary and (summary.finalScore or summary.score) or 0) or 0
-    local updatedAt = tonumber(summary and summary.updated_at or 0) or os.time() or 0
+    local recordedAt = tonumber(summary and (summary.recorded_at or summary.recordedAt or summary.updated_at or summary.updatedAt) or 0) or os.time() or 0
     local existingEntry = sanitized.entries_by_map[mapUuid]
 
     if existingEntry and score <= (tonumber(existingEntry.score) or 0) then
@@ -104,7 +104,7 @@ function localScoreStorage.updateBestScore(store, summary)
     sanitized.entries_by_map[mapUuid] = {
         map_uuid = mapUuid,
         score = score,
-        updated_at = updatedAt,
+        recorded_at = recordedAt,
     }
     return sanitized, true
 end

--- a/src/game/local_score_storage.lua
+++ b/src/game/local_score_storage.lua
@@ -1,0 +1,112 @@
+local json = require("src.game.json")
+
+local localScoreStorage = {}
+
+local SCOREBOARD_FILE = "local_scoreboard.json"
+local STORAGE_VERSION = 1
+
+local function sanitizeEntry(mapUuid, entry)
+    local resolvedMapUuid = tostring(mapUuid or entry and entry.map_uuid or "")
+    if resolvedMapUuid == "" then
+        return nil
+    end
+
+    return {
+        map_uuid = resolvedMapUuid,
+        score = tonumber(entry and entry.score or 0) or 0,
+        updated_at = tonumber(entry and entry.updated_at or 0) or 0,
+    }
+end
+
+local function sanitizeStore(store)
+    local sanitized = {
+        version = STORAGE_VERSION,
+        entries_by_map = {},
+    }
+    local sourceEntries = type(store) == "table" and (store.entries_by_map or store.entriesByMap) or nil
+
+    if type(sourceEntries) ~= "table" then
+        return sanitized
+    end
+
+    for mapUuid, entry in pairs(sourceEntries) do
+        local sanitizedEntry = sanitizeEntry(mapUuid, entry)
+        if sanitizedEntry then
+            sanitized.entries_by_map[sanitizedEntry.map_uuid] = sanitizedEntry
+        end
+    end
+
+    return sanitized
+end
+
+local function readStoreFile()
+    if not love.filesystem.getInfo(SCOREBOARD_FILE, "file") then
+        return nil
+    end
+
+    local content = love.filesystem.read(SCOREBOARD_FILE)
+    if not content then
+        return nil
+    end
+
+    local decoded = json.decode(content)
+    if type(decoded) ~= "table" then
+        return nil
+    end
+
+    return decoded
+end
+
+function localScoreStorage.save(store)
+    local sanitized = sanitizeStore(store)
+    local encodedStore = json.encode(sanitized)
+    local ok, writeError = love.filesystem.write(SCOREBOARD_FILE, encodedStore)
+    if not ok then
+        return nil, writeError or "The local scoreboard could not be saved."
+    end
+
+    return sanitized
+end
+
+function localScoreStorage.load()
+    local loadedStore = readStoreFile()
+    local sanitized = sanitizeStore(loadedStore)
+    local needsSave = loadedStore == nil
+        or loadedStore.version ~= sanitized.version
+        or loadedStore.entries_by_map == nil
+        or loadedStore.entriesByMap ~= nil
+
+    if needsSave then
+        local savedStore = localScoreStorage.save(sanitized)
+        if savedStore then
+            sanitized = savedStore
+        end
+    end
+
+    return sanitized
+end
+
+function localScoreStorage.updateBestScore(store, summary)
+    local sanitized = sanitizeStore(store)
+    local mapUuid = tostring(summary and summary.mapUuid or "")
+    if mapUuid == "" then
+        return sanitized, false
+    end
+
+    local score = tonumber(summary and (summary.finalScore or summary.score) or 0) or 0
+    local updatedAt = tonumber(summary and summary.updated_at or 0) or os.time() or 0
+    local existingEntry = sanitized.entries_by_map[mapUuid]
+
+    if existingEntry and score <= (tonumber(existingEntry.score) or 0) then
+        return sanitized, false
+    end
+
+    sanitized.entries_by_map[mapUuid] = {
+        map_uuid = mapUuid,
+        score = score,
+        updated_at = updatedAt,
+    }
+    return sanitized, true
+end
+
+return localScoreStorage

--- a/src/game/profile_storage.lua
+++ b/src/game/profile_storage.lua
@@ -2,8 +2,19 @@ local profileStorage = {}
 local uuid = require("src.game.uuid")
 
 local PROFILE_FILE = "profile.lua"
+local PROFILE_VERSION = 2
 local PLAYER_ID_PREFIX = "player-"
 local UUID_PATTERN = "^[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+%-[0-9a-fA-F]+$"
+local PLAY_MODE_ONLINE = "online"
+local PLAY_MODE_OFFLINE = "offline"
+
+local function normalizePlayMode(value)
+    if value == PLAY_MODE_ONLINE or value == PLAY_MODE_OFFLINE then
+        return value
+    end
+
+    return ""
+end
 
 local function isIdentifier(value)
     return type(value) == "string" and value:match("^[%a_][%w_]*$") ~= nil
@@ -103,9 +114,10 @@ local function sanitizeProfile(profile)
     end
 
     local sanitized = {
-        version = 1,
+        version = PROFILE_VERSION,
         player_uuid = resolvedPlayerUuid,
         playerDisplayName = type(profile.playerDisplayName) == "string" and profile.playerDisplayName or "",
+        playMode = normalizePlayMode(profile.playMode),
         debugMode = profile.debugMode == true,
     }
 
@@ -147,6 +159,7 @@ function profileStorage.load()
         or loadedProfile.playerId ~= nil
         or loadedProfile.playerUuid ~= nil
         or loadedProfile.playerDisplayName ~= sanitized.playerDisplayName
+        or loadedProfile.playMode ~= sanitized.playMode
         or loadedProfile.debugMode ~= sanitized.debugMode
 
     if needsSave then

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -132,8 +132,14 @@ local PROFILE_MODE_SETUP_LAYOUT = {
     buttonW = 220,
     buttonH = 72,
     buttonGap = 28,
-    buttonY = 230,
-    helperTextY = 322,
+    buttonY = 246,
+}
+local PROFILE_MODE_TOOLTIP_LAYOUT = {
+    maxWidth = 268,
+    paddingX = 14,
+    paddingY = 12,
+    cornerRadius = 12,
+    gap = 10,
 }
 
 local LEADERBOARD_LOADING = {
@@ -289,6 +295,53 @@ local function getWrappedLineCount(font, text, width)
         return math.max(1, #secondValue)
     end
     return 1
+end
+
+local function drawProfileModeTooltip(game, rect, text)
+    if not rect or not text or text == "" then
+        return
+    end
+
+    local graphics = love.graphics
+    local maxTextWidth = PROFILE_MODE_TOOLTIP_LAYOUT.maxWidth - (PROFILE_MODE_TOOLTIP_LAYOUT.paddingX * 2)
+    local lineCount = getWrappedLineCount(game.fonts.small, text, maxTextWidth)
+    local tooltipWidth = PROFILE_MODE_TOOLTIP_LAYOUT.maxWidth
+    local tooltipHeight = (lineCount * game.fonts.small:getHeight()) + (PROFILE_MODE_TOOLTIP_LAYOUT.paddingY * 2)
+    local tooltipX = math.floor(rect.x + (rect.w - tooltipWidth) * 0.5 + 0.5)
+    local tooltipY = math.floor(rect.y - tooltipHeight - PROFILE_MODE_TOOLTIP_LAYOUT.gap + 0.5)
+
+    graphics.setColor(0.08, 0.1, 0.14, 0.98)
+    graphics.rectangle(
+        "fill",
+        tooltipX,
+        tooltipY,
+        tooltipWidth,
+        tooltipHeight,
+        PROFILE_MODE_TOOLTIP_LAYOUT.cornerRadius,
+        PROFILE_MODE_TOOLTIP_LAYOUT.cornerRadius
+    )
+    graphics.setColor(0.28, 0.4, 0.52, 1)
+    graphics.setLineWidth(2)
+    graphics.rectangle(
+        "line",
+        tooltipX,
+        tooltipY,
+        tooltipWidth,
+        tooltipHeight,
+        PROFILE_MODE_TOOLTIP_LAYOUT.cornerRadius,
+        PROFILE_MODE_TOOLTIP_LAYOUT.cornerRadius
+    )
+    graphics.setLineWidth(1)
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.58, 0.64, 0.7, 1)
+    graphics.printf(
+        text,
+        tooltipX + PROFILE_MODE_TOOLTIP_LAYOUT.paddingX,
+        tooltipY + PROFILE_MODE_TOOLTIP_LAYOUT.paddingY,
+        tooltipWidth - (PROFILE_MODE_TOOLTIP_LAYOUT.paddingX * 2),
+        "center"
+    )
 end
 
 local function formatScore(value)
@@ -2995,6 +3048,16 @@ function ui.drawProfileModeSetup(game)
     local panel = getProfileModeSetupPanelRect(game)
     local optionRects = getProfileModeSetupOptionRects(game)
     local isOnlineSelected = game.profileModeSelection == "online"
+    local promptText = "Do you want to use online features such as online leaderboards and community maps?"
+    local offlineTooltipText = "We're only storing your username as well as the uploaded maps and leaderboard stats. You can turn this on or off at any time in the main menu."
+    local promptWidth = panel.w - 88
+    local promptLineCount = getWrappedLineCount(game.fonts.body, promptText, promptWidth)
+    local promptHeight = promptLineCount * game.fonts.body:getHeight()
+    local textBlockHeight = promptHeight
+    local textAreaTop = panel.y + 84
+    local textAreaBottom = optionRects.online.y - 34
+    local textBlockY = textAreaTop + math.floor(((textAreaBottom - textAreaTop) - textBlockHeight) * 0.5 + 0.5)
+    local promptX = panel.x + math.floor((panel.w - promptWidth) * 0.5 + 0.5)
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -3002,42 +3065,36 @@ function ui.drawProfileModeSetup(game)
 
     love.graphics.setFont(game.fonts.title)
     graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf("Choose Mode", panel.x + 24, panel.y + 34, panel.w - 48, "center")
+    graphics.printf("Enable Online Functionality?", panel.x + 24, panel.y + 34, panel.w - 48, "center")
 
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.84, 0.88, 0.92, 1)
     graphics.printf(
-        "Offline keeps every score local. Online enables scoreboards and community maps.",
-        panel.x + 44,
-        panel.y + 92,
-        panel.w - 88,
+        promptText,
+        promptX,
+        textBlockY,
+        promptWidth,
         "center"
     )
 
     drawButton(
         optionRects.online,
         "Online",
-        isOnlineSelected and { 0.12, 0.17, 0.2, 0.98 } or { 0.08, 0.1, 0.14, 0.98 },
-        isOnlineSelected and { 0.48, 0.92, 0.62, 1 } or { 0.3, 0.42, 0.54, 1 },
+        isOnlineSelected and { 0.1, 0.22, 0.14, 0.98 } or { 0.08, 0.18, 0.11, 0.98 },
+        isOnlineSelected and { 0.54, 0.96, 0.66, 1 } or { 0.42, 0.86, 0.55, 1 },
         game.fonts.body
     )
     drawButton(
         optionRects.offline,
         "Offline",
-        isOnlineSelected and { 0.08, 0.1, 0.14, 0.98 } or { 0.12, 0.17, 0.2, 0.98 },
-        isOnlineSelected and { 0.3, 0.42, 0.54, 1 } or { 0.48, 0.92, 0.62, 1 },
+        { 0.08, 0.1, 0.14, 0.98 },
+        { 0.3, 0.42, 0.54, 1 },
         game.fonts.body
     )
 
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.72, 0.78, 0.84, 1)
-    graphics.printf(
-        "Use Left or Right and press Enter, or click a mode.",
-        panel.x + 40,
-        panel.y + PROFILE_MODE_SETUP_LAYOUT.helperTextY,
-        panel.w - 80,
-        "center"
-    )
+    if game.profileModeHoverId == "offline" then
+        drawProfileModeTooltip(game, optionRects.offline, offlineTooltipText)
+    end
 
     if game.profileModeSetupError then
         graphics.setColor(0.99, 0.78, 0.32, 1)

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -161,18 +161,18 @@ local LEADERBOARD_LAYOUT = {
     headerY = 116,
     rowYOffset = 28,
     rowHeight = 34,
-    offlineRowHeight = 52,
     rowGap = 8,
     rowRadius = 10,
     rankWidth = 40,
     mapGap = 28,
     mapWidth = 260,
+    recordedGap = 24,
+    recordedWidth = 164,
     playerXOffset = 52,
     playerRightPadding = 36,
     scoreWidth = 120,
     rowBottomPadding = 56,
     rowPrimaryTextOffsetY = 2,
-    rowSecondaryTextOffsetY = 22,
     tooltipWidth = 360,
     tooltipHeight = 62,
     tooltipOffsetY = 18,
@@ -450,16 +450,8 @@ local function shouldShowLeaderboardMapColumn(game)
     return state.scope == "global"
 end
 
-local function shouldShowLeaderboardRecordedAt(game)
+local function shouldShowLeaderboardRecordedColumn(game)
     return game:isOfflineMode()
-end
-
-local function getLeaderboardRowHeight(game)
-    if shouldShowLeaderboardRecordedAt(game) then
-        return LEADERBOARD_LAYOUT.offlineRowHeight
-    end
-
-    return LEADERBOARD_LAYOUT.rowHeight
 end
 
 local function formatLeaderboardRecordedAt(value)
@@ -476,8 +468,21 @@ local function getLeaderboardContentLayout(game)
     local panel = getLeaderboardPanelRect(game)
     local contentX = panel.x + LEADERBOARD_LAYOUT.contentPadding
     local contentW = panel.w - (LEADERBOARD_LAYOUT.contentPadding * 2)
-    local scoreX = contentX + math.floor((contentW - LEADERBOARD_LAYOUT.scoreWidth) * 0.5 + 0.5)
-    local mapX = scoreX + LEADERBOARD_LAYOUT.scoreWidth + LEADERBOARD_LAYOUT.mapGap
+    local recordedX = nil
+    local scoreX = nil
+    local mapX = nil
+
+    if shouldShowLeaderboardRecordedColumn(game) then
+        recordedX = contentX + contentW - LEADERBOARD_LAYOUT.recordedWidth
+        scoreX = recordedX - LEADERBOARD_LAYOUT.recordedGap - LEADERBOARD_LAYOUT.scoreWidth
+        if shouldShowLeaderboardMapColumn(game) then
+            mapX = scoreX - LEADERBOARD_LAYOUT.mapGap - LEADERBOARD_LAYOUT.mapWidth
+        end
+    else
+        scoreX = contentX + math.floor((contentW - LEADERBOARD_LAYOUT.scoreWidth) * 0.5 + 0.5)
+        mapX = shouldShowLeaderboardMapColumn(game) and (scoreX + LEADERBOARD_LAYOUT.scoreWidth + LEADERBOARD_LAYOUT.mapGap) or nil
+    end
+
     local playerX = contentX + LEADERBOARD_LAYOUT.playerXOffset
     local playerRightEdge = shouldShowLeaderboardMapColumn(game)
         and (mapX - LEADERBOARD_LAYOUT.mapGap)
@@ -489,6 +494,7 @@ local function getLeaderboardContentLayout(game)
         contentX = contentX,
         contentW = contentW,
         mapX = mapX,
+        recordedX = recordedX,
         scoreX = scoreX,
         playerX = playerX,
         playerWidth = playerWidth,
@@ -517,7 +523,7 @@ end
 local function buildLeaderboardRowRects(game, entries)
     local layout = getLeaderboardContentLayout(game)
     local rects = {}
-    local rowHeight = getLeaderboardRowHeight(game)
+    local rowHeight = LEADERBOARD_LAYOUT.rowHeight
     local rowStep = rowHeight + LEADERBOARD_LAYOUT.rowGap
     local availableHeight = layout.panel.h - LEADERBOARD_LAYOUT.headerY - LEADERBOARD_LAYOUT.rowYOffset - LEADERBOARD_LAYOUT.rowBottomPadding
     local maxEntries = math.min(
@@ -546,6 +552,12 @@ local function buildLeaderboardRowRects(game, entries)
                 x = layout.mapX,
                 y = rowY,
                 w = LEADERBOARD_LAYOUT.mapWidth,
+                h = rowHeight - 8,
+            } or nil,
+            recorded = shouldShowLeaderboardRecordedColumn(game) and {
+                x = layout.recordedX,
+                y = rowY,
+                w = LEADERBOARD_LAYOUT.recordedWidth,
                 h = rowHeight - 8,
             } or nil,
         }
@@ -3108,6 +3120,9 @@ function ui.drawLeaderboard(game)
     if shouldShowLeaderboardMapColumn(game) then
         graphics.printf(game:isOfflineMode() and "Map" or "Latest Map", layout.mapX, headerY, LEADERBOARD_LAYOUT.mapWidth, "left")
     end
+    if shouldShowLeaderboardRecordedColumn(game) and layout.recordedX then
+        graphics.printf("Recorded", layout.recordedX, headerY, LEADERBOARD_LAYOUT.recordedWidth, "left")
+    end
 
     local rowRects = buildLeaderboardRowRects(game, state.entries or {})
     for _, rowRect in ipairs(rowRects) do
@@ -3134,13 +3149,13 @@ function ui.drawLeaderboard(game)
             LEADERBOARD_LAYOUT.scoreWidth,
             "center"
         )
-        if shouldShowLeaderboardRecordedAt(game) then
-            graphics.setColor(0.68, 0.74, 0.8, 1)
+        if rowRect.recorded then
+            graphics.setColor(0.72, 0.78, 0.84, 1)
             graphics.printf(
-                string.format("Recorded %s", formatLeaderboardRecordedAt(entry.updatedAt)),
-                rowRect.player.x,
-                rowY + LEADERBOARD_LAYOUT.rowSecondaryTextOffsetY,
-                rowRect.player.w,
+                formatLeaderboardRecordedAt(entry.recordedAt or entry.updatedAt),
+                rowRect.recorded.x,
+                rowY + LEADERBOARD_LAYOUT.rowPrimaryTextOffsetY,
+                rowRect.recorded.w,
                 "left"
             )
             graphics.setColor(0.97, 0.98, 1, 1)

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -126,6 +126,16 @@ local MENU_LAYOUT = {
     footerY = 654,
 }
 
+local PROFILE_MODE_SETUP_LAYOUT = {
+    panelW = 640,
+    panelH = 360,
+    buttonW = 220,
+    buttonH = 72,
+    buttonGap = 28,
+    buttonY = 230,
+    helperTextY = 322,
+}
+
 local LEADERBOARD_LOADING = {
     spinnerRadius = 18,
     spinnerThickness = 4,
@@ -151,6 +161,7 @@ local LEADERBOARD_LAYOUT = {
     headerY = 116,
     rowYOffset = 28,
     rowHeight = 34,
+    offlineRowHeight = 52,
     rowGap = 8,
     rowRadius = 10,
     rankWidth = 40,
@@ -159,6 +170,9 @@ local LEADERBOARD_LAYOUT = {
     playerXOffset = 52,
     playerRightPadding = 36,
     scoreWidth = 120,
+    rowBottomPadding = 56,
+    rowPrimaryTextOffsetY = 2,
+    rowSecondaryTextOffsetY = 22,
     tooltipWidth = 360,
     tooltipHeight = 62,
     tooltipOffsetY = 18,
@@ -390,7 +404,7 @@ end
 
 local function drawLeaderboardRefreshIndicator(game, panel, state)
     local graphics = love.graphics
-    local label = formatLeaderboardRefreshLabel(
+    local label = state and state.refreshLabel or formatLeaderboardRefreshLabel(
         state and state.nextRefreshAt or nil,
         getNowSeconds(),
         state and state.status == "loading" or false,
@@ -407,7 +421,7 @@ end
 
 local function drawLevelSelectLeaderboardRefreshIndicator(game, contentRect, previewState)
     local graphics = love.graphics
-    local label = formatLevelSelectLeaderboardRefreshLabel(
+    local label = previewState and previewState.refreshLabel or formatLevelSelectLeaderboardRefreshLabel(
         previewState and previewState.nextRefreshAt or nil,
         getNowUnixSeconds(),
         previewState and previewState.isLoading or false,
@@ -434,6 +448,28 @@ end
 local function shouldShowLeaderboardMapColumn(game)
     local state = game.leaderboardState or {}
     return state.scope == "global"
+end
+
+local function shouldShowLeaderboardRecordedAt(game)
+    return game:isOfflineMode()
+end
+
+local function getLeaderboardRowHeight(game)
+    if shouldShowLeaderboardRecordedAt(game) then
+        return LEADERBOARD_LAYOUT.offlineRowHeight
+    end
+
+    return LEADERBOARD_LAYOUT.rowHeight
+end
+
+local function formatLeaderboardRecordedAt(value)
+    local timestamp = tonumber(value)
+    if timestamp then
+        return os.date("%Y-%m-%d %H:%M", timestamp)
+    end
+
+    local text = tostring(value or "")
+    return text ~= "" and text or "Unknown"
 end
 
 local function getLeaderboardContentLayout(game)
@@ -481,7 +517,13 @@ end
 local function buildLeaderboardRowRects(game, entries)
     local layout = getLeaderboardContentLayout(game)
     local rects = {}
-    local maxEntries = math.min(12, #(entries or {}))
+    local rowHeight = getLeaderboardRowHeight(game)
+    local rowStep = rowHeight + LEADERBOARD_LAYOUT.rowGap
+    local availableHeight = layout.panel.h - LEADERBOARD_LAYOUT.headerY - LEADERBOARD_LAYOUT.rowYOffset - LEADERBOARD_LAYOUT.rowBottomPadding
+    local maxEntries = math.min(
+        #(entries or {}),
+        math.max(1, math.floor((availableHeight + LEADERBOARD_LAYOUT.rowGap) / rowStep))
+    )
     local rowY = layout.panel.y + LEADERBOARD_LAYOUT.headerY + LEADERBOARD_LAYOUT.rowYOffset
 
     for index = 1, maxEntries do
@@ -492,24 +534,24 @@ local function buildLeaderboardRowRects(game, entries)
                 x = layout.contentX,
                 y = rowY - 6,
                 w = layout.contentW,
-                h = LEADERBOARD_LAYOUT.rowHeight,
+                h = rowHeight,
             },
             player = {
                 x = layout.playerX,
                 y = rowY,
                 w = layout.playerWidth,
-                h = game.fonts.small:getHeight() + 8,
+                h = rowHeight - 8,
             },
             map = shouldShowLeaderboardMapColumn(game) and {
                 x = layout.mapX,
                 y = rowY,
                 w = LEADERBOARD_LAYOUT.mapWidth,
-                h = game.fonts.small:getHeight() + 8,
+                h = rowHeight - 8,
             } or nil,
         }
 
         rects[#rects + 1] = rowRect
-        rowY = rowY + LEADERBOARD_LAYOUT.rowHeight + LEADERBOARD_LAYOUT.rowGap
+        rowY = rowY + rowStep
     end
 
     return rects
@@ -1407,8 +1449,15 @@ getLevelSelectActionButtons = function(game)
         buttonSpecs = {
             { id = "open_map", label = "Start", w = LEVEL_SELECT_ACTION_LAYOUT.startW },
             { id = editButtonId, label = editButtonLabel, w = LEVEL_SELECT_ACTION_LAYOUT.editW },
-            { id = "toggle_mode", label = "Online Maps", w = LEVEL_SELECT_ACTION_LAYOUT.toggleW },
         }
+
+        if game:isOnlineMode() then
+            buttonSpecs[#buttonSpecs + 1] = {
+                id = "toggle_mode",
+                label = "Online Maps",
+                w = LEVEL_SELECT_ACTION_LAYOUT.toggleW,
+            }
+        end
 
         if selectedMap and game:isUploadSelectedMapAvailable(selectedMap) then
             buttonSpecs[#buttonSpecs + 1] = {
@@ -1966,7 +2015,7 @@ local function drawLevelSelectLeaderboardBack(game, rect)
 
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(PANEL_COLORS.titleText[1], PANEL_COLORS.titleText[2], PANEL_COLORS.titleText[3], PANEL_COLORS.titleText[4])
-    graphics.printf("Leaderboard", contentRect.x, contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.titleTop, contentRect.w, "center")
+    graphics.printf(previewState.title or "Leaderboard", contentRect.x, contentRect.y + LEVEL_SELECT_LEADERBOARD_CARD.titleTop, contentRect.w, "center")
 
     for index, entry in ipairs(topEntries) do
         local rowRect = {
@@ -2126,7 +2175,7 @@ local function getMenuButtons(game)
             y = buttonY + MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap,
             w = MENU_LAYOUT.buttonWidth,
             h = MENU_LAYOUT.buttonHeight,
-            label = "Online Leaderboard",
+            label = game:getLeaderboardButtonLabel(),
         },
         {
             id = "editor",
@@ -2137,9 +2186,17 @@ local function getMenuButtons(game)
             label = "Map Editor",
         },
         {
-            id = "quit",
+            id = "toggle_play_mode",
             x = centerX,
             y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 3),
+            w = MENU_LAYOUT.buttonWidth,
+            h = MENU_LAYOUT.buttonHeight,
+            label = game:getPlayModeButtonLabel(),
+        },
+        {
+            id = "quit",
+            x = centerX,
+            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 4),
             w = MENU_LAYOUT.buttonWidth,
             h = MENU_LAYOUT.buttonHeight,
             label = "Quit",
@@ -2153,6 +2210,36 @@ local function getProfileSetupConfirmRect(game)
         y = 430,
         w = 220,
         h = 52,
+    }
+end
+
+local function getProfileModeSetupPanelRect(game)
+    return {
+        x = math.floor(game.viewport.w * 0.5 - PROFILE_MODE_SETUP_LAYOUT.panelW * 0.5 + 0.5),
+        y = math.floor(game.viewport.h * 0.5 - PROFILE_MODE_SETUP_LAYOUT.panelH * 0.5 + 0.5),
+        w = PROFILE_MODE_SETUP_LAYOUT.panelW,
+        h = PROFILE_MODE_SETUP_LAYOUT.panelH,
+    }
+end
+
+local function getProfileModeSetupOptionRects(game)
+    local panel = getProfileModeSetupPanelRect(game)
+    local totalWidth = (PROFILE_MODE_SETUP_LAYOUT.buttonW * 2) + PROFILE_MODE_SETUP_LAYOUT.buttonGap
+    local startX = panel.x + math.floor((panel.w - totalWidth) * 0.5 + 0.5)
+
+    return {
+        online = {
+            x = startX,
+            y = panel.y + PROFILE_MODE_SETUP_LAYOUT.buttonY,
+            w = PROFILE_MODE_SETUP_LAYOUT.buttonW,
+            h = PROFILE_MODE_SETUP_LAYOUT.buttonH,
+        },
+        offline = {
+            x = startX + PROFILE_MODE_SETUP_LAYOUT.buttonW + PROFILE_MODE_SETUP_LAYOUT.buttonGap,
+            y = panel.y + PROFILE_MODE_SETUP_LAYOUT.buttonY,
+            w = PROFILE_MODE_SETUP_LAYOUT.buttonW,
+            h = PROFILE_MODE_SETUP_LAYOUT.buttonH,
+        },
     }
 end
 
@@ -2197,6 +2284,17 @@ end
 function ui.getProfileSetupActionAt(game, x, y)
     if pointInRect(x, y, getProfileSetupConfirmRect(game)) then
         return "confirm"
+    end
+    return nil
+end
+
+function ui.getProfileModeSetupActionAt(game, x, y)
+    local optionRects = getProfileModeSetupOptionRects(game)
+    if pointInRect(x, y, optionRects.online) then
+        return "online"
+    end
+    if pointInRect(x, y, optionRects.offline) then
+        return "offline"
     end
     return nil
 end
@@ -2785,7 +2883,9 @@ function ui.drawMenu(game)
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.84, 0.88, 0.92, 1)
     graphics.printf(
-        "Route trains through lever-controlled merges, upload cleared scores, and compare runs online.",
+        game:isOfflineMode()
+            and "Route trains through lever-controlled merges and keep your personal scores on this device."
+            or "Route trains through lever-controlled merges, upload cleared scores, and compare runs online.",
         game.viewport.w * 0.5 - 280,
         188,
         560,
@@ -2801,7 +2901,15 @@ function ui.drawMenu(game)
 
     love.graphics.setFont(game.fonts.small)
     graphics.setColor(0.72, 0.78, 0.84, 1)
-    graphics.printf("Enter starts. L opens the leaderboard. D toggles debug mode. Esc quits.", 0, MENU_LAYOUT.footerY, game.viewport.w, "center")
+    graphics.printf(
+        game:isOfflineMode()
+            and "Enter starts. L opens personal scores. O toggles online or offline mode. D toggles debug mode. Esc quits."
+            or "Enter starts. L opens the leaderboard. O toggles online or offline mode. D toggles debug mode. Esc quits.",
+        0,
+        MENU_LAYOUT.footerY,
+        game.viewport.w,
+        "center"
+    )
 end
 
 function ui.drawProfileSetup(game)
@@ -2830,7 +2938,7 @@ function ui.drawProfileSetup(game)
 
     love.graphics.setFont(game.fonts.body)
     graphics.setColor(0.84, 0.88, 0.92, 1)
-    graphics.printf("Enter the name to use in the leaderboard.", panel.x + 42, panel.y + 84, panel.w - 84, "center")
+    graphics.printf("Enter the name to use in the game.", panel.x + 42, panel.y + 84, panel.w - 84, "center")
 
     graphics.setColor(0.48, 0.92, 0.62, 0.12)
     graphics.rectangle("fill", inputRect.x - 4, inputRect.y - 4, inputRect.w + 8, inputRect.h + 8, 16, 16)
@@ -2868,6 +2976,61 @@ function ui.drawProfileSetup(game)
     end
 
     drawButton(confirmRect, "Continue", { 0.09, 0.11, 0.15, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
+end
+
+function ui.drawProfileModeSetup(game)
+    local graphics = love.graphics
+    local panel = getProfileModeSetupPanelRect(game)
+    local optionRects = getProfileModeSetupOptionRects(game)
+    local isOnlineSelected = game.profileModeSelection == "online"
+
+    graphics.setColor(0.05, 0.07, 0.1, 1)
+    graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    drawMetalPanel(panel, 0.98)
+
+    love.graphics.setFont(game.fonts.title)
+    graphics.setColor(0.97, 0.98, 1, 1)
+    graphics.printf("Choose Mode", panel.x + 24, panel.y + 34, panel.w - 48, "center")
+
+    love.graphics.setFont(game.fonts.body)
+    graphics.setColor(0.84, 0.88, 0.92, 1)
+    graphics.printf(
+        "Offline keeps every score local. Online enables scoreboards and community maps.",
+        panel.x + 44,
+        panel.y + 92,
+        panel.w - 88,
+        "center"
+    )
+
+    drawButton(
+        optionRects.online,
+        "Online",
+        isOnlineSelected and { 0.12, 0.17, 0.2, 0.98 } or { 0.08, 0.1, 0.14, 0.98 },
+        isOnlineSelected and { 0.48, 0.92, 0.62, 1 } or { 0.3, 0.42, 0.54, 1 },
+        game.fonts.body
+    )
+    drawButton(
+        optionRects.offline,
+        "Offline",
+        isOnlineSelected and { 0.08, 0.1, 0.14, 0.98 } or { 0.12, 0.17, 0.2, 0.98 },
+        isOnlineSelected and { 0.3, 0.42, 0.54, 1 } or { 0.48, 0.92, 0.62, 1 },
+        game.fonts.body
+    )
+
+    love.graphics.setFont(game.fonts.small)
+    graphics.setColor(0.72, 0.78, 0.84, 1)
+    graphics.printf(
+        "Use Left or Right and press Enter, or click a mode.",
+        panel.x + 40,
+        panel.y + PROFILE_MODE_SETUP_LAYOUT.helperTextY,
+        panel.w - 80,
+        "center"
+    )
+
+    if game.profileModeSetupError then
+        graphics.setColor(0.99, 0.78, 0.32, 1)
+        graphics.printf(game.profileModeSetupError, panel.x + 40, panel.y + panel.h - 42, panel.w - 80, "center")
+    end
 end
 
 function ui.drawLeaderboard(game)
@@ -2943,7 +3106,7 @@ function ui.drawLeaderboard(game)
     graphics.print("Player", layout.playerX, headerY)
     graphics.printf("Score", layout.scoreX, headerY, LEADERBOARD_LAYOUT.scoreWidth, "center")
     if shouldShowLeaderboardMapColumn(game) then
-        graphics.printf("Latest Map", layout.mapX, headerY, LEADERBOARD_LAYOUT.mapWidth, "left")
+        graphics.printf(game:isOfflineMode() and "Map" or "Latest Map", layout.mapX, headerY, LEADERBOARD_LAYOUT.mapWidth, "left")
     end
 
     local rowRects = buildLeaderboardRowRects(game, state.entries or {})
@@ -2956,12 +3119,41 @@ function ui.drawLeaderboard(game)
         graphics.rectangle("line", rowRect.row.x, rowRect.row.y, rowRect.row.w, rowRect.row.h, LEADERBOARD_LAYOUT.rowRadius, LEADERBOARD_LAYOUT.rowRadius)
 
         graphics.setColor(0.97, 0.98, 1, 1)
-        graphics.print(tostring(entry.rank or 0), contentX + 12, rowY + 2)
-        graphics.printf(entry.playerDisplayName or "Unknown", rowRect.player.x, rowY + 2, rowRect.player.w, "left")
-        graphics.printf(formatLeaderboardScore(entry.score or 0), layout.scoreX, rowY + 2, LEADERBOARD_LAYOUT.scoreWidth, "center")
+        graphics.print(tostring(entry.rank or 0), contentX + 12, rowY + LEADERBOARD_LAYOUT.rowPrimaryTextOffsetY)
+        graphics.printf(
+            entry.playerDisplayName or "Unknown",
+            rowRect.player.x,
+            rowY + LEADERBOARD_LAYOUT.rowPrimaryTextOffsetY,
+            rowRect.player.w,
+            "left"
+        )
+        graphics.printf(
+            formatLeaderboardScore(entry.score or 0),
+            layout.scoreX,
+            rowY + LEADERBOARD_LAYOUT.rowPrimaryTextOffsetY,
+            LEADERBOARD_LAYOUT.scoreWidth,
+            "center"
+        )
+        if shouldShowLeaderboardRecordedAt(game) then
+            graphics.setColor(0.68, 0.74, 0.8, 1)
+            graphics.printf(
+                string.format("Recorded %s", formatLeaderboardRecordedAt(entry.updatedAt)),
+                rowRect.player.x,
+                rowY + LEADERBOARD_LAYOUT.rowSecondaryTextOffsetY,
+                rowRect.player.w,
+                "left"
+            )
+            graphics.setColor(0.97, 0.98, 1, 1)
+        end
         if rowRect.map then
             graphics.setColor(0.72, 0.78, 0.84, 1)
-            graphics.printf(entry.mapName or "Unknown Map", rowRect.map.x, rowY + 2, rowRect.map.w, "left")
+            graphics.printf(
+                entry.mapName or "Unknown Map",
+                rowRect.map.x,
+                rowY + LEADERBOARD_LAYOUT.rowPrimaryTextOffsetY,
+                rowRect.map.w,
+                "left"
+            )
         end
     end
 
@@ -3268,7 +3460,13 @@ function ui.drawResults(game)
         onlineColor = { 0.99, 0.78, 0.32, 1 }
     end
     graphics.setColor(onlineColor[1], onlineColor[2], onlineColor[3], onlineColor[4])
-    graphics.printf(onlineState.message or "Online sync pending.", panel.x + 38, panel.y + 158, panel.w - 76, "center")
+    graphics.printf(
+        onlineState.message or (game:isOfflineMode() and "Local score pending." or "Online sync pending."),
+        panel.x + 38,
+        panel.y + 158,
+        panel.w - 76,
+        "center"
+    )
 
     local breakdownX = panel.x + 58
     local valueX = panel.x + panel.w - 58
@@ -3305,12 +3503,19 @@ function ui.drawResults(game)
     end
 
     drawButton(buttons.replay, "Replay", { 0.1, 0.14, 0.18, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.small)
-    drawButton(buttons.leaderboard, "Leaderboard", { 0.1, 0.14, 0.18, 0.98 }, { 0.56, 0.72, 0.98, 1 }, game.fonts.small)
+    drawButton(
+        buttons.leaderboard,
+        game:isOfflineMode() and "Scores" or "Leaderboard",
+        { 0.1, 0.14, 0.18, 0.98 },
+        { 0.56, 0.72, 0.98, 1 },
+        game.fonts.small
+    )
     drawButton(buttons.editor, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
     drawButton(buttons.menu, "Main Menu", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
 end
 
 ui.formatLeaderboardScore = formatLeaderboardScore
+ui.formatLeaderboardRecordedAt = formatLeaderboardRecordedAt
 ui.formatLevelSelectLeaderboardPlayerName = formatLevelSelectLeaderboardPlayerName
 ui.formatLeaderboardRefreshLabel = formatLeaderboardRefreshLabel
 ui.formatLevelSelectLeaderboardRefreshLabel = formatLevelSelectLeaderboardRefreshLabel

--- a/tests/local_score_storage_test.lua
+++ b/tests/local_score_storage_test.lua
@@ -47,4 +47,25 @@ assertEqual(
     "higher scores keep the record creation timestamp"
 )
 
+local originalOsTime = os.time
+os.time = function()
+    return 123456789
+end
+
+local fallbackTimestampScoreboard, storedFallbackTimestamp = localScoreStorage.updateBestScore({
+    entries_by_map = {},
+}, {
+    mapUuid = "map-2",
+    finalScore = 7,
+})
+
+os.time = originalOsTime
+
+assertEqual(storedFallbackTimestamp, true, "new local bests still save when the run summary has no timestamp")
+assertEqual(
+    fallbackTimestampScoreboard.entries_by_map["map-2"].recorded_at,
+    123456789,
+    "missing local best timestamps fall back to the current save time"
+)
+
 print("local score storage tests passed")

--- a/tests/local_score_storage_test.lua
+++ b/tests/local_score_storage_test.lua
@@ -1,0 +1,50 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local localScoreStorage = require("src.game.local_score_storage")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local scoreboard = {
+    entries_by_map = {
+        ["map-1"] = {
+            map_uuid = "map-1",
+            score = 42,
+            updated_at = 10,
+        },
+    },
+}
+
+local unchangedScoreboard, keptExistingBest = localScoreStorage.updateBestScore(scoreboard, {
+    mapUuid = "map-1",
+    finalScore = 41,
+    updated_at = 12,
+})
+assertEqual(keptExistingBest, false, "lower scores do not replace the local best")
+assertEqual(
+    unchangedScoreboard.entries_by_map["map-1"].score,
+    42,
+    "lower scores leave the stored local best untouched"
+)
+
+local improvedScoreboard, storedNewBest = localScoreStorage.updateBestScore(scoreboard, {
+    mapUuid = "map-1",
+    finalScore = 48,
+    updated_at = 14,
+})
+assertEqual(storedNewBest, true, "higher scores replace the local best")
+assertEqual(
+    improvedScoreboard.entries_by_map["map-1"].score,
+    48,
+    "higher scores overwrite the stored local best"
+)
+assertEqual(
+    improvedScoreboard.entries_by_map["map-1"].updated_at,
+    14,
+    "higher scores keep the newest timestamp"
+)
+
+print("local score storage tests passed")

--- a/tests/local_score_storage_test.lua
+++ b/tests/local_score_storage_test.lua
@@ -13,7 +13,7 @@ local scoreboard = {
         ["map-1"] = {
             map_uuid = "map-1",
             score = 42,
-            updated_at = 10,
+            recorded_at = 10,
         },
     },
 }
@@ -21,7 +21,7 @@ local scoreboard = {
 local unchangedScoreboard, keptExistingBest = localScoreStorage.updateBestScore(scoreboard, {
     mapUuid = "map-1",
     finalScore = 41,
-    updated_at = 12,
+    recorded_at = 12,
 })
 assertEqual(keptExistingBest, false, "lower scores do not replace the local best")
 assertEqual(
@@ -33,7 +33,7 @@ assertEqual(
 local improvedScoreboard, storedNewBest = localScoreStorage.updateBestScore(scoreboard, {
     mapUuid = "map-1",
     finalScore = 48,
-    updated_at = 14,
+    recorded_at = 14,
 })
 assertEqual(storedNewBest, true, "higher scores replace the local best")
 assertEqual(
@@ -42,9 +42,9 @@ assertEqual(
     "higher scores overwrite the stored local best"
 )
 assertEqual(
-    improvedScoreboard.entries_by_map["map-1"].updated_at,
+    improvedScoreboard.entries_by_map["map-1"].recorded_at,
     14,
-    "higher scores keep the newest timestamp"
+    "higher scores keep the record creation timestamp"
 )
 
 print("local score storage tests passed")

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -15,6 +15,13 @@ assertEqual(ui.formatLeaderboardScore(70.3), "70.300", "leaderboard score keeps 
 assertEqual(ui.formatLeaderboardScore(70.013), "70.013", "leaderboard score keeps thousandths")
 assertEqual(ui.formatLeaderboardScore(70), "70.000", "leaderboard score shows three decimals for integers")
 
+assert(type(ui.formatLeaderboardRecordedAt) == "function", "ui.formatLeaderboardRecordedAt should exist")
+assertEqual(
+    ui.formatLeaderboardRecordedAt(0),
+    os.date("%Y-%m-%d %H:%M", 0),
+    "leaderboard recorded timestamp formats unix seconds"
+)
+
 assert(type(ui.formatLevelSelectLeaderboardPlayerName) == "function", "ui.formatLevelSelectLeaderboardPlayerName should exist")
 assertEqual(
     ui.formatLevelSelectLeaderboardPlayerName("ABCDEFGHIJKLMN"),


### PR DESCRIPTION
## Requested Behavior
- Fix offline local leaderboard saves so the achieved save date is stored correctly.
- Update the online/offline mode selection dialog copy and styling:
  - rename the dialog title to `Enable Online Functionality`
  - change the main prompt to ask about using online features like leaderboards and community maps
  - make the `Online` button highlighted in green
  - keep the `Offline` button neutral
  - move the explanatory note out of the dialog body and show it as a hover tooltip on `Offline`
  - keep the prompt visually centered with cleaner spacing

## Summary
- Fixed local leaderboard persistence so offline bests save a real recorded timestamp instead of `0`.
- Normalized local leaderboard payload handling to consistently use `recorded_at`.
- Reworked the profile mode setup dialog copy, spacing, and button emphasis.
- Added an `Offline` hover tooltip explaining that the setting can be changed later.
- Updated tests for local score storage and UI formatting.

## Testing
- `tests/local_score_storage_test.lua`
- `tests/ui_formatting_test.lua`