### PR TITLE
Add output selector tooltip and hover handling

### DIFF
--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -18,6 +18,7 @@ local SPRING_RELEASE_DURATION = 0.42
 local ROAD_PATTERN_OUTLINE = { 0.04, 0.05, 0.07, 0.98 }
 local ROAD_PATTERN_FILL = { 0.97, 0.98, 1.0, 0.94 }
 local TRACK_STRIPE_LENGTH = 14
+local OUTPUT_SELECTOR_RADIUS = 15
 
 local function clamp(value, minValue, maxValue)
     if value < minValue then
@@ -35,6 +36,23 @@ local function copyColor(color)
     end
 
     return { color[1], color[2], color[3] }
+end
+
+local function hasOutputSelector(junction)
+    return junction
+        and #(junction.outputs or {}) > 1
+        and junction.control
+        and junction.control.type ~= "relay"
+        and junction.control.type ~= "crossbar"
+end
+
+local function getContrastTextColor(color)
+    local luminance = color[1] * 0.299 + color[2] * 0.587 + color[3] * 0.114
+    if luminance >= 0.7 then
+        return { 0.05, 0.06, 0.08, 1 }
+    end
+
+    return { 0.97, 0.98, 1, 1 }
 end
 
 local function getColorById(colorId)
@@ -373,8 +391,7 @@ local function withIconScale(graphics, centerX, centerY, iconScale, drawFn)
 end
 
 local function getControlBubbleLayout(junction)
-    local bubbleRadius = junction.crossingRadius - 4
-    return junction.mergePoint.x, junction.mergePoint.y, bubbleRadius
+    return junction.mergePoint.x, junction.mergePoint.y, junction.crossingRadius
 end
 
 local function drawJunctionCircle(graphics, junction, primaryColor, stripeColors)
@@ -406,6 +423,19 @@ end
 local function getSelectorIconScale(junction)
     local press = clamp(junction and junction.selectorPress or 0, -0.4, 1.2)
     return 1 - press * 0.25
+end
+
+function renderer.getControlBubbleLayout(junction)
+    return getControlBubbleLayout(junction)
+end
+
+function renderer.getOutputSelectorLayout(junction)
+    if not hasOutputSelector(junction) then
+        return nil
+    end
+
+    local bubbleX, bubbleY, bubbleRadius = getControlBubbleLayout(junction)
+    return bubbleX, bubbleY + bubbleRadius, OUTPUT_SELECTOR_RADIUS
 end
 
 function renderer.drawTrackPatternSegment(_, startX, startY, endX, endY, alpha, outlineWidth, fillWidth)
@@ -778,20 +808,28 @@ function renderer.drawCrossing(scene, junction)
         graphics.circle("fill", x, y, junction.crossingRadius + 4)
     end
 
-    if #junction.outputs > 1 and junction.control.type ~= "relay" and junction.control.type ~= "crossbar" then
-        local selectorY = y + 36
+    renderer.drawControlOverlay(scene, junction)
+
+    local selectorX, selectorY, selectorRadius = renderer.getOutputSelectorLayout(junction)
+    if selectorX then
         local selectorScale = getSelectorIconScale(junction)
-        withIconScale(graphics, x, selectorY, selectorScale, function()
-            graphics.setColor(0.08, 0.1, 0.13, 1)
-            graphics.circle("fill", x, selectorY, 15)
+        local labelColor = getContrastTextColor(activeOutputColor)
+        withIconScale(graphics, selectorX, selectorY, selectorScale, function()
             graphics.setColor(activeOutputColor[1], activeOutputColor[2], activeOutputColor[3], 1)
-            graphics.circle("line", x, selectorY, 15)
-            graphics.setColor(0.97, 0.98, 1, 1)
-            graphics.printf(tostring(junction.activeOutputIndex), x - 14, selectorY - 7, 28, "center")
+            graphics.circle("fill", selectorX, selectorY, selectorRadius)
+            graphics.setLineWidth(3)
+            graphics.setColor(0.05, 0.06, 0.08, 1)
+            graphics.circle("line", selectorX, selectorY, selectorRadius)
+            graphics.setColor(labelColor[1], labelColor[2], labelColor[3], labelColor[4])
+            graphics.printf(
+                tostring(junction.activeOutputIndex),
+                selectorX - selectorRadius,
+                selectorY - 7,
+                selectorRadius * 2,
+                "center"
+            )
         end)
     end
-
-    renderer.drawControlOverlay(scene, junction)
 end
 
 function renderer.drawTrackSignal(_, junction, inputIndex)

--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -46,15 +46,6 @@ local function hasOutputSelector(junction)
         and junction.control.type ~= "crossbar"
 end
 
-local function getContrastTextColor(color)
-    local luminance = color[1] * 0.299 + color[2] * 0.587 + color[3] * 0.114
-    if luminance >= 0.7 then
-        return { 0.05, 0.06, 0.08, 1 }
-    end
-
-    return { 0.97, 0.98, 1, 1 }
-end
-
 local function getColorById(colorId)
     for _, option in ipairs(COLOR_OPTIONS) do
         if option.id == colorId then
@@ -813,21 +804,12 @@ function renderer.drawCrossing(scene, junction)
     local selectorX, selectorY, selectorRadius = renderer.getOutputSelectorLayout(junction)
     if selectorX then
         local selectorScale = getSelectorIconScale(junction)
-        local labelColor = getContrastTextColor(activeOutputColor)
         withIconScale(graphics, selectorX, selectorY, selectorScale, function()
             graphics.setColor(activeOutputColor[1], activeOutputColor[2], activeOutputColor[3], 1)
             graphics.circle("fill", selectorX, selectorY, selectorRadius)
             graphics.setLineWidth(3)
             graphics.setColor(0.05, 0.06, 0.08, 1)
             graphics.circle("line", selectorX, selectorY, selectorRadius)
-            graphics.setColor(labelColor[1], labelColor[2], labelColor[3], labelColor[4])
-            graphics.printf(
-                tostring(junction.activeOutputIndex),
-                selectorX - selectorRadius,
-                selectorY - 7,
-                selectorRadius * 2,
-                "center"
-            )
         end)
     end
 end

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -885,6 +885,21 @@ local function getJunctionTooltipText(junction)
     return "Switches to the next input as soon as you click it."
 end
 
+local function getOutputSelectorTooltipInfo(junction)
+    local activeOutput = junction and junction.outputs and junction.outputs[junction.activeOutputIndex] or nil
+    local outputLabel = activeOutput and activeOutput.label or ("Output " .. tostring(junction and junction.activeOutputIndex or 1))
+
+    return {
+        x = junction.mergePoint.x,
+        y = junction.mergePoint.y + junction.crossingRadius,
+        title = "Output Selector",
+        text = string.format(
+            "Controls which outgoing line is active. Left click to cycle forward, right click to cycle backward. Current route: %s.",
+            outputLabel
+        ),
+    }
+end
+
 local function getSpeedTooltipInfo(roadTypeId, x, y)
     local config = roadTypes.getConfig(roadTypeId)
     if not config or config.id == roadTypes.DEFAULT_ID then
@@ -3312,13 +3327,23 @@ end
 
 local function getJunctionHoverInfo(game, x, y)
     for _, junction in ipairs(game.world.junctionOrder or {}) do
-        if game.world:isCrossingHit(junction, x, y) or game.world:isOutputSelectorHit(junction, x, y) then
+        if game.world:isCrossingHit(junction, x, y) then
             return {
                 x = junction.mergePoint.x,
                 y = junction.mergePoint.y - junction.crossingRadius,
                 title = getJunctionTooltipTitle(junction),
                 text = getJunctionTooltipText(junction),
             }
+        end
+    end
+
+    return nil
+end
+
+local function getOutputSelectorHoverInfo(game, x, y)
+    for _, junction in ipairs(game.world.junctionOrder or {}) do
+        if game.world:isOutputSelectorHit(junction, x, y) then
+            return getOutputSelectorTooltipInfo(junction)
         end
     end
 
@@ -3376,6 +3401,7 @@ function ui.getPlayHoverInfoAt(game, x, y)
 
     return getPrepTrainHoverInfo(game, x, y)
         or getOutputBadgeHoverInfo(game, x, y)
+        or getOutputSelectorHoverInfo(game, x, y)
         or getJunctionHoverInfo(game, x, y)
         or getTrackSectionHoverInfo(game, x, y)
 end

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1392,11 +1392,12 @@ function world:isCrossingHit(junction, x, y)
 end
 
 function world:isOutputSelectorHit(junction, x, y)
-    if #junction.outputs <= 1 or junction.control.type == "relay" or junction.control.type == "crossbar" then
+    local selectorX, selectorY, selectorRadius = trackSceneRenderer.getOutputSelectorLayout(junction)
+    if not selectorX then
         return false
     end
 
-    return distanceSquared(x, y, junction.mergePoint.x, junction.mergePoint.y + 36) <= 15 * 15
+    return distanceSquared(x, y, selectorX, selectorY) <= selectorRadius * selectorRadius
 end
 
 function world:handleClick(x, y, button, isPreparationPhase)

--- a/tests/track_scene_renderer_layout_test.lua
+++ b/tests/track_scene_renderer_layout_test.lua
@@ -1,0 +1,58 @@
+love = love or {}
+love.graphics = love.graphics or {}
+
+local renderer = require("src.game.track_scene_renderer")
+
+local function assertEqual(actual, expected, message)
+    if actual ~= expected then
+        error(string.format("%s (expected %s, got %s)", message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assertTrue(value, message)
+    if not value then
+        error(message, 2)
+    end
+end
+
+local directJunction = {
+    mergePoint = { x = 100, y = 200 },
+    crossingRadius = 24,
+    outputs = { {}, {} },
+    control = { type = "direct" },
+}
+
+local bubbleX, bubbleY, bubbleRadius = renderer.getControlBubbleLayout(directJunction)
+assertEqual(bubbleX, 100, "bubble layout keeps the junction horizontally centered")
+assertEqual(bubbleY, 200, "bubble layout keeps the junction vertically centered")
+assertEqual(bubbleRadius, 24, "bubble layout covers the full junction circle")
+
+local selectorX, selectorY, selectorRadius = renderer.getOutputSelectorLayout(directJunction)
+assertEqual(selectorX, 100, "selector stays horizontally centered on the junction")
+assertEqual(selectorY, 224, "selector center sits on the bottom border of the main control")
+assertEqual(selectorRadius, 15, "selector keeps the expected radius")
+assertEqual(selectorY, bubbleY + bubbleRadius, "selector anchors to the main control border")
+
+local singleOutputJunction = {
+    mergePoint = { x = 100, y = 200 },
+    crossingRadius = 24,
+    outputs = { {} },
+    control = { type = "direct" },
+}
+
+local _, singleBubbleY = renderer.getControlBubbleLayout(singleOutputJunction)
+assertEqual(singleBubbleY, 200, "single-output junctions keep the control bubble centered")
+assertEqual(renderer.getOutputSelectorLayout(singleOutputJunction), nil, "single-output junctions do not expose a selector")
+
+local crossbarJunction = {
+    mergePoint = { x = 100, y = 200 },
+    crossingRadius = 24,
+    outputs = { {}, {} },
+    control = { type = "crossbar" },
+}
+
+local _, crossbarBubbleY = renderer.getControlBubbleLayout(crossbarJunction)
+assertEqual(crossbarBubbleY, 200, "crossbar junctions keep the main control centered")
+assertEqual(renderer.getOutputSelectorLayout(crossbarJunction), nil, "crossbar junctions do not expose the manual selector")
+
+print("track scene renderer layout tests passed")

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -233,6 +233,11 @@ local testWorld = {
             mergePoint = { x = 600, y = 300 },
             crossingRadius = 20,
             control = { type = "delayed", delay = 2.25 },
+            activeOutputIndex = 2,
+            outputs = {
+                { label = "South Exit" },
+                { label = "West Exit" },
+            },
         },
     },
     edges = {
@@ -268,8 +273,8 @@ function testWorld:isCrossingHit(junction, x, y)
     return (dx * dx) + (dy * dy) <= junction.crossingRadius * junction.crossingRadius
 end
 
-function testWorld:isOutputSelectorHit()
-    return false
+function testWorld:isOutputSelectorHit(_, x, y)
+    return x == 600 and y == 320
 end
 
 local hoverGame = {
@@ -302,6 +307,10 @@ assertEqual(badgeHover.title, "Expected Trains", "play hover identifies exit bad
 
 local junctionHover = ui.getPlayHoverInfoAt(hoverGame, 600, 300)
 assertEqual(junctionHover.title, "Delay Junction", "play hover identifies junction controls")
+
+local selectorHover = ui.getPlayHoverInfoAt(hoverGame, 600, 320)
+assertEqual(selectorHover.title, "Output Selector", "play hover identifies outgoing selector controls")
+assertEqual(selectorHover.text:find("West Exit", 1, true) ~= nil, true, "selector hover includes the active output label")
 
 local speedHover = ui.getPlayHoverInfoAt(hoverGame, 810, 414)
 assertEqual(speedHover.title, "Fast Section", "play hover identifies speed-modified track sections")


### PR DESCRIPTION
## Requested Behavior
- Add a tooltip for the outgoing line junction control.
- Make the outgoing selector properly hoverable.
- Prevent the selector hover area from fighting with the main junction hitbox so tooltips show reliably.

## Summary
- Added a dedicated tooltip for the output selector with the active output label.
- Split selector hover detection from main junction hover detection and gave the selector its own hover path.
- Kept selector hit-testing aligned with the renderer so hover and click behavior use the same geometry.
- Extended UI tests to cover the new selector tooltip and hover priority.

## Testing
- Not run (not requested)