### PR TITLE
Remove live score HUD and ignore prep interactions

### DIFF
--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -4021,28 +4021,8 @@ end
 
 function ui.drawPlay(game)
     local graphics = love.graphics
-    local runSummary = game.world:getRunSummary()
     local inputGroups = game.world:getInputEdgeGroups()
     local outputGroups = game.world:getOutputBadgeGroups()
-    local scorePanel = {
-        x = math.floor(game.viewport.w - 274 + 0.5),
-        y = math.floor(game.viewport.h * 0.5 - 52 + 0.5),
-        w = 236,
-        h = 104,
-    }
-
-    graphics.setColor(0.08, 0.1, 0.13, 0.94)
-    graphics.rectangle("fill", scorePanel.x, scorePanel.y, scorePanel.w, scorePanel.h, 18, 18)
-    graphics.setColor(0.3, 0.36, 0.42, 1)
-    graphics.rectangle("line", scorePanel.x, scorePanel.y, scorePanel.w, scorePanel.h, 18, 18)
-
-    love.graphics.setFont(game.fonts.small)
-    graphics.setColor(0.8, 0.84, 0.9, 0.95)
-    graphics.printf("Score", scorePanel.x + 20, scorePanel.y + 18, scorePanel.w - 40, "left")
-
-    love.graphics.setFont(game.fonts.title)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf(formatScore(runSummary.finalScore or 0), scorePanel.x + 20, scorePanel.y + 44, scorePanel.w - 40, "left")
 
     for _, badge in ipairs(outputGroups) do
         drawOutputBadge(game, badge)

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1429,8 +1429,8 @@ function world:handleClick(x, y, button, isPreparationPhase)
             if changed then
                 if not isPreparationPhase then
                     self:pressOutputSelector(junction, 1)
+                    self:registerInteraction()
                 end
-                self:registerInteraction()
             end
             return true
         end
@@ -1446,8 +1446,8 @@ function world:handleClick(x, y, button, isPreparationPhase)
             if changed then
                 if not isPreparationPhase then
                     self:pressJunctionIcon(junction, 1)
+                    self:registerInteraction()
                 end
-                self:registerInteraction()
             end
             return true
         end

--- a/tests/world_preparation_junction_setup_test.lua
+++ b/tests/world_preparation_junction_setup_test.lua
@@ -116,6 +116,7 @@ for _, controlType in ipairs(controlTypes) do
     local clickedCenter = simulation:handleClick(centerX, centerY, 1, true)
     assertEqual(clickedCenter, true, controlType .. " prep center click should be consumed")
     assertEqual(junction.activeInputIndex, 2, controlType .. " prep center click should cycle the selected input")
+    assertEqual(simulation.interactionCount, 0, controlType .. " prep center click should not count as an interaction")
 
     if controlType == "relay" then
         assertEqual(junction.activeOutputIndex, 2, controlType .. " prep center click should keep the coupled output mapping in sync")
@@ -139,6 +140,7 @@ for _, controlType in ipairs(controlTypes) do
         assertEqual(clickedSelector, true, controlType .. " prep output selector click should be consumed")
         assertEqual(junction.activeOutputIndex, 2, controlType .. " prep output selector click should cycle the selected output")
     end
+    assertEqual(simulation.interactionCount, 0, controlType .. " prep selector click should not count as an interaction")
 
     assertNoPreparationSideEffects(junction, controlType)
 end


### PR DESCRIPTION
## Requested Behavior
We should remove the score that is currently always displayed in the preparation phase and in-game as well. The score should only be shown in the result screen. And also, a bug I just found regarding the interaction counter. While in the preparation phase and while we are able to click on junctions and like outward facing junctions, those controls, the counter for interactions is already counting up and thereby already decreasing our score. This should not be the case. In preparation phase, we can play around as much as we want, set up things how we want, but this should not factor into our interaction counter or interaction penalty.

## Summary
- Removed the always-visible score panel from the play screen so score is only shown in results.
- Stopped prep-phase junction and output-selector clicks from incrementing `interactionCount`.
- Added a regression test to verify preparation clicks do not affect interaction scoring.

## Testing
- `world_preparation_junction_setup_test.lua`
- `ui_formatting_test.lua`