### PR TITLE
Fix sequencer panel click handling

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -5022,15 +5022,15 @@ function mapEditor:mousepressed(screenX, screenY, button)
     end
 
     if pointInRect(screenX, screenY, self.sidePanel) then
+        if self.sidePanelMode == "sequencer" then
+            return self:handleSequencerClick(screenX, screenY, button)
+        end
+
         if self:handleEditorDrawerClick(screenX, screenY) then
             return true
         end
 
-        if self.sidePanelMode == "sequencer" and self:handleSequencerClick(screenX, screenY, button) then
-            return true
-        end
-
-        if self.sidePanelMode == "default" and self:handleValidationListClick(screenX, screenY) then
+        if self:handleValidationListClick(screenX, screenY) then
             return true
         end
 

--- a/tests/map_editor_sequencer_click_consumption_test.lua
+++ b/tests/map_editor_sequencer_click_consumption_test.lua
@@ -1,0 +1,47 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editor = mapEditor.new(1280, 720, nil)
+editor.sidePanelMode = "sequencer"
+
+local addRect = editor:getSequencerAddButtonRect()
+local overlappingClickX = addRect.x + math.floor(addRect.w * 0.5)
+local overlappingClickY = addRect.y + addRect.h - 2
+
+local wasConsumed = editor:mousepressed(overlappingClickX, overlappingClickY, 1)
+
+assertTrue(wasConsumed, "sequencer panel clicks should be consumed")
+assertEqual(#editor.trains, 1, "clicking the overlapping add button area should add a train")
+assertEqual(editor.gridVisible, true, "sequencer clicks must not toggle the underlying grid button")
+
+local inertPanelClickX = editor.sidePanel.x + 24
+local inertPanelClickY = editor.sidePanel.y + editor.sidePanel.h - 120
+
+wasConsumed = editor:mousepressed(inertPanelClickX, inertPanelClickY, 1)
+
+assertTrue(wasConsumed, "clicking unused sequencer panel space should still be consumed")
+assertEqual(#editor.trains, 1, "clicking unused sequencer panel space should not trigger drawer actions")
+assertEqual(editor.gridVisible, true, "clicking unused sequencer panel space should leave the grid toggle alone")
+
+print("map editor sequencer click consumption tests passed")


### PR DESCRIPTION
## Requested Behavior
- Our trend sequencer panel should fully consume clicks inside the panel so underlying controls like hiding the grid do not react through it.
- Clicking anywhere in the sequencer panel should not leak through to other side panel actions.
- The Add Train button should remain reliably clickable.

## Summary
- Routed sequencer-mode side panel clicks directly to the sequencer handler.
- Prevented the default editor drawer from processing clicks while the sequencer is open.
- Added a regression test covering click consumption and the overlapping Add Train area.

## Testing
- `tests/map_editor_sequencer_click_consumption_test.lua`
- `tests/map_editor_validation_scroll_test.lua`
- `tests/map_editor_junction_state_test.lua`