### PR TITLE
Allow overlapping merged lanes to keep distinct styles

### DIFF
--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -246,21 +246,6 @@ local function extractRouteSegment(routePoints, startDistance, endDistance)
     return segmentPoints
 end
 
-local function pointsRoughlyMatch(firstPoints, secondPoints, tolerance)
-    if #firstPoints ~= #secondPoints then
-        return false
-    end
-
-    local toleranceSquared = (tolerance or 0.001) * (tolerance or 0.001)
-    for index = 1, #firstPoints do
-        if distanceSquared(firstPoints[index].x, firstPoints[index].y, secondPoints[index].x, secondPoints[index].y) > toleranceSquared then
-            return false
-        end
-    end
-
-    return true
-end
-
 local function getEndpointById(editorData, endpointId)
     for _, endpoint in ipairs(editorData.endpoints or {}) do
         if endpoint.id == endpointId then
@@ -339,29 +324,6 @@ local function buildRouteStyleSections(route, startDistance, endDistance)
     return styleSections
 end
 
-local function styleSectionsRoughlyMatch(firstSections, secondSections, tolerance)
-    if #firstSections ~= #secondSections then
-        return false
-    end
-
-    local epsilon = tolerance or 0.001
-    for sectionIndex = 1, #firstSections do
-        local firstSection = firstSections[sectionIndex]
-        local secondSection = secondSections[sectionIndex]
-        if firstSection.roadType ~= secondSection.roadType then
-            return false
-        end
-        if math.abs(firstSection.startRatio - secondSection.startRatio) > epsilon then
-            return false
-        end
-        if math.abs(firstSection.endRatio - secondSection.endRatio) > epsilon then
-            return false
-        end
-    end
-
-    return true
-end
-
 local function sortRouteIdsByMagnet(editorData, routeIds, magnetKind)
     table.sort(routeIds, function(firstRouteId, secondRouteId)
         local firstRoute = getRouteById(editorData, firstRouteId)
@@ -402,25 +364,6 @@ local function buildOutputRoutesByEndpoint(editorData, junctionData)
     end
 
     return routesByEndpoint
-end
-
-local function roundPointKey(point)
-    return string.format("%.4f:%.4f", point.x, point.y)
-end
-
-local function buildEdgeKey(edge)
-    local parts = {
-        edge.sourceType or "unknown",
-        edge.sourceId or "none",
-        edge.targetType or "unknown",
-        edge.targetId or "none",
-    }
-
-    for _, point in ipairs(edge.points or {}) do
-        parts[#parts + 1] = roundPointKey(point)
-    end
-
-    return table.concat(parts, "|")
 end
 
 local function sortEdgesByStart(edges)
@@ -755,23 +698,9 @@ local function buildCompiledLevel(mapName, editorData)
                 targetId = targetNode.id,
             }
 
-            local edgeKey = buildEdgeKey(edge)
-            local existingEdge = edgeLookup[edgeKey]
-            if existingEdge then
-                if not pointsRoughlyMatch(existingEdge.points, edge.points) then
-                    local diagnosticIndex = addError("Merged tracks must share the same path between their nodes.")
-                    routeBlockingDiagnosticIndexByColor[route.color] = diagnosticIndex
-                    goto continue_route
-                end
-                if not styleSectionsRoughlyMatch(existingEdge.styleSections or {}, edge.styleSections or {}) then
-                    local diagnosticIndex = addError("Merged tracks must use the same road style profile.")
-                    routeBlockingDiagnosticIndexByColor[route.color] = diagnosticIndex
-                    goto continue_route
-                end
-                edge = existingEdge
-            else
-                edgeLookup[edgeKey] = edge
-            end
+            -- Keep authored route segments distinct even when they overlap exactly,
+            -- so each lane can preserve its own style and speed profile.
+            edgeLookup[edge.id] = edge
 
             if sourceNode.kind == "junction" then
                 local sourceJunction = junctionLookup[sourceNode.id]

--- a/tests/authored_map_large_junction_test.lua
+++ b/tests/authored_map_large_junction_test.lua
@@ -50,7 +50,7 @@ local editorData = {
     trains = {},
 }
 
-local level, buildErrors, firstError = authoredMap.buildPlayableLevel("Large Junction", editorData, nil)
+local level, firstError, buildErrors = authoredMap.buildPlayableLevel("Large Junction", editorData, nil)
 
 assertTrue(level ~= nil, "authored map should allow a junction with more than five inputs and outputs")
 assertTrue(firstError == nil, "large junction validation should not report a first error")

--- a/tests/authored_map_overlapping_route_styles_test.lua
+++ b/tests/authored_map_overlapping_route_styles_test.lua
@@ -1,0 +1,126 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local authoredMap = require("src.game.authored_map")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_blue", kind = "input", x = 0.10, y = 0.20, colors = { "blue" } },
+        { id = "input_orange", kind = "input", x = 0.10, y = 0.80, colors = { "orange" } },
+        { id = "output_blue", kind = "output", x = 0.90, y = 0.20, colors = { "blue" } },
+        { id = "output_orange", kind = "output", x = 0.90, y = 0.80, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_blue",
+            endEndpointId = "output_blue",
+            segmentRoadTypes = { "normal", "slow", "normal" },
+            points = {
+                { x = 0.10, y = 0.20 },
+                { x = 0.35, y = 0.35 },
+                { x = 0.65, y = 0.50 },
+                { x = 0.90, y = 0.20 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_orange",
+            endEndpointId = "output_orange",
+            segmentRoadTypes = { "normal", "fast", "normal" },
+            points = {
+                { x = 0.10, y = 0.80 },
+                { x = 0.35, y = 0.35 },
+                { x = 0.65, y = 0.50 },
+                { x = 0.90, y = 0.80 },
+            },
+        },
+    },
+    junctions = {
+        {
+            id = "junction_left",
+            x = 0.35,
+            y = 0.35,
+            control = "direct",
+            activeInputIndex = 1,
+            activeOutputIndex = 1,
+            routes = { "route_blue", "route_orange" },
+        },
+        {
+            id = "junction_right",
+            x = 0.65,
+            y = 0.50,
+            control = "direct",
+            activeInputIndex = 1,
+            activeOutputIndex = 1,
+            routes = { "route_blue", "route_orange" },
+        },
+    },
+    trains = {
+        {
+            id = "train_blue",
+            lineColor = "blue",
+            trainColor = "blue",
+            spawnTime = 0,
+            wagonCount = 4,
+        },
+        {
+            id = "train_orange",
+            lineColor = "orange",
+            trainColor = "orange",
+            spawnTime = 0,
+            wagonCount = 4,
+        },
+    },
+}
+
+local level, errorText, errors, diagnostics = authoredMap.buildPlayableLevel("Overlapping Route Styles", editorData, nil)
+
+if errorText ~= nil then
+    error(string.format("expected overlapping routes with different styles to compile, got %s", tostring(errorText)), 2)
+end
+
+assertEqual(#(errors or {}), 0, "overlapping routes with different styles should not emit validation errors")
+assertEqual(#(diagnostics or {}), 0, "overlapping routes with different styles should not emit diagnostics")
+assertTrue(level ~= nil, "expected a playable level to be built")
+assertEqual(#(level.edges or {}), 6, "each authored segment should stay distinct in the playable level")
+assertEqual(#(level.junctions or {}), 2, "expected both shared junctions to remain playable")
+
+local junctionById = {}
+for _, junction in ipairs(level.junctions or {}) do
+    junctionById[junction.id] = junction
+end
+
+assertEqual(#(junctionById.junction_left.inputEdgeIds or {}), 2, "left junction should keep two input lanes")
+assertEqual(#(junctionById.junction_left.outputEdgeIds or {}), 2, "left junction should keep two overlapping output lanes")
+assertEqual(#(junctionById.junction_right.inputEdgeIds or {}), 2, "right junction should keep two overlapping input lanes")
+assertEqual(#(junctionById.junction_right.outputEdgeIds or {}), 2, "right junction should keep two output lanes")
+
+local middleSegments = {}
+for _, edge in ipairs(level.edges or {}) do
+    if edge.sourceId == "junction_left" and edge.targetId == "junction_right" then
+        middleSegments[#middleSegments + 1] = edge
+    end
+end
+
+assertEqual(#middleSegments, 2, "shared middle section should remain as two lanes")
+assertTrue(middleSegments[1].roadType ~= middleSegments[2].roadType, "shared middle lanes should preserve their distinct road types")
+
+print("authored map overlapping route styles tests passed")

--- a/tests/love_runner/main.lua
+++ b/tests/love_runner/main.lua
@@ -1,0 +1,13 @@
+function love.load(args)
+    local testPath = args and args[1]
+    if not testPath or testPath == "" then
+        error("expected a test path argument", 2)
+    end
+
+    local ok, err = pcall(dofile, testPath)
+    if not ok then
+        error(err, 0)
+    end
+
+    love.event.quit(0)
+end


### PR DESCRIPTION
## Requested Behavior
- Using the current thread context and the commit and pull request contexts below, generate one git commit message plus one pull request title and body.
- Make merged lanes behave as separate playable lanes in the editor and game, so overlapping routes can keep independent speed/style settings.

## Summary
- Removed authored-map coalescing that forced identical overlapping segments to share one edge and one road style profile.
- Preserved overlapping route segments as distinct edges so each lane can carry its own style and speed.
- Added a regression test covering overlapping routes with different road styles.
- Fixed the existing large-junction test unpacking order while verifying the change.

## Testing
- `tests/authored_map_overlapping_route_styles_test.lua`
- `tests/authored_map_route_diagnostics_test.lua`
- `tests/map_editor_repeated_route_pair_junction_test.lua`
- `tests/authored_map_large_junction_test.lua`