### PR TITLE
Fix map upload gating for local env files

### DIFF
--- a/src/game/env_loader.lua
+++ b/src/game/env_loader.lua
@@ -23,6 +23,16 @@ local SOURCE_SOURCE_DIRECTORY_BUILD = "source directory build.env"
 local SOURCE_SAVE_DIRECTORY = "save directory .env"
 local SOURCE_SAVE_DIRECTORY_BUILD = "save directory build.env"
 local SOURCE_PROCESS_ENVIRONMENT = "process environment"
+local LOCAL_CONFIG_SOURCES = {
+    [SOURCE_WORKING_DIRECTORY] = true,
+    [SOURCE_WORKING_DIRECTORY_BUILD] = true,
+    [SOURCE_LOVE_FILESYSTEM] = true,
+    [SOURCE_LOVE_FILESYSTEM_BUILD] = true,
+    [SOURCE_SOURCE_DIRECTORY] = true,
+    [SOURCE_SOURCE_DIRECTORY_BUILD] = true,
+    [SOURCE_SAVE_DIRECTORY] = true,
+    [SOURCE_SAVE_DIRECTORY_BUILD] = true,
+}
 
 local function trim(value)
     return (value or ""):gsub("^%s+", ""):gsub("%s+$", "")
@@ -226,6 +236,16 @@ local function applyProcessEnvironment(values, sourceByKey)
     end
 end
 
+local function hasLocalRequiredKeys(sourceByKey)
+    for _, key in ipairs(REQUIRED_KEYS) do
+        if not LOCAL_CONFIG_SOURCES[sourceByKey[key]] then
+            return false
+        end
+    end
+
+    return true
+end
+
 function envLoader.load()
     local values, sourceByKey, loadedSourceCount = readEnvValues()
     local errors = {}
@@ -239,6 +259,8 @@ function envLoader.load()
     local apiKey = values.API_KEY or ""
     local apiBaseUrl = values.API_BASE_URL or ""
     local hmacSecret = values.HMAC_SECRET or ""
+    local hasLocalConfigFile = loadedSourceCount > 0
+    local hasLocalRequiredConfig = hasLocalConfigFile and hasLocalRequiredKeys(sourceByKey)
 
     if apiKey == "" then
         errors[#errors + 1] = "API_KEY is missing. Set it in the process environment or in .env."
@@ -254,6 +276,8 @@ function envLoader.load()
         apiBaseUrl = apiBaseUrl,
         hmacSecret = hmacSecret,
         sourceByKey = sourceByKey,
+        hasLocalConfigFile = hasLocalConfigFile,
+        hasLocalRequiredConfig = hasLocalRequiredConfig,
         isConfigured = #errors == 0,
         errors = errors,
     }

--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -91,6 +91,7 @@ local LEADERBOARD_TITLE_MAP_PERSONAL = "Personal Best"
 local RESULTS_MESSAGE_LOCAL_BEST_SAVED = "Saved a new local personal best."
 local RESULTS_MESSAGE_LOCAL_BEST_KEPT = "Your local personal best stays higher."
 local RESULTS_MESSAGE_LOCAL_SAVE_FAILED = "The local personal score could not be saved."
+local LEVEL_SELECT_UPLOAD_ENV_REQUIRED_MESSAGE = "Create a local .env or build.env file with API_KEY and API_BASE_URL before uploading maps."
 
 local function getNowSeconds()
     if love and love.timer and love.timer.getTime then
@@ -560,13 +561,26 @@ function Game:getPlayModeButtonLabel()
 end
 
 function Game:getLocalScoreEntry(mapUuid)
-    if not mapUuid or mapUuid == "" then
+    local resolvedMapUuid = tostring(mapUuid or "")
+    if resolvedMapUuid == "" then
         return nil
     end
 
     local scoreboard = self.localScoreboard or {}
     local entriesByMap = scoreboard.entries_by_map or scoreboard.entriesByMap or {}
-    local entry = entriesByMap[mapUuid]
+    local entry = entriesByMap[resolvedMapUuid]
+    if type(entry) ~= "table" then
+        for _, candidateEntry in pairs(entriesByMap) do
+            local candidateMapUuid = type(candidateEntry) == "table"
+                and tostring(candidateEntry.map_uuid or candidateEntry.mapUuid or candidateEntry.id or "")
+                or ""
+            if candidateMapUuid == resolvedMapUuid then
+                entry = candidateEntry
+                break
+            end
+        end
+    end
+
     if type(entry) ~= "table" then
         return nil
     end
@@ -1885,10 +1899,40 @@ function Game:canUploadMapDescriptor(mapDescriptor)
         and mapDescriptor.isRemoteImport ~= true
 end
 
+function Game:getUploadConfig()
+    if not self:isOnlineMode() then
+        return {
+            isConfigured = false,
+            errors = { "Offline mode is enabled." },
+        }
+    end
+
+    local uploadConfig = leaderboardClient.getConfig()
+    if uploadConfig.isConfigured and uploadConfig.hasLocalRequiredConfig then
+        return uploadConfig
+    end
+
+    local errors = {}
+    for _, errorMessage in ipairs(uploadConfig.errors or {}) do
+        errors[#errors + 1] = errorMessage
+    end
+
+    if not uploadConfig.hasLocalConfigFile then
+        errors[#errors + 1] = LEVEL_SELECT_UPLOAD_ENV_REQUIRED_MESSAGE
+    elseif not uploadConfig.hasLocalRequiredConfig then
+        errors[#errors + 1] = LEVEL_SELECT_UPLOAD_ENV_REQUIRED_MESSAGE
+    end
+
+    uploadConfig.isConfigured = false
+    uploadConfig.errors = errors
+    return uploadConfig
+end
+
 function Game:isUploadSelectedMapAvailable(mapDescriptor)
     return self:isOnlineMode()
         and self.levelSelectMode == LEVEL_SELECT_MODE_LIBRARY
         and self.levelSelectFilter == "user"
+        and self:getUploadConfig().isConfigured
         and self:canUploadMapDescriptor(mapDescriptor or self:getSelectedLevelMap())
 end
 
@@ -1959,7 +2003,7 @@ function Game:uploadSelectedMap()
         return
     end
 
-    local onlineConfig = self:getActiveOnlineConfig()
+    local onlineConfig = self:getUploadConfig()
     if not onlineConfig.isConfigured then
         self:setLevelSelectActionState(
             LEVEL_SELECT_ACTION_STATUS_ERROR,

--- a/src/game/local_score_storage.lua
+++ b/src/game/local_score_storage.lua
@@ -6,7 +6,8 @@ local SCOREBOARD_FILE = "local_scoreboard.json"
 local STORAGE_VERSION = 2
 
 local function sanitizeEntry(mapUuid, entry)
-    local resolvedMapUuid = tostring(mapUuid or entry and entry.map_uuid or "")
+    local entryMapUuid = type(entry) == "table" and tostring(entry.map_uuid or entry.mapUuid or entry.id or "") or ""
+    local resolvedMapUuid = entryMapUuid ~= "" and entryMapUuid or tostring(mapUuid or "")
     if resolvedMapUuid == "" then
         return nil
     end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -2146,6 +2146,17 @@ local function getLevelSelectLeaderboardPinnedRowY(contentRect, visibleEntryCoun
         + LEVEL_SELECT_LEADERBOARD_CARD.pinnedGap
 end
 
+local function shouldShowLevelSelectLeaderboardMessage(topEntries, pinnedPlayerEntry, previewState)
+    local hasTopEntries = #(topEntries or {}) > 0
+    local hasPinnedEntry = pinnedPlayerEntry ~= nil
+
+    return not hasTopEntries
+        and not hasPinnedEntry
+        and not (previewState and previewState.isLoading)
+        and previewState
+        and previewState.message ~= nil
+end
+
 local function drawLevelSelectLeaderboardBack(game, rect)
     local graphics = love.graphics
     local contentRect = {
@@ -2196,7 +2207,7 @@ local function drawLevelSelectLeaderboardBack(game, rect)
             contentRect.y + math.floor(contentRect.h * 0.56 + 0.5),
             { 0.48, 0.92, 0.62, 1 }
         )
-    elseif previewState.message then
+    elseif shouldShowLevelSelectLeaderboardMessage(topEntries, pinnedPlayerEntry, previewState) then
         love.graphics.setFont(game.fonts.small)
         graphics.setColor(PANEL_COLORS.mutedText[1], PANEL_COLORS.mutedText[2], PANEL_COLORS.mutedText[3], PANEL_COLORS.mutedText[4])
         graphics.printf(


### PR DESCRIPTION
## Requested Behavior
Add the missing upload gating so the Upload button only appears when a local `.env` or `build.env` file is present and both required keys exist.

## Summary
- Adds local config metadata to the env loader so the game can distinguish process env from local files.
- Gates map upload availability on a local config file with `API_KEY` and `API_BASE_URL` present.
- Uses the same stricter check in the upload action itself so indirect triggers are blocked too.
- Keeps the existing local score and leaderboard fixes in place.

## Testing
- Not run (not requested)