### PR TITLE
Update results tooltip to show on-time points and loss breakdown

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -474,6 +474,7 @@ function Game.new()
     drainChannel(self.leaderboardResponseChannel)
     self.playPhase = nil
     self.playHoverInfo = nil
+    self.resultsHoverInfo = nil
 
     self:updateRenderTransform()
     self:refreshMaps()
@@ -3187,6 +3188,7 @@ function Game:openResults()
     end
 
     self.resultsSummary = self.world:getRunSummary()
+    self.resultsHoverInfo = nil
     self.failureReason = self.resultsSummary.endReason == "level_clear" and nil or self.resultsSummary.endReason
     self.levelComplete = self.resultsSummary.endReason == "level_clear"
     self.screen = "results"
@@ -3700,6 +3702,7 @@ end
 
 function Game:mousemoved(x, y, dx, dy)
     self.playHoverInfo = nil
+    self.resultsHoverInfo = nil
     self.levelSelectHoverInfo = nil
     if self.screen == "leaderboard" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
@@ -3723,6 +3726,12 @@ function Game:mousemoved(x, y, dx, dy)
     if self.screen == "editor" then
         local viewportX, viewportY = self:toViewportPosition(x, y)
         self.editor:mousemoved(viewportX, viewportY, dx, dy)
+        return
+    end
+
+    if self.screen == "results" then
+        local viewportX, viewportY = self:toViewportPosition(x, y)
+        self.resultsHoverInfo = ui.getResultsHoverInfoAt(self, viewportX, viewportY)
         return
     end
 

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -4136,6 +4136,49 @@ local function getResultsButtonRects(game)
     }
 end
 
+local function getResultsPanelRect(game)
+    return {
+        x = game.viewport.w * 0.5 - 300,
+        y = 50,
+        w = 600,
+        h = 580,
+    }
+end
+
+local function getResultsBreakdownRowRects(game)
+    local panel = getResultsPanelRect(game)
+    local breakdownX = panel.x + 58
+    local valueX = panel.x + panel.w - 58
+    local rows = {}
+    local lineY = panel.y + 220
+
+    for index = 1, 5 do
+        rows[index] = {
+            label = {
+                x = breakdownX,
+                y = lineY,
+                w = math.max(0, valueX - breakdownX - 150),
+                h = 24,
+            },
+            value = {
+                x = valueX - 140,
+                y = lineY,
+                w = 140,
+                h = 24,
+            },
+            row = {
+                x = breakdownX,
+                y = lineY - 2,
+                w = valueX - breakdownX,
+                h = 26,
+            },
+        }
+        lineY = lineY + 28
+    end
+
+    return rows
+end
+
 function ui.getResultsHit(game, x, y)
     local buttons = getResultsButtonRects(game)
     if pointInRect(x, y, buttons.replay) then
@@ -4151,6 +4194,46 @@ function ui.getResultsHit(game, x, y)
         return "editor"
     end
     return nil
+end
+
+function ui.getResultsHoverInfoAt(game, x, y)
+    local summary = game.resultsSummary or {}
+    local rowRects = getResultsBreakdownRowRects(game)
+    local onTimeRow = rowRects[1]
+    if not onTimeRow or not pointInRect(x, y, onTimeRow.row) then
+        return nil
+    end
+
+    local lossBreakdown = summary.onTimePointLossBreakdown or {}
+    local lateLoss = lossBreakdown.lateClears or 0
+    local wrongDestinationLoss = lossBreakdown.wrongDestinations or 0
+    local unfinishedLoss = lossBreakdown.unfinished or 0
+    local lines = {
+        string.format(
+            "Correct routing: +%s",
+            formatScore((summary.scoreBreakdown and summary.scoreBreakdown.onTimeClears) or 0)
+        ),
+    }
+
+    if lateLoss > 0 then
+        lines[#lines + 1] = string.format("Late arrivals: -%s", formatScore(lateLoss))
+    end
+
+    if wrongDestinationLoss > 0 then
+        lines[#lines + 1] = string.format("Wrong destinations: -%s", formatScore(wrongDestinationLoss))
+    end
+
+    if unfinishedLoss > 0 then
+        lines[#lines + 1] = string.format("Unfinished trains: -%s", formatScore(unfinishedLoss))
+    end
+
+    return {
+        title = "On-Time Points",
+        text = table.concat(lines, "\n"),
+        x = onTimeRow.row.x + (onTimeRow.row.w * 0.5),
+        y = onTimeRow.row.y + onTimeRow.row.h,
+        preferBelow = true,
+    }
 end
 
 local function drawPlayGuideOverlay(game)
@@ -4818,13 +4901,12 @@ function ui.drawResults(game)
     local graphics = love.graphics
     local summary = game.resultsSummary or {}
     local level = game.world and game.world:getLevel() or {}
-    local panel = {
-        x = game.viewport.w * 0.5 - 300,
-        y = 50,
-        w = 600,
-        h = 580,
-    }
+    local finalScore = summary.finalScore or 0
+    local onTimePointCap = summary.onTimePointCap or 0
+    local panel = getResultsPanelRect(game)
     local buttons = getResultsButtonRects(game)
+    local rowRects = getResultsBreakdownRowRects(game)
+    local breakdownX = rowRects[1] and rowRects[1].label.x or (panel.x + 58)
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -4856,7 +4938,7 @@ function ui.drawResults(game)
 
     love.graphics.setFont(game.fonts.title)
     graphics.setColor(accent[1], accent[2], accent[3], 1)
-    graphics.printf(string.format("Score %s", formatScore(summary.finalScore or 0)), panel.x, panel.y + 108, panel.w, "center")
+    graphics.printf(string.format("Score %s", formatScore(finalScore)), panel.x, panel.y + 108, panel.w, "center")
 
     love.graphics.setFont(game.fonts.small)
     local onlineState = game.resultsOnlineState or {}
@@ -4875,21 +4957,20 @@ function ui.drawResults(game)
         "center"
     )
 
-    local breakdownX = panel.x + 58
-    local valueX = panel.x + panel.w - 58
-    local lineY = panel.y + 220
     local rows = {
-        { "On-time clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.onTimeClears) or 0)) },
+        { "On-time clears", string.format("%s / %s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.onTimeClears) or 0), formatScore(onTimePointCap)) },
         { "Late clears", string.format("+%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.lateClears) or 0)) },
         { "Time penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.timePenalty) or 0)) },
         { "Interaction penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.interactionPenalty) or 0)) },
         { "Distance penalty", string.format("-%s", formatScore((summary.scoreBreakdown and summary.scoreBreakdown.extraDistancePenalty) or 0)) },
     }
 
-    for _, row in ipairs(rows) do
+    local lineY = panel.y + 220
+    for index, row in ipairs(rows) do
+        local rowRect = rowRects[index]
         graphics.setColor(0.84, 0.88, 0.92, 1)
-        graphics.print(row[1], breakdownX, lineY)
-        graphics.printf(row[2], valueX - 140, lineY, 140, "right")
+        graphics.print(row[1], rowRect.label.x, lineY)
+        graphics.printf(row[2], rowRect.value.x, lineY, rowRect.value.w, "right")
         lineY = lineY + 28
     end
 
@@ -4919,6 +5000,10 @@ function ui.drawResults(game)
     )
     drawButton(buttons.editor, "Open In Editor", { 0.1, 0.14, 0.18, 0.98 }, { 0.99, 0.78, 0.32, 1 }, game.fonts.small)
     drawButton(buttons.menu, getRunBackLabel(game), { 0.1, 0.14, 0.18, 0.98 }, { 0.3, 0.36, 0.42, 1 }, game.fonts.small)
+
+    if game.resultsHoverInfo then
+        drawPlayTooltip(game, game.resultsHoverInfo)
+    end
 end
 
 ui.formatLeaderboardScore = formatLeaderboardScore

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -1905,10 +1905,12 @@ end
 
 function world:getRunSummary()
     local scoring = self:getScoringConstants()
+    local onTimePointCap = #self.trains * scoring.onTimeClear
     local summary = {
         endReason = self:getRunEndReason(),
         mapUuid = self.level and (self.level.mapUuid or self.level.id) or nil,
         mapTitle = self.level and self.level.title or nil,
+        totalTrainCount = #self.trains,
         correctOnTimeCount = 0,
         correctLateCount = 0,
         wrongDestinationCount = 0,
@@ -1925,6 +1927,13 @@ function world:getRunSummary()
             extraDistancePenalty = 0,
         },
         finalScore = 0,
+        maxPossibleScore = onTimePointCap,
+        onTimePointCap = onTimePointCap,
+        onTimePointLossBreakdown = {
+            lateClears = 0,
+            wrongDestinations = 0,
+            unfinished = 0,
+        },
     }
 
     for _, train in ipairs(self.trains) do
@@ -1947,6 +1956,16 @@ function world:getRunSummary()
             summary.wrongDestinationCount = summary.wrongDestinationCount + 1
         end
     end
+
+    summary.onTimePointLossBreakdown.lateClears = summary.correctLateCount * (scoring.onTimeClear - scoring.lateClear)
+    summary.onTimePointLossBreakdown.wrongDestinations = summary.wrongDestinationCount * scoring.onTimeClear
+    summary.onTimePointLossBreakdown.unfinished = math.max(
+        0,
+        summary.onTimePointCap
+            - summary.scoreBreakdown.onTimeClears
+            - summary.onTimePointLossBreakdown.lateClears
+            - summary.onTimePointLossBreakdown.wrongDestinations
+    )
 
     summary.scoreBreakdown.timePenalty = summary.elapsedSeconds * scoring.secondsPenalty
     summary.scoreBreakdown.interactionPenalty = roundScoreValue(summary.interactionCount * scoring.interactionPenalty)

--- a/tests/ui_formatting_test.lua
+++ b/tests/ui_formatting_test.lua
@@ -329,6 +329,29 @@ assertEqual(selectorHover.text:find("West Exit", 1, true) ~= nil, true, "selecto
 local speedHover = ui.getPlayHoverInfoAt(hoverGame, 810, 414)
 assertEqual(speedHover.title, "Fast Section", "play hover identifies speed-modified track sections")
 
+local resultsHoverGame = {
+    viewport = { w = 1280, h = 720 },
+    resultsSummary = {
+        scoreBreakdown = {
+            onTimeClears = 30,
+        },
+        onTimePointCap = 50,
+        onTimePointLossBreakdown = {
+            lateClears = 10,
+            wrongDestinations = 10,
+            unfinished = 0,
+        },
+    },
+}
+
+local resultsHover = ui.getResultsHoverInfoAt(resultsHoverGame, 640, 272)
+assertEqual(resultsHover.title, "On-Time Points", "results hover identifies the on-time points row")
+assertEqual(resultsHover.preferBelow, true, "results hover prefers showing the tooltip below the row")
+assertEqual(resultsHover.text:find("Correct routing: +30", 1, true) ~= nil, true, "results hover includes earned routing points")
+assertEqual(resultsHover.text:find("Late arrivals: -10", 1, true) ~= nil, true, "results hover includes late arrival losses")
+assertEqual(resultsHover.text:find("Wrong destinations: -10", 1, true) ~= nil, true, "results hover includes wrong destination losses")
+assertEqual(ui.getResultsHoverInfoAt(resultsHoverGame, 640, 340), nil, "results hover ignores non-hover rows")
+
 hoverGame.playPhase = "play"
 assertEqual(ui.getPlayHoverInfoAt(hoverGame, 600, 300), nil, "play hover disables itself outside preparation")
 hoverGame.playPhase = "prepare"

--- a/tests/world_run_summary_score_cap_test.lua
+++ b/tests/world_run_summary_score_cap_test.lua
@@ -1,0 +1,84 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.graphics = love.graphics or {}
+love.filesystem = love.filesystem or {}
+
+love.filesystem.getInfo = function()
+    return false
+end
+
+local world = require("src.game.world")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local simulation = world.new(100, 100, {
+    junctions = {
+        {
+            id = "main",
+            label = "Main",
+            control = { type = "direct" },
+            activeInputIndex = 1,
+            inputs = {
+                {
+                    id = "blue_in",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    inputPoints = {
+                        { x = 0.10, y = 0.50 },
+                        { x = 0.50, y = 0.50 },
+                    },
+                },
+            },
+            outputs = {
+                {
+                    id = "blue_out",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    outputPoints = {
+                        { x = 0.50, y = 0.50 },
+                        { x = 0.90, y = 0.50 },
+                    },
+                },
+            },
+        },
+    },
+    trains = {
+        { id = "train_1", junctionId = "main", inputIndex = 1, goalColor = "blue" },
+        { id = "train_2", junctionId = "main", inputIndex = 1, goalColor = "blue" },
+        { id = "train_3", junctionId = "main", inputIndex = 1, goalColor = "blue" },
+        { id = "train_4", junctionId = "main", inputIndex = 1, goalColor = "blue" },
+        { id = "train_5", junctionId = "main", inputIndex = 1, goalColor = "blue" },
+    },
+})
+
+simulation.elapsedTime = 40
+
+for index, train in ipairs(simulation.trains) do
+    train.completed = true
+    train.deliveredCorrectly = true
+    train.deliveredLate = index >= 4
+    train.failedWrongDestination = false
+    train.actualDistance = train.minimumDistance or 0
+end
+
+local summary = simulation:getRunSummary()
+
+assertEqual(summary.totalTrainCount, 5, "run summary keeps the train count")
+assertEqual(summary.maxPossibleScore, 50, "run summary exposes the score cap")
+assertEqual(summary.onTimePointCap, 50, "run summary exposes the on-time score cap")
+assertEqual(summary.correctOnTimeCount, 3, "run summary counts on-time clears")
+assertEqual(summary.correctLateCount, 2, "run summary counts late clears")
+assertEqual(summary.scoreBreakdown.onTimeClears, 30, "on-time score reflects three trains")
+assertEqual(summary.scoreBreakdown.lateClears, 10, "late score reflects two trains")
+assertEqual(summary.onTimePointLossBreakdown.lateClears, 10, "late clears report their on-time point loss")
+assertEqual(summary.onTimePointLossBreakdown.wrongDestinations, 0, "wrong destinations report no loss when none occurred")
+assertEqual(summary.onTimePointLossBreakdown.unfinished, 0, "unfinished trains report no loss when all trains completed")
+assertEqual(summary.scoreBreakdown.timePenalty, 10, "time penalty remains part of the final score")
+assertEqual(summary.finalScore, 30, "final score can be compared against the score cap")
+
+print("world run summary score cap tests passed")


### PR DESCRIPTION
## Requested Behavior
- Update the results screen so the `On-time clears` line shows points earned out of the total possible points for that category.
- Add a hover tooltip for that line that explains how many points were earned for correct routing and how many were lost to late arrivals and wrong destinations.

## Summary
- Moved the `earned / possible` display from the overall score header into the `On-time clears` row.
- Added results-screen hover handling so the on-time row shows a tooltip with earned points and loss breakdown.
- Extended run summary data with on-time point cap/loss fields to support the new UI.
- Added tests for the updated summary values and tooltip behavior.

## Testing
- Not run (not requested)