### PR TITLE
Update level select badge tooltips and junction terminology

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -347,6 +347,7 @@ function Game.new()
     self.levelSelectSelectedMapUuid = nil
     self.levelSelectFilter = "all"
     self.levelSelectHoverId = nil
+    self.levelSelectHoverInfo = nil
     self.levelSelectVisualIndex = nil
     self.levelSelectTargetVisualIndex = nil
     self.levelSelectScroll = 0
@@ -2617,6 +2618,7 @@ function Game:setLevelSelectMode(mode)
 
     self.levelSelectMode = resolvedMode
     self.levelSelectHoverId = nil
+    self.levelSelectHoverInfo = nil
     self.levelSelectIssue = nil
     self:clearLevelSelectActionState()
     self:getSelectedLevelMap()
@@ -2643,6 +2645,7 @@ function Game:setLevelSelectMarketplaceTab(tabId)
         if tabId == allowedTabId then
             self.levelSelectMarketplaceTab = tabId
             self.levelSelectHoverId = nil
+            self.levelSelectHoverInfo = nil
             self:clearLevelSelectActionState()
             self:getSelectedLevelMap()
             self:resetLevelSelectVisualIndex()
@@ -2834,6 +2837,7 @@ function Game:openMenu()
     self.screen = "menu"
     self.levelSelectIssue = nil
     self.levelSelectHoverId = nil
+    self.levelSelectHoverInfo = nil
     self:clearLevelSelectActionState()
     self.resultsSummary = nil
     self.playOverlayMode = nil
@@ -2846,6 +2850,7 @@ function Game:openLevelSelect()
     self.levelSelectIssue = nil
     self.levelSelectFilter = "all"
     self.levelSelectHoverId = nil
+    self.levelSelectHoverInfo = nil
     self.levelSelectMode = LEVEL_SELECT_MODE_LIBRARY
     self.levelSelectMarketplaceTab = LEVEL_SELECT_MARKETPLACE_TAB_TOP
     self.levelSelectMarketplaceSearchQuery = ""
@@ -3487,6 +3492,7 @@ end
 
 function Game:mousemoved(x, y, dx, dy)
     self.playHoverInfo = nil
+    self.levelSelectHoverInfo = nil
     if self.screen == "leaderboard" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
         self.leaderboardHoverInfo = ui.getLeaderboardHoverInfoAt(self, viewportX, viewportY)
@@ -3502,6 +3508,7 @@ function Game:mousemoved(x, y, dx, dy)
     if self.screen == "level_select" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
         self.levelSelectHoverId = ui.getLevelSelectHoverId(self, viewportX, viewportY)
+        self.levelSelectHoverInfo = ui.getLevelSelectHoverInfoAt(self, viewportX, viewportY)
         return
     end
 

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -85,12 +85,66 @@ local PREVIEW_COLORS = {
 
 local CONTROL_SHORT_LABELS = {
     direct = "Direct",
-    delayed = "Timer",
+    delayed = "Delay",
     pump = "Charge",
     spring = "Spring",
     relay = "Relay",
     trip = "Trip",
     crossbar = "Cross",
+}
+
+local LEVEL_SELECT_BADGE_DEFINITIONS = {
+    direct = {
+        label = "Direct",
+        tooltipTitle = "Direct Junction",
+        tooltipText = "This map contains a direct junction.",
+    },
+    delayed = {
+        label = "Delay",
+        tooltipTitle = "Delay Junction",
+        tooltipText = "This map contains a delay junction.",
+    },
+    pump = {
+        label = "Charge",
+        tooltipTitle = "Charge Junction",
+        tooltipText = "This map contains a charge junction.",
+    },
+    spring = {
+        label = "Spring",
+        tooltipTitle = "Spring Junction",
+        tooltipText = "This map contains a spring junction.",
+    },
+    relay = {
+        label = "Relay",
+        tooltipTitle = "Relay Junction",
+        tooltipText = "This map contains a relay junction.",
+    },
+    trip = {
+        label = "Trip",
+        tooltipTitle = "Trip Junction",
+        tooltipText = "This map contains a trip junction.",
+    },
+    crossbar = {
+        label = "Cross",
+        tooltipTitle = "Crossbar Junction",
+        tooltipText = "This map contains a crossbar junction.",
+    },
+    deadline = {
+        label = "Deadline",
+        tooltipTitle = "Map Deadline",
+        tooltipText = "This map has an overall deadline.",
+        fillColor = { 0.98, 0.66, 0.28, 0.98 },
+        lineColor = { 0.99, 0.86, 0.44, 1 },
+        textColor = { 0.2, 0.12, 0.02, 1 },
+    },
+    express = {
+        label = "Express",
+        tooltipTitle = "Express Train",
+        tooltipText = "This map contains at least one train with a deadline.",
+        fillColor = { 0.38, 0.94, 0.86, 0.98 },
+        lineColor = { 0.74, 0.99, 0.95, 1 },
+        textColor = { 0.05, 0.16, 0.14, 1 },
+    },
 }
 
 local PANEL_COLORS = {
@@ -855,7 +909,7 @@ local function getJunctionTooltipTitle(junction)
         pump = "Charge Junction",
         spring = "Spring Junction",
         relay = "Relay Junction",
-        trip = "Trap Junction",
+        trip = "Trip Junction",
         crossbar = "Crossbar Junction",
     }
 
@@ -1496,6 +1550,67 @@ local function appendUniqueControl(controls, seen, controlType)
     end
 end
 
+local function mapHasLevelDeadline(descriptor)
+    local level = descriptor and descriptor.previewLevel or nil
+    return level and level.timeLimit ~= nil
+end
+
+local function mapHasExpressTrain(descriptor)
+    local level = descriptor and descriptor.previewLevel or nil
+    for _, train in ipairs(level and level.trains or {}) do
+        if train.deadline ~= nil then
+            return true
+        end
+    end
+    return false
+end
+
+local function buildLevelSelectBadges(descriptor)
+    local badges = {}
+
+    for _, controlType in ipairs(getMapControlTypes(descriptor)) do
+        local definition = LEVEL_SELECT_BADGE_DEFINITIONS[controlType] or {}
+        badges[#badges + 1] = {
+            key = controlType,
+            controlType = controlType,
+            label = definition.label or CONTROL_SHORT_LABELS[controlType] or controlType,
+            tooltipTitle = definition.tooltipTitle or (definition.label or controlType),
+            tooltipText = definition.tooltipText or string.format("This map contains %s.", definition.label or controlType),
+            fillColor = definition.fillColor,
+            lineColor = definition.lineColor,
+            textColor = definition.textColor,
+        }
+    end
+
+    if mapHasLevelDeadline(descriptor) then
+        local definition = LEVEL_SELECT_BADGE_DEFINITIONS.deadline
+        badges[#badges + 1] = {
+            key = "deadline",
+            label = definition.label,
+            tooltipTitle = definition.tooltipTitle,
+            tooltipText = definition.tooltipText,
+            fillColor = definition.fillColor,
+            lineColor = definition.lineColor,
+            textColor = definition.textColor,
+        }
+    end
+
+    if mapHasExpressTrain(descriptor) then
+        local definition = LEVEL_SELECT_BADGE_DEFINITIONS.express
+        badges[#badges + 1] = {
+            key = "express",
+            label = definition.label,
+            tooltipTitle = definition.tooltipTitle,
+            tooltipText = definition.tooltipText,
+            fillColor = definition.fillColor,
+            lineColor = definition.lineColor,
+            textColor = definition.textColor,
+        }
+    end
+
+    return badges
+end
+
 getMapControlTypes = function(descriptor)
     local controls = {}
     local seen = {}
@@ -1650,7 +1765,6 @@ local function drawMapPreview(descriptor, rect)
 end
 
 local function buildCardBadges(game, descriptor, maxWidth)
-    local controls = getMapControlTypes(descriptor)
     local font = game.fonts.small
     local badges = {}
     local totalWidth = 0
@@ -1680,12 +1794,18 @@ local function buildCardBadges(game, descriptor, maxWidth)
         })
     end
 
-    for _, controlType in ipairs(controls) do
-        local label = CONTROL_SHORT_LABELS[controlType] or controlType
+    for _, badgeDefinition in ipairs(buildLevelSelectBadges(descriptor)) do
+        local label = badgeDefinition.label
         local appended = appendBadge({
-            controlType = controlType,
+            key = badgeDefinition.key,
+            controlType = badgeDefinition.controlType,
             label = label,
             width = font:getWidth(label) + 22,
+            tooltipTitle = badgeDefinition.tooltipTitle,
+            tooltipText = badgeDefinition.tooltipText,
+            fillColor = badgeDefinition.fillColor,
+            lineColor = badgeDefinition.lineColor,
+            textColor = badgeDefinition.textColor,
         })
         if not appended then
             break
@@ -2106,9 +2226,22 @@ local function buildLevelSelectCardRects(game)
             rects[#rects].badgeRow = {
                 x = x + math.floor((width - badgeTotalWidth) * 0.5 + 0.5),
                 y = badgeY,
-                widths = badgeWidths,
+                badges = badgeWidths,
                 totalWidth = badgeTotalWidth,
             }
+            local badgeRects = {}
+            local badgeX = rects[#rects].badgeRow.x
+            for _, badge in ipairs(badgeWidths) do
+                badgeRects[#badgeRects + 1] = {
+                    badge = badge,
+                    x = badgeX,
+                    y = badgeY,
+                    w = badge.width,
+                    h = badgeH,
+                }
+                badgeX = badgeX + badge.width + 6
+            end
+            rects[#rects].badgeRow.badgeRects = badgeRects
         end
     end
 
@@ -2131,8 +2264,8 @@ local function drawControlBadges(game, descriptor, x, y, maxWidth, badgeRow)
     local widths = {}
     local totalWidth = 0
 
-    if badgeRow and badgeRow.widths then
-        widths = badgeRow.widths
+    if badgeRow and badgeRow.badges then
+        widths = badgeRow.badges
         totalWidth = badgeRow.totalWidth or 0
     else
         widths, totalWidth = buildCardBadges(game, descriptor, maxWidth)
@@ -2151,6 +2284,24 @@ local function drawControlBadges(game, descriptor, x, y, maxWidth, badgeRow)
         graphics.printf(badge.label, badgeX, y + 3, badge.width, "center")
         badgeX = badgeX + badge.width + 6
     end
+end
+
+local function getLevelSelectBadgeHoverInfo(game, x, y)
+    for _, rect in ipairs(buildLevelSelectCardRects(game)) do
+        local badgeRow = rect.badgeRow
+        for _, badgeRect in ipairs(badgeRow and badgeRow.badgeRects or {}) do
+            if pointInRect(x, y, badgeRect) then
+                return {
+                    x = badgeRect.x + badgeRect.w * 0.5,
+                    y = badgeRect.y,
+                    title = badgeRect.badge.tooltipTitle or badgeRect.badge.label,
+                    text = badgeRect.badge.tooltipText or badgeRect.badge.label,
+                }
+            end
+        end
+    end
+
+    return nil
 end
 
 local function drawLevelSelectChrome(game)
@@ -2911,6 +3062,14 @@ function ui.getLevelSelectHoverId(game, x, y)
     end
 
     return nil
+end
+
+function ui.getLevelSelectHoverInfoAt(game, x, y)
+    if game.levelSelectIssue then
+        return nil
+    end
+
+    return getLevelSelectBadgeHoverInfo(game, x, y)
 end
 
 local function getPlayBackRect(game)
@@ -4017,6 +4176,10 @@ function ui.drawLevelSelect(game)
         drawButton(overlay.edit, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
         drawButton(overlay.cancel, "Cancel", { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
     end
+
+    if game.levelSelectHoverInfo and not game.levelSelectIssue then
+        drawPlayTooltip(game, game.levelSelectHoverInfo)
+    end
 end
 
 function ui.drawPlay(game)
@@ -4212,5 +4375,6 @@ ui.formatLevelSelectLeaderboardRefreshLabel = formatLevelSelectLeaderboardRefres
 ui.getLevelSelectLeaderboardVisibleEntries = getLevelSelectLeaderboardVisibleEntries
 ui.getLevelSelectLeaderboardPinnedRowY = getLevelSelectLeaderboardPinnedRowY
 ui.formatMarketplaceFavoriteLabel = formatMarketplaceFavoriteLabel
+ui.getLevelSelectBadges = buildLevelSelectBadges
 
 return ui

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -139,6 +139,8 @@ assertEqual(
 )
 
 assert(type(ui.getPlayHoverInfoAt) == "function", "ui.getPlayHoverInfoAt should exist")
+assert(type(ui.getLevelSelectBadges) == "function", "ui.getLevelSelectBadges should exist")
+assert(type(ui.getLevelSelectHoverInfoAt) == "function", "ui.getLevelSelectHoverInfoAt should exist")
 
 love.graphics = love.graphics or {}
 love.graphics.setFont = function()
@@ -317,5 +319,92 @@ assertEqual(speedHover.title, "Fast Section", "play hover identifies speed-modif
 
 hoverGame.playPhase = "play"
 assertEqual(ui.getPlayHoverInfoAt(hoverGame, 600, 300), nil, "play hover disables itself outside preparation")
+
+local levelSelectDescriptor = {
+    previewLevel = {
+        timeLimit = 45,
+        junctions = {
+            { control = { type = "direct" } },
+            { control = { type = "delayed" } },
+            { control = { type = "trip" } },
+        },
+        trains = {
+            { deadline = nil },
+            { deadline = 18 },
+        },
+    },
+}
+
+local levelSelectBadges = ui.getLevelSelectBadges(levelSelectDescriptor)
+local badgeLabels = {}
+local badgeByLabel = {}
+for _, badge in ipairs(levelSelectBadges) do
+    badgeLabels[#badgeLabels + 1] = badge.label
+    badgeByLabel[badge.label] = badge
+end
+
+assertEqual(
+    table.concat(badgeLabels, ","),
+    "Direct,Delay,Trip,Deadline,Express",
+    "level select badges include renamed delay plus deadline and express"
+)
+assertEqual(
+    badgeByLabel.Direct.tooltipText,
+    "This map contains a direct junction.",
+    "direct badge tooltip explains the direct junction"
+)
+assertEqual(
+    badgeByLabel.Delay.tooltipText,
+    "This map contains a delay junction.",
+    "delay badge tooltip explains the delay junction"
+)
+
+local levelSelectGame = {
+    viewport = { w = 1280, h = 720 },
+    fonts = {
+        title = makeFont(12, 24),
+        body = makeFont(9, 18),
+        small = makeFont(7, 14),
+    },
+    levelSelectMode = "library",
+    levelSelectFilter = "all",
+    levelSelectSelectedId = "builtin:badge_test.lua",
+    levelSelectSelectedMapUuid = "badge-test",
+    levelSelectVisualIndex = 1,
+    levelSelectTargetVisualIndex = 1,
+    levelSelectIssue = nil,
+    availableMaps = {
+        {
+            id = "builtin:badge_test.lua",
+            mapUuid = "badge-test",
+            source = "builtin",
+            mapKind = "tutorial",
+            name = "Badge Test",
+            displayName = "Badge Test",
+            previewLevel = levelSelectDescriptor.previewLevel,
+        },
+    },
+}
+
+local delayBadgeHover = nil
+for y = 360, 390 do
+    for x = 500, 780 do
+        local hoverInfo = ui.getLevelSelectHoverInfoAt(levelSelectGame, x, y)
+        if hoverInfo and hoverInfo.title == "Delay Junction" then
+            delayBadgeHover = hoverInfo
+            break
+        end
+    end
+    if delayBadgeHover then
+        break
+    end
+end
+
+assert(delayBadgeHover ~= nil, "level select hover should detect delay badge tooltips")
+assertEqual(
+    delayBadgeHover.text,
+    "This map contains a delay junction.",
+    "level select hover uses the badge tooltip copy"
+)
 
 print("ui formatting tests passed")


### PR DESCRIPTION
## Requested Behavior
- Add hover tooltips to the level select badges using the existing tooltip component.
- Rename the `timer` badge to `delay`.
- Add missing `deadline` and `express` badges.
- Keep the level select easier to read and understand for players.
- Use consistent `junction` terminology in the badge tooltips.

## Summary
- Added badge metadata and hover hit detection for level select cards.
- Reused the existing tooltip renderer for badge hover text.
- Renamed the timer badge label to `Delay` and standardized tooltip wording to `... Junction`.
- Added computed `Deadline` and `Express` badges from map data.
- Expanded UI coverage for badge labels and hover behavior.

## Testing
- Not run (not requested)