### PR TITLE
Fix wagon hitboxes to match the full wagon body

### DIFF
--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -838,7 +838,7 @@ function renderer.drawTrain(scene, train)
     local graphics = love.graphics
     local carriages = scene:getTrainCarriagePositions(train)
     local width = scene.carriageLength
-    local height = 18
+    local height = scene.carriageHeight or 18
     local outlineWidth = 2
 
     for carriageIndex = #carriages, 1, -1 do

--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -840,18 +840,10 @@ function renderer.drawTrain(scene, train)
     local width = scene.carriageLength
     local height = 18
     local outlineWidth = 2
-    local alpha = 1
-
-    if train.exiting and scene.exitFadeDuration > 0 then
-        alpha = clamp((train.exitFadeRemaining or 0) / scene.exitFadeDuration, 0, 1)
-    end
-
-    if alpha <= 0 then
-        return
-    end
 
     for carriageIndex = #carriages, 1, -1 do
         local carriage = carriages[carriageIndex]
+        local alpha = carriage.alpha or 1
 
         graphics.push()
         graphics.translate(carriage.x, carriage.y)

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1112,27 +1112,20 @@ function world:spawnTrain(train)
 end
 
 function world:isTrainCleared(train)
-    return train.completed or train.exiting
+    return train.completed
 end
 
 function world:beginTrainExit(train)
-    if not train or train.completed or train.exiting then
+    if not train or train.completed then
         return
     end
 
     local occupiedEdges = self:getOccupiedEdges(train)
     local currentEdge = occupiedEdges[#occupiedEdges]
-    if currentEdge then
-        local edgePrefix = self:getDistanceOnOccupiedEdges(occupiedEdges) - currentEdge.path.length
-        train.headDistance = edgePrefix + currentEdge.path.length
-        self:trimTrainOccupiedEdges(train, occupiedEdges)
+    if currentEdge and currentEdge.targetType == "exit" then
+        train.exiting = true
+        train.clearingExitEdgeId = train.clearingExitEdgeId or currentEdge.id
     end
-
-    train.currentSpeed = 0
-    train.exiting = true
-    train.exitFadeRemaining = self.exitFadeDuration
-    train.clearedAt = self.elapsedTime
-    train.clearingExitEdgeId = train.clearingExitEdgeId or (currentEdge and currentEdge.id or nil)
 end
 
 function world:completeTrain(train)
@@ -1150,14 +1143,7 @@ function world:completeTrain(train)
 end
 
 function world:updateTrainExit(train, dt)
-    if not train.exiting or train.completed then
-        return
-    end
-
-    train.exitFadeRemaining = math.max(0, (train.exitFadeRemaining or 0) - dt)
-    if train.exitFadeRemaining <= 0 then
-        self:completeTrain(train)
-    end
+    return
 end
 
 function world:doesOutputAcceptTrain(train, junction, outputEdge)
@@ -1241,6 +1227,30 @@ function world:pointOnOccupiedEdges(occupiedEdges, distance)
 
     local lastEdge = occupiedEdges[#occupiedEdges]
     return pointOnPath(lastEdge.path, lastEdge.path.length + offset)
+end
+
+function world:getTrainExitState(train, occupiedEdges)
+    local edges = occupiedEdges or self:getOccupiedEdges(train)
+    local exitEdge = edges[#edges]
+    if not exitEdge or exitEdge.targetType ~= "exit" then
+        return nil, nil, nil
+    end
+
+    local occupiedLength = self:getDistanceOnOccupiedEdges(edges)
+    local fadeDistance = math.max(self.carriageLength, (train.speed or self.trainSpeed) * self.exitFadeDuration)
+    return exitEdge, occupiedLength, fadeDistance
+end
+
+function world:hasTrainFullyClearedExit(train, occupiedEdges)
+    local _, occupiedLength = self:getTrainExitState(train, occupiedEdges)
+    if not occupiedLength then
+        return false
+    end
+
+    local carriageSpacing = self.carriageLength + self.carriageGap
+    local tailOffset = ((train.wagonCount or self.carriageCount) - 1) * carriageSpacing
+    local tailRearDistance = (train.headDistance or 0) - tailOffset - self.carriageLength * 0.5
+    return tailRearDistance >= occupiedLength
 end
 
 function world:resize(viewportW, viewportH)
@@ -1615,9 +1625,9 @@ function world:updateTrain(train, dt)
         return
     end
 
+    local localProgress = self:getHeadLocalProgress(train)
     local desiredStopDistance = self:getDesiredLeadDistance(train)
     local targetSpeed = train.speed * self:getEdgeSpeedScaleAtDistance(currentEdge, localProgress)
-    local localProgress = self:getHeadLocalProgress(train)
 
     if desiredStopDistance then
         local brakingWindow = 110
@@ -1644,7 +1654,13 @@ function world:updateTrain(train, dt)
         nextProgress = desiredStopDistance
         train.currentSpeed = 0
     end
-    local movedDistance = math.max(0, nextProgress - localProgress)
+    local countedCurrentProgress = localProgress
+    local countedNextProgress = nextProgress
+    if currentEdge.targetType == "exit" then
+        countedCurrentProgress = math.min(localProgress, currentEdge.path.length)
+        countedNextProgress = math.min(nextProgress, currentEdge.path.length)
+    end
+    local movedDistance = math.max(0, countedNextProgress - countedCurrentProgress)
     train.actualDistance = (train.actualDistance or 0) + movedDistance
 
     local previousLength = self:getDistanceOnOccupiedEdges(self:getOccupiedEdges(train)) - currentEdge.path.length
@@ -1680,10 +1696,11 @@ function world:updateTrain(train, dt)
                 break
             end
         elseif currentEdge.targetType == "exit" then
-            if overflow > 0 then
-                train.actualDistance = math.max(0, (train.actualDistance or 0) - overflow)
-            end
             self:beginTrainExit(train)
+            if self:hasTrainFullyClearedExit(train, self:getOccupiedEdges(train)) then
+                train.clearedAt = self.elapsedTime
+                self:completeTrain(train)
+            end
             break
         else
             break
@@ -1695,6 +1712,7 @@ function world:getTrainCarriagePositions(train)
     local positions = {}
     local carriageSpacing = self.carriageLength + self.carriageGap
     local occupiedEdges = self:getOccupiedEdges(train)
+    local _, occupiedLength, fadeDistance = self:getTrainExitState(train, occupiedEdges)
 
     if (train.completed and not train.exiting) or not train.spawned or #occupiedEdges == 0 then
         return positions
@@ -1703,11 +1721,26 @@ function world:getTrainCarriagePositions(train)
     for carriageIndex = 1, (train.wagonCount or self.carriageCount) do
         local carriageDistance = (train.headDistance or 0) - (carriageIndex - 1) * carriageSpacing
         local x, y, angle = self:pointOnOccupiedEdges(occupiedEdges, carriageDistance)
-        positions[#positions + 1] = {
-            x = x,
-            y = y,
-            angle = angle,
-        }
+        local alpha = 1
+        local collidable = true
+
+        if occupiedLength then
+            local frontDistance = carriageDistance + self.carriageLength * 0.5
+            if frontDistance >= occupiedLength then
+                collidable = false
+                alpha = clamp(1 - ((frontDistance - occupiedLength) / math.max(fadeDistance or self.carriageLength, 0.0001)), 0, 1)
+            end
+        end
+
+        if alpha > 0 then
+            positions[#positions + 1] = {
+                x = x,
+                y = y,
+                angle = angle,
+                alpha = alpha,
+                collidable = collidable,
+            }
+        end
     end
 
     return positions
@@ -1731,7 +1764,8 @@ function world:updateCollisionState()
 
                     for _, firstCar in ipairs(firstCars) do
                         for _, secondCar in ipairs(secondCars) do
-                            if distanceSquared(firstCar.x, firstCar.y, secondCar.x, secondCar.y) <= collisionRadiusSquared then
+                            if firstCar.collidable and secondCar.collidable
+                                and distanceSquared(firstCar.x, firstCar.y, secondCar.x, secondCar.y) <= collisionRadiusSquared then
                                 self.failureReason = "collision"
                                 self.collisionPoint = {
                                     x = (firstCar.x + secondCar.x) * 0.5,

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -56,6 +56,45 @@ local function distanceSquared(ax, ay, bx, by)
     return dx * dx + dy * dy
 end
 
+local function dot(ax, ay, bx, by)
+    return ax * bx + ay * by
+end
+
+local function carriagesOverlap(firstCar, secondCar, carriageLength, carriageHeight)
+    local halfLength = (carriageLength or 0) * 0.5
+    local halfHeight = (carriageHeight or 0) * 0.5
+    local firstForwardX = math.cos(firstCar.angle or 0)
+    local firstForwardY = math.sin(firstCar.angle or 0)
+    local firstSideX = -firstForwardY
+    local firstSideY = firstForwardX
+    local secondForwardX = math.cos(secondCar.angle or 0)
+    local secondForwardY = math.sin(secondCar.angle or 0)
+    local secondSideX = -secondForwardY
+    local secondSideY = secondForwardX
+    local offsetX = (secondCar.x or 0) - (firstCar.x or 0)
+    local offsetY = (secondCar.y or 0) - (firstCar.y or 0)
+    local axes = {
+        { x = firstForwardX, y = firstForwardY },
+        { x = firstSideX, y = firstSideY },
+        { x = secondForwardX, y = secondForwardY },
+        { x = secondSideX, y = secondSideY },
+    }
+
+    for _, axis in ipairs(axes) do
+        local centerDistance = math.abs(dot(offsetX, offsetY, axis.x, axis.y))
+        local firstExtent = halfLength * math.abs(dot(firstForwardX, firstForwardY, axis.x, axis.y))
+            + halfHeight * math.abs(dot(firstSideX, firstSideY, axis.x, axis.y))
+        local secondExtent = halfLength * math.abs(dot(secondForwardX, secondForwardY, axis.x, axis.y))
+            + halfHeight * math.abs(dot(secondSideX, secondSideY, axis.x, axis.y))
+
+        if centerDistance > firstExtent + secondExtent then
+            return false
+        end
+    end
+
+    return true
+end
+
 local function copyPoint(point)
     return { x = point.x, y = point.y }
 end
@@ -430,6 +469,7 @@ function world.new(viewportW, viewportH, levelSource)
     self.trainSpeed = 168
     self.trainAcceleration = 260
     self.carriageLength = 34
+    self.carriageHeight = 18
     self.carriageGap = 12
     self.carriageCount = 4
     self.exitFadeDuration = 0.25
@@ -1747,9 +1787,6 @@ function world:getTrainCarriagePositions(train)
 end
 
 function world:updateCollisionState()
-    local collisionRadius = math.min(self.carriageLength, 24)
-    local collisionRadiusSquared = collisionRadius * collisionRadius
-
     self.collisionPoint = nil
 
     for firstIndex = 1, #self.trains - 1 do
@@ -1765,7 +1802,7 @@ function world:updateCollisionState()
                     for _, firstCar in ipairs(firstCars) do
                         for _, secondCar in ipairs(secondCars) do
                             if firstCar.collidable and secondCar.collidable
-                                and distanceSquared(firstCar.x, firstCar.y, secondCar.x, secondCar.y) <= collisionRadiusSquared then
+                                and carriagesOverlap(firstCar, secondCar, self.carriageLength, self.carriageHeight) then
                                 self.failureReason = "collision"
                                 self.collisionPoint = {
                                     x = (firstCar.x + secondCar.x) * 0.5,

--- a/tests/world_exit_phase_test.lua
+++ b/tests/world_exit_phase_test.lua
@@ -1,0 +1,101 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.graphics = love.graphics or {}
+love.filesystem = love.filesystem or {}
+
+love.filesystem.getInfo = function()
+    return false
+end
+
+local world = require("src.game.world")
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function buildSimulation()
+    return world.new(100, 100, {
+        junctions = {
+            {
+                id = "main",
+                label = "Main",
+                control = { type = "direct" },
+                activeInputIndex = 1,
+                inputs = {
+                    {
+                        id = "blue_in",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        inputPoints = {
+                            { x = 0.10, y = 0.50 },
+                            { x = 0.50, y = 0.50 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = "blue_out",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        outputPoints = {
+                            { x = 0.50, y = 0.50 },
+                            { x = 0.90, y = 0.50 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {
+            {
+                id = "blue_train",
+                junctionId = "main",
+                inputIndex = 1,
+                goalColor = "blue",
+                wagonCount = 2,
+            },
+        },
+    })
+end
+
+local fadeSimulation = buildSimulation()
+local fadeTrain = fadeSimulation.trains[1]
+local fadeInput = fadeSimulation.junctions.main.inputs[1]
+local fadeExit = fadeSimulation.junctions.main.outputs[1]
+local occupiedLength = fadeInput.path.length + fadeExit.path.length
+
+fadeTrain.spawned = true
+fadeTrain.edgeId = fadeExit.id
+fadeTrain.occupiedEdgeIds = { fadeInput.id, fadeExit.id }
+fadeTrain.headDistance = occupiedLength - fadeSimulation.carriageLength * 0.5 + 4
+
+local carriages = fadeSimulation:getTrainCarriagePositions(fadeTrain)
+assertTrue(#carriages == 2, "train should still render both wagons while only the lead wagon is phasing out")
+assertTrue(carriages[1].collidable == false, "lead wagon should lose collision as soon as it reaches the exit")
+assertTrue(carriages[1].alpha > 0 and carriages[1].alpha < 1, "lead wagon should start fading immediately after touching the exit")
+assertTrue(carriages[2].collidable == true, "following wagon should remain collidable until it reaches the exit")
+assertTrue(carriages[2].alpha == 1, "following wagon should stay fully opaque before it reaches the exit")
+
+local completionSimulation = buildSimulation()
+local completionTrain = completionSimulation.trains[1]
+local completionExit = completionSimulation.junctions.main.outputs[1]
+local clearanceDistance = ((completionTrain.wagonCount or completionSimulation.carriageCount) - 1)
+    * (completionSimulation.carriageLength + completionSimulation.carriageGap)
+    + completionSimulation.carriageLength * 0.5
+
+completionTrain.spawned = true
+completionTrain.edgeId = completionExit.id
+completionTrain.occupiedEdgeIds = { completionExit.id }
+completionTrain.currentSpeed = 0
+
+completionTrain.headDistance = completionExit.path.length + clearanceDistance - 0.5
+completionSimulation:updateTrain(completionTrain, 0)
+assertTrue(completionTrain.completed == false, "train should not complete until the rear of the last wagon clears the exit")
+
+completionTrain.headDistance = completionExit.path.length + clearanceDistance + 0.5
+completionSimulation:updateTrain(completionTrain, 0)
+assertTrue(completionTrain.completed == true, "train should complete once the rear of the last wagon clears the exit")
+
+print("world exit phase tests passed")

--- a/tests/world_wagon_collision_hitbox_test.lua
+++ b/tests/world_wagon_collision_hitbox_test.lua
@@ -1,0 +1,65 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.graphics = love.graphics or {}
+love.filesystem = love.filesystem or {}
+
+love.filesystem.getInfo = function()
+    return false
+end
+
+local world = require("src.game.world")
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local simulation = world.new(100, 100, {
+    edges = {},
+    junctions = {},
+    trains = {},
+})
+
+simulation.trains = {
+    {
+        id = "first",
+        spawned = true,
+        completed = false,
+    },
+    {
+        id = "second",
+        spawned = true,
+        completed = false,
+    },
+}
+
+simulation.getTrainCarriagePositions = function(_, train)
+    if train.id == "first" then
+        return {
+            {
+                x = 10,
+                y = 10,
+                angle = 0,
+                collidable = true,
+            },
+        }
+    end
+
+    return {
+        {
+            x = 40,
+            y = 10,
+            angle = 0,
+            collidable = true,
+        },
+    }
+end
+
+simulation:updateCollisionState()
+
+assertTrue(simulation.failureReason == "collision", "wagon collisions should use the full wagon body, not just the inner window area")
+assertTrue(simulation.collisionPoint ~= nil, "wagon body collisions should record a collision point")
+
+print("world wagon collision hitbox tests passed")


### PR DESCRIPTION
## Requested Behavior
- Keep trains phasing out per wagon when exiting.
- Ensure each wagon loses collision as soon as it starts fading.
- Make wagon collision use the full outer wagon body, not just the inner visual core.

## Summary
- Replaced the old center-radius train collision check with an oriented wagon-rectangle overlap test.
- Shared wagon dimensions between simulation and rendering so the hitbox matches the drawn body.
- Kept the exit phasing behavior intact while preserving per-wagon collision drop-off.

## Testing
- Passed `world_wagon_collision_hitbox_test.lua`
- Passed `world_exit_phase_test.lua`
- Passed `world_minimum_distance_crossbar_test.lua`