### PR TITLE
Fix prep-phase junction setup + fix animation of clicked junctions not wrongly playing on start

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -4055,6 +4055,16 @@ function mapEditor:isIntersectionOutputSelectorHit(intersection, x, y)
         <= INTERSECTION_SELECTOR_CLICK_RADIUS * INTERSECTION_SELECTOR_CLICK_RADIUS
 end
 
+function mapEditor:findIntersectionOutputSelectorHit(x, y)
+    for _, intersection in ipairs(self.intersections) do
+        if self:isIntersectionOutputSelectorHit(intersection, x, y) then
+            return intersection
+        end
+    end
+
+    return nil
+end
+
 function mapEditor:setIntersectionControlType(intersection, controlType)
     if not intersection or not controlType then
         return false
@@ -4069,15 +4079,9 @@ function mapEditor:setIntersectionControlType(intersection, controlType)
 
     intersection.controlType = controlType
     if intersection.controlType == "relay" then
-        local outputCount = #(intersection.outputEndpointIds or {})
-        if outputCount > 0 then
-            intersection.activeOutputIndex = math.min(intersection.activeInputIndex or 1, outputCount)
-        end
+        self:syncIntersectionOutputToControl(intersection)
     elseif intersection.controlType == "crossbar" then
-        local outputCount = #(intersection.outputEndpointIds or {})
-        if outputCount > 0 then
-            intersection.activeOutputIndex = math.max(1, outputCount - (intersection.activeInputIndex or 1) + 1)
-        end
+        self:syncIntersectionOutputToControl(intersection)
     end
 
     self:refreshValidation(self.currentMapName)
@@ -4102,6 +4106,53 @@ function mapEditor:cycleIntersection(intersection)
     self:setIntersectionControlType(intersection, CONTROL_ORDER[nextIndex])
 end
 
+function mapEditor:syncIntersectionOutputToControl(intersection)
+    if not intersection then
+        return
+    end
+
+    local outputCount = #(intersection.outputEndpointIds or {})
+    if outputCount <= 0 then
+        intersection.activeOutputIndex = 1
+        return
+    end
+
+    if intersection.controlType == "relay" then
+        intersection.activeOutputIndex = math.min(intersection.activeInputIndex or 1, outputCount)
+    elseif intersection.controlType == "crossbar" then
+        intersection.activeOutputIndex = math.max(1, outputCount - (intersection.activeInputIndex or 1) + 1)
+    else
+        intersection.activeOutputIndex = clamp(intersection.activeOutputIndex or 1, 1, outputCount)
+    end
+end
+
+function mapEditor:cycleIntersectionInput(intersection)
+    if not intersection then
+        return false
+    end
+    if intersection.unsupported then
+        self:showStatus("Junctions currently support up to five inputs and five outputs.")
+        return false
+    end
+
+    local inputCount = #(intersection.inputRouteIds or {})
+    if inputCount <= 1 then
+        intersection.activeInputIndex = 1
+        self:syncIntersectionOutputToControl(intersection)
+        return false
+    end
+
+    intersection.activeInputIndex = (intersection.activeInputIndex or 1) + 1
+    if intersection.activeInputIndex > inputCount then
+        intersection.activeInputIndex = 1
+    end
+
+    self:syncIntersectionOutputToControl(intersection)
+    self:refreshValidation(self.currentMapName)
+    self:showStatus("Junction start switched to " .. intersection.activeInputIndex .. ".")
+    return true
+end
+
 function mapEditor:cycleIntersectionOutput(intersection, direction)
     if intersection.controlType == "relay" or intersection.controlType == "crossbar" then
         self:showStatus("This dial couples start and end together.")
@@ -4120,6 +4171,7 @@ function mapEditor:cycleIntersectionOutput(intersection, direction)
         intersection.activeOutputIndex = 1
     end
 
+    self:refreshValidation(self.currentMapName)
     self:showStatus("Junction end switched to " .. intersection.activeOutputIndex .. ".")
 end
 
@@ -5043,11 +5095,13 @@ function mapEditor:mousepressed(screenX, screenY, button)
             return true
         end
 
-        local hitIntersection = self:findIntersectionHit(x, y)
-        if self:isIntersectionOutputSelectorHit(hitIntersection, x, y) then
-            self:cycleIntersectionOutput(hitIntersection, -1)
+        local outputSelectorIntersection = self:findIntersectionOutputSelectorHit(x, y)
+        if outputSelectorIntersection then
+            self:cycleIntersectionOutput(outputSelectorIntersection, -1)
             return true
         end
+
+        local hitIntersection = self:findIntersectionHit(x, y)
         if hitIntersection then
             self:openJunctionPicker(hitIntersection, screenX, screenY)
             self:updateJunctionPickerHover(screenX, screenY)
@@ -5083,32 +5137,34 @@ function mapEditor:mousepressed(screenX, screenY, button)
         return true
     end
 
+    local outputSelectorIntersection = self:findIntersectionOutputSelectorHit(x, y)
+    if outputSelectorIntersection then
+        self:cycleIntersectionOutput(outputSelectorIntersection, 1)
+        return true
+    end
+
     local hitIntersection = self:findIntersectionHit(x, y)
     if hitIntersection then
-        if self:isIntersectionOutputSelectorHit(hitIntersection, x, y) then
-            self:cycleIntersectionOutput(hitIntersection, 1)
-        else
-            self.drag = {
-                kind = "intersection",
-                intersectionId = hitIntersection.id,
-                intersectionSnapshot = {
-                    id = hitIntersection.id,
-                    x = hitIntersection.x,
-                    y = hitIntersection.y,
-                    routeIds = copyArray(hitIntersection.routeIds),
-                },
-                sharedPointId = nil,
-                routeId = nil,
-                pointIndex = nil,
-                startMouseX = x,
-                startMouseY = y,
-                moved = false,
-                isMagnet = false,
-                magnetKind = nil,
-            }
-            self:closeColorPicker()
-            self:closeRouteTypePicker()
-        end
+        self.drag = {
+            kind = "intersection",
+            intersectionId = hitIntersection.id,
+            intersectionSnapshot = {
+                id = hitIntersection.id,
+                x = hitIntersection.x,
+                y = hitIntersection.y,
+                routeIds = copyArray(hitIntersection.routeIds),
+            },
+            sharedPointId = nil,
+            routeId = nil,
+            pointIndex = nil,
+            startMouseX = x,
+            startMouseY = y,
+            moved = false,
+            isMagnet = false,
+            magnetKind = nil,
+        }
+        self:closeColorPicker()
+        self:closeRouteTypePicker()
         return true
     end
 
@@ -5307,8 +5363,19 @@ function mapEditor:mousereleased(screenX, screenY, button)
         end
     end
 
-    if self.drag.kind == "intersection" and self.drag.moved then
-        self:showStatus("Junction moved.")
+    if self.drag.kind == "intersection" then
+        local activeIntersection = self:getIntersectionById(self.drag.intersectionId)
+        local wasMoved = self.drag.moved
+        self.drag = nil
+
+        if wasMoved then
+            self:showStatus("Junction moved.")
+            self:rebuildIntersections()
+            return true
+        end
+
+        self:cycleIntersectionInput(activeIntersection)
+        return true
     end
 
     self.drag = nil

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1316,6 +1316,23 @@ function world:canActivateControl(junction, isPreparationPhase)
     return true
 end
 
+function world:activatePreparationControl(junction)
+    if not junction then
+        return false
+    end
+
+    local changed = self:cycleInput(junction)
+    local controlType = junction.control and junction.control.type or "direct"
+
+    if controlType == "relay" then
+        self:syncRelayOutput(junction)
+    elseif controlType == "crossbar" then
+        self:syncCrossbarOutput(junction)
+    end
+
+    return changed
+end
+
 function world:activateControl(junction)
     local control = junction.control
 
@@ -1409,15 +1426,26 @@ function world:handleClick(x, y, button, isPreparationPhase)
                 changed = self:cycleOutput(junction, 1)
             end
             if changed then
-                self:pressOutputSelector(junction, 1)
+                if not isPreparationPhase then
+                    self:pressOutputSelector(junction, 1)
+                end
                 self:registerInteraction()
             end
             return true
         end
 
         if button == 1 and self:isCrossingHit(junction, x, y) then
-            if self:canActivateControl(junction, isPreparationPhase) and self:activateControl(junction) then
-                self:pressJunctionIcon(junction, 1)
+            local changed = false
+            if isPreparationPhase then
+                changed = self:activatePreparationControl(junction)
+            elseif self:canActivateControl(junction, false) then
+                changed = self:activateControl(junction)
+            end
+
+            if changed then
+                if not isPreparationPhase then
+                    self:pressJunctionIcon(junction, 1)
+                end
                 self:registerInteraction()
             end
             return true

--- a/tests/map_editor_junction_state_test.lua
+++ b/tests/map_editor_junction_state_test.lua
@@ -1,0 +1,130 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.2, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.82, y = 0.8, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.2, colors = { "orange" } },
+        { id = "output_left", kind = "output", x = 0.18, y = 0.8, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.18, y = 0.2 },
+                { x = 0.82, y = 0.8 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.82, y = 0.2 },
+                { x = 0.18, y = 0.8 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Junction State Regression", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 1, "crossing routes should produce one junction")
+assertTrue(editor.previewWorld and editor.previewWorld.junctionOrder and editor.previewWorld.junctionOrder[1], "editor preview should build a playable junction")
+
+local intersection = editor.intersections[1]
+local previewJunction = editor.previewWorld.junctionOrder[1]
+
+assertEqual(intersection.activeInputIndex, 1, "junction starts on the first input by default")
+assertEqual(intersection.activeOutputIndex, 1, "junction starts on the first output by default")
+assertEqual(previewJunction.activeInputIndex, 1, "preview world starts on the first input by default")
+assertEqual(previewJunction.activeOutputIndex, 1, "preview world starts on the first output by default")
+
+local centerScreenX, centerScreenY = editor:mapToScreen(intersection.x, intersection.y)
+editor:mousepressed(centerScreenX, centerScreenY, 1)
+editor:mousereleased(centerScreenX, centerScreenY, 1)
+
+intersection = editor.intersections[1]
+previewJunction = editor.previewWorld.junctionOrder[1]
+
+assertEqual(intersection.activeInputIndex, 2, "left-clicking a junction cycles the saved starting input")
+assertEqual(previewJunction.activeInputIndex, 2, "preview world reflects the cycled starting input")
+
+local selectorScreenX, selectorScreenY = editor:mapToScreen(intersection.x, intersection.y + 36)
+editor:mousepressed(selectorScreenX, selectorScreenY, 1)
+
+intersection = editor.intersections[1]
+previewJunction = editor.previewWorld.junctionOrder[1]
+
+assertEqual(intersection.activeOutputIndex, 2, "clicking the output selector cycles the saved starting output")
+assertEqual(previewJunction.activeOutputIndex, 2, "preview world reflects the cycled starting output")
+
+local exported = editor:getExportData()
+local reloadedEditor = mapEditor.new(1280, 720, nil)
+reloadedEditor:loadEditorData(exported, "Junction State Reloaded", nil, nil)
+
+assertEqual(reloadedEditor.intersections[1].activeInputIndex, 2, "reloaded editor keeps the saved starting input")
+assertEqual(reloadedEditor.intersections[1].activeOutputIndex, 2, "reloaded editor keeps the saved starting output")
+
+local movedIntersection = reloadedEditor.intersections[1]
+local beforeX = movedIntersection.x
+local beforeY = movedIntersection.y
+local beforeInputIndex = movedIntersection.activeInputIndex
+local dragStartScreenX, dragStartScreenY = reloadedEditor:mapToScreen(beforeX, beforeY)
+local dragEndScreenX, dragEndScreenY = reloadedEditor:mapToScreen(beforeX + 16, beforeY + 8)
+
+reloadedEditor:mousepressed(dragStartScreenX, dragStartScreenY, 1)
+reloadedEditor:mousemoved(dragEndScreenX, dragEndScreenY, dragEndScreenX - dragStartScreenX, dragEndScreenY - dragStartScreenY)
+reloadedEditor:mousereleased(dragEndScreenX, dragEndScreenY, 1)
+
+local movedAfterDrag = reloadedEditor.intersections[1]
+assertTrue(
+    math.abs(movedAfterDrag.x - beforeX) > 10 or math.abs(movedAfterDrag.y - beforeY) > 10,
+    "dragging a junction should still move it instead of cycling the saved state"
+)
+assertEqual(movedAfterDrag.activeInputIndex, beforeInputIndex, "dragging keeps the chosen starting input")
+
+print("map editor junction state tests passed")

--- a/tests/world_preparation_junction_setup_test.lua
+++ b/tests/world_preparation_junction_setup_test.lua
@@ -1,0 +1,146 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local world = require("src.game.world")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function buildSimulation(controlType)
+    return world.new(1200, 800, {
+        junctions = {
+            {
+                id = controlType .. "_junction",
+                label = controlType,
+                control = {
+                    type = controlType,
+                    delay = 2.25,
+                    target = 3,
+                    holdTime = 1.6,
+                    passCount = 2,
+                    decayDelay = 0.55,
+                    decayInterval = 0.2,
+                },
+                activeInputIndex = 1,
+                activeOutputIndex = 1,
+                inputs = {
+                    {
+                        id = controlType .. "_input_a",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        inputPoints = {
+                            { x = 0.20, y = 0.12 },
+                            { x = 0.32, y = 0.28 },
+                            { x = 0.50, y = 0.50 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_b",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "orange" },
+                        inputPoints = {
+                            { x = 0.80, y = 0.12 },
+                            { x = 0.68, y = 0.28 },
+                            { x = 0.50, y = 0.50 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = controlType .. "_output_a",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "mint" },
+                        outputPoints = {
+                            { x = 0.50, y = 0.50 },
+                            { x = 0.32, y = 0.72 },
+                            { x = 0.20, y = 0.88 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_b",
+                        color = { 0.82, 0.56, 0.98 },
+                        colors = { "violet" },
+                        outputPoints = {
+                            { x = 0.50, y = 0.50 },
+                            { x = 0.68, y = 0.72 },
+                            { x = 0.80, y = 0.88 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {},
+    })
+end
+
+local function assertNoPreparationSideEffects(junction, controlType)
+    local control = junction.control
+    assertEqual(control.armed, false, controlType .. " prep click should not arm the control")
+    assertEqual(control.remainingDelay, 0, controlType .. " prep click should not start a delay")
+    assertEqual(control.remainingHold, 0, controlType .. " prep click should not start a spring hold")
+    assertEqual(control.releaseTimer, 0, controlType .. " prep click should not start a spring release")
+    assertEqual(control.remainingTrips, 0, controlType .. " prep click should not start trip counting")
+    assertEqual(control.pendingResetTrainId, nil, controlType .. " prep click should not bind a trip reset train")
+    assertEqual(control.pendingResetEdgeId, nil, controlType .. " prep click should not bind a trip reset edge")
+    assertEqual(control.pumpCount, 0, controlType .. " prep click should not add pump charge")
+    assertEqual(control.decayHold, 0, controlType .. " prep click should not start pump decay")
+    assertEqual(control.decayTimer, 0, controlType .. " prep click should not start pump decay timing")
+    assertEqual(control.iconPress, 0, controlType .. " prep click should not queue a control press animation")
+    assertEqual(control.iconPressVelocity, 0, controlType .. " prep click should not queue a control press velocity")
+    assertEqual(junction.selectorPress, 0, controlType .. " prep click should not queue an output selector animation")
+    assertEqual(junction.selectorPressVelocity, 0, controlType .. " prep click should not queue an output selector velocity")
+
+    if controlType == "relay" or controlType == "crossbar" or controlType == "trip" then
+        assertEqual(control.flashTimer, 0, controlType .. " prep click should not trigger a flash")
+    end
+end
+
+local controlTypes = { "direct", "delayed", "pump", "spring", "relay", "trip", "crossbar" }
+
+for _, controlType in ipairs(controlTypes) do
+    local simulation = buildSimulation(controlType)
+    local junction = simulation.junctions[controlType .. "_junction"]
+    local centerX = junction.mergePoint.x
+    local centerY = junction.mergePoint.y
+
+    local clickedCenter = simulation:handleClick(centerX, centerY, 1, true)
+    assertEqual(clickedCenter, true, controlType .. " prep center click should be consumed")
+    assertEqual(junction.activeInputIndex, 2, controlType .. " prep center click should cycle the selected input")
+
+    if controlType == "relay" then
+        assertEqual(junction.activeOutputIndex, 2, controlType .. " prep center click should keep the coupled output mapping in sync")
+    elseif controlType == "crossbar" then
+        assertEqual(junction.activeOutputIndex, 1, controlType .. " prep center click should keep the mirrored output mapping in sync")
+    else
+        assertEqual(junction.activeOutputIndex, 1, controlType .. " prep center click should not force a different output")
+    end
+
+    assertNoPreparationSideEffects(junction, controlType)
+
+    local clickedSelector = simulation:handleClick(centerX, centerY + 48, 1, true)
+    if controlType == "relay" or controlType == "crossbar" then
+        assertEqual(clickedSelector, false, controlType .. " should not expose a separate output selector")
+        if controlType == "relay" then
+            assertEqual(junction.activeOutputIndex, 2, controlType .. " should still keep the coupled output after selector click")
+        else
+            assertEqual(junction.activeOutputIndex, 1, controlType .. " should still keep the mirrored output after selector click")
+        end
+    else
+        assertEqual(clickedSelector, true, controlType .. " prep output selector click should be consumed")
+        assertEqual(junction.activeOutputIndex, 2, controlType .. " prep output selector click should cycle the selected output")
+    end
+
+    assertNoPreparationSideEffects(junction, controlType)
+end
+
+print("world preparation junction setup tests passed")


### PR DESCRIPTION
## Requested Behavior
- Let players change the starting incoming lane and outgoing selector during preparation.
- Do not arm delay/pump/spring/trip behavior or trigger any actual control action when doing so.
- Keep the setup state across load/save and avoid any misleading button-press animation when entering play.

## Summary
- Split preparation-phase junction clicks from normal activation in `world.lua`.
- Keep prep clicks as selection-only changes for all junction types.
- Suppress junction and selector press animations during preparation so nothing carries into play visually.
- Preserve editor-side junction state selection/loading behavior.

## Testing
- `world_preparation_junction_setup_test.lua`
- `world_minimum_distance_crossbar_test.lua`
- `map_editor_junction_state_test.lua`