### PR TITLE
Fix junction rendering for repeated route crossings

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -13,7 +13,9 @@ local DEFAULT_CONTROL = "direct"
 local MAX_TRIP_PASS_COUNT = 5
 local MERGE_SNAP_RADIUS = 40
 local INTERSECTION_GROUP_BUCKET = 20
-local STRICT_INTERSECTION_CLUSTER_RADIUS = 6
+-- Keep this tight so nearby steep crossings do not collapse into one junction.
+-- True multi-route junction hits still land within the point match tolerance.
+local STRICT_INTERSECTION_CLUSTER_RADIUS = 3
 local SHARED_LANE_STRIPE_LENGTH = 14
 local CONTROL_ORDER = { "direct", "delayed", "pump", "spring", "relay", "trip", "crossbar" }
 local DEFAULT_TRAIN_WAGONS = 4
@@ -563,6 +565,12 @@ local function buildSegmentGroupKey(a, b)
         return firstKey .. "|" .. secondKey
     end
     return secondKey .. "|" .. firstKey
+end
+
+local function buildIntersectionId(routeKey, point)
+    local safeRouteKey = tostring(routeKey or "junction"):gsub("[^%w]+", "_")
+    local pointKey = roundPointKey(point or { x = 0, y = 0 }):gsub("[^%w]+", "_")
+    return string.format("junction_%s_%s", safeRouteKey, pointKey)
 end
 
 local function getWrappedLineCount(font, text, width)
@@ -2758,7 +2766,9 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
         end
         table.sort(sortedRouteIds)
         self:restoreSharedPointsForRoutes(sortedRouteIds)
-        self.importedJunctionState[table.concat(sortedRouteIds, "|")] = {
+        local routeKey = table.concat(sortedRouteIds, "|")
+        self.importedJunctionState[routeKey] = self.importedJunctionState[routeKey] or {}
+        self.importedJunctionState[routeKey][#self.importedJunctionState[routeKey] + 1] = {
             id = junctionData.id,
             x = junctionData.x * self.mapSize.w,
             y = junctionData.y * self.mapSize.h,
@@ -3090,7 +3100,8 @@ function mapEditor:resetFromLevel(level)
 
         if #branchRoutes == 2 then
             local key = routePairKey(branchRoutes[1].id, branchRoutes[2].id)
-            self.importedJunctionState[key] = {
+            self.importedJunctionState[key] = self.importedJunctionState[key] or {}
+            self.importedJunctionState[key][#self.importedJunctionState[key] + 1] = {
                 x = mergeX,
                 y = mergeY,
                 controlType = ((junctionDefinition.control or {}).type) or DEFAULT_CONTROL,
@@ -3506,32 +3517,62 @@ function mapEditor:deleteSelection()
 end
 
 function mapEditor:getIntersectionControlType(intersection, previousMatches)
-    local imported = self.importedJunctionState[intersection.routeKey]
-    if imported and distanceSquared(imported.x, imported.y, intersection.x, intersection.y) <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED then
-        return imported.controlType
+    local bestDistanceSquared = nil
+    local bestControlType = nil
+
+    for _, imported in ipairs(self.importedJunctionState[intersection.routeKey] or {}) do
+        local candidateDistanceSquared = distanceSquared(imported.x, imported.y, intersection.x, intersection.y)
+        if candidateDistanceSquared <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED
+            and (not bestDistanceSquared or candidateDistanceSquared < bestDistanceSquared) then
+            bestDistanceSquared = candidateDistanceSquared
+            bestControlType = imported.controlType
+        end
     end
 
     for _, previous in ipairs(previousMatches) do
-        if previous.routeKey == intersection.routeKey
-            and distanceSquared(previous.x, previous.y, intersection.x, intersection.y) <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED then
-            return previous.controlType
+        if previous.routeKey == intersection.routeKey then
+            local candidateDistanceSquared = distanceSquared(previous.x, previous.y, intersection.x, intersection.y)
+            if candidateDistanceSquared <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED
+                and (not bestDistanceSquared or candidateDistanceSquared < bestDistanceSquared) then
+                bestDistanceSquared = candidateDistanceSquared
+                bestControlType = previous.controlType
+            end
         end
+    end
+
+    if bestControlType then
+        return bestControlType
     end
 
     return DEFAULT_CONTROL
 end
 
 function mapEditor:getJunctionState(intersection, previousMatches)
-    local imported = self.importedJunctionState[intersection.routeKey]
-    if imported and distanceSquared(imported.x, imported.y, intersection.x, intersection.y) <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED then
-        return imported
+    local bestDistanceSquared = nil
+    local bestMatch = nil
+
+    for _, imported in ipairs(self.importedJunctionState[intersection.routeKey] or {}) do
+        local candidateDistanceSquared = distanceSquared(imported.x, imported.y, intersection.x, intersection.y)
+        if candidateDistanceSquared <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED
+            and (not bestDistanceSquared or candidateDistanceSquared < bestDistanceSquared) then
+            bestDistanceSquared = candidateDistanceSquared
+            bestMatch = imported
+        end
     end
 
     for _, previous in ipairs(previousMatches) do
-        if previous.routeKey == intersection.routeKey
-            and distanceSquared(previous.x, previous.y, intersection.x, intersection.y) <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED then
-            return previous
+        if previous.routeKey == intersection.routeKey then
+            local candidateDistanceSquared = distanceSquared(previous.x, previous.y, intersection.x, intersection.y)
+            if candidateDistanceSquared <= INTERSECTION_STATE_MATCH_DISTANCE_SQUARED
+                and (not bestDistanceSquared or candidateDistanceSquared < bestDistanceSquared) then
+                bestDistanceSquared = candidateDistanceSquared
+                bestMatch = previous
+            end
         end
+    end
+
+    if bestMatch then
+        return bestMatch
     end
 
     return nil
@@ -3608,15 +3649,11 @@ function mapEditor:resolveGroupedIntersections(groupedIntersection)
     end
 
     for routeKey, clusters in pairs(candidatesByRouteKey) do
-        for clusterIndex, cluster in ipairs(clusters) do
+        for _, cluster in ipairs(clusters) do
             local bestCandidate = chooseBestCandidatePoint(cluster.candidates)
             if bestCandidate then
                 resolved[#resolved + 1] = {
-                    id = string.format(
-                        "junction_%s_%d",
-                        routeKey:gsub("[^%w]+", "_"),
-                        clusterIndex
-                    ),
+                    id = buildIntersectionId(routeKey, bestCandidate),
                     x = bestCandidate.x,
                     y = bestCandidate.y,
                     routeIds = cluster.routeIds,

--- a/tests/map_editor_close_junction_regression_test.lua
+++ b/tests/map_editor_close_junction_regression_test.lua
@@ -1,0 +1,87 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_a", kind = "input", x = 636 / 1280, y = 400 / 720, colors = { "blue" } },
+        { id = "output_a", kind = "output", x = 644 / 1280, y = 400 / 720, colors = { "blue" } },
+        { id = "input_b", kind = "input", x = 636 / 1280, y = 360 / 720, colors = { "orange" } },
+        { id = "output_b", kind = "output", x = 644 / 1280, y = 360 / 720, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_a",
+            label = "route_a",
+            color = "blue",
+            startEndpointId = "input_a",
+            endEndpointId = "output_a",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 636 / 1280, y = 400 / 720 },
+                { x = 640 / 1280, y = 360 / 720 },
+                { x = 644 / 1280, y = 400 / 720 },
+            },
+        },
+        {
+            id = "route_b",
+            label = "route_b",
+            color = "orange",
+            startEndpointId = "input_b",
+            endEndpointId = "output_b",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 636 / 1280, y = 360 / 720 },
+                { x = 640 / 1280, y = 400 / 720 },
+                { x = 644 / 1280, y = 360 / 720 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Close Junction Regression", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 2, "close double-crossing routes should produce two separate junctions")
+assertTrue(
+    editor.previewWorld and editor.previewWorld.junctionOrder and #(editor.previewWorld.junctionOrder or {}) == 2,
+    "preview world should keep both close junctions renderable"
+)
+
+local first = editor.intersections[1]
+local second = editor.intersections[2]
+assertTrue(first and second and math.abs(first.x - second.x) >= 4, "junctions should remain visually distinct after rebuild")
+
+print("map editor close junction regression tests passed")

--- a/tests/map_editor_repeated_route_pair_junction_test.lua
+++ b/tests/map_editor_repeated_route_pair_junction_test.lua
@@ -1,0 +1,96 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_blue", kind = "input", x = 0.10, y = 0.20, colors = { "blue" } },
+        { id = "output_blue", kind = "output", x = 0.90, y = 0.20, colors = { "blue" } },
+        { id = "input_orange", kind = "input", x = 0.10, y = 0.60, colors = { "orange" } },
+        { id = "output_orange", kind = "output", x = 0.90, y = 0.60, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_blue",
+            endEndpointId = "output_blue",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.10, y = 0.20 },
+                { x = 0.50, y = 0.80 },
+                { x = 0.90, y = 0.20 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_orange",
+            endEndpointId = "output_orange",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.10, y = 0.60 },
+                { x = 0.50, y = 0.00 },
+                { x = 0.90, y = 0.60 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Repeated Route Pair Junctions", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 2, "two crossings on the same route pair should produce two editor junctions")
+assertTrue(editor.intersections[1].id ~= editor.intersections[2].id, "repeated crossings should keep distinct junction ids")
+assertTrue(
+    editor.previewWorld and editor.previewWorld.junctionOrder and #(editor.previewWorld.junctionOrder or {}) == 2,
+    "preview world should render both repeated-route junctions"
+)
+
+local exported = editor:getExportData()
+assertEqual(#(exported.junctions or {}), 2, "export should keep both repeated-route junctions")
+assertTrue(exported.junctions[1].id ~= exported.junctions[2].id, "exported repeated-route junction ids should stay unique")
+
+local reloadedEditor = mapEditor.new(1280, 720, nil)
+reloadedEditor:loadEditorData(exported, "Repeated Route Pair Reloaded", nil, nil)
+assertEqual(#(reloadedEditor.intersections or {}), 2, "reloaded editor should keep both repeated-route junctions")
+assertTrue(
+    reloadedEditor.previewWorld and reloadedEditor.previewWorld.junctionOrder and #(reloadedEditor.previewWorld.junctionOrder or {}) == 2,
+    "reloaded preview should keep both repeated-route junctions"
+)
+
+print("map editor repeated route pair junction tests passed")


### PR DESCRIPTION
## Requested Behavior
- Fix an issue where junctions stop rendering or become non-clickable when more than one junction exists on the same lane/line, especially when the same red/blue route pair crosses more than once.
- Ensure close or repeated crossings remain distinct and interactable in the map editor and preview world.

## Summary
- Tightened close-intersection clustering so steep crossings are not merged into one junction.
- Changed junction identity and saved-state matching so repeated crossings on the same route pair stay unique instead of overwriting each other.
- Added regressions for close crossings and repeated same-route-pair crossings.

## Testing
- `map editor close junction regression tests passed`
- `map editor repeated route pair junction tests passed`
- `map editor strict intersection tests passed`
- `map editor junction state tests passed`