### PR TITLE
Add a merged-bend toggle for eligible merger junctions

### DIFF
--- a/src/game/authored_map.lua
+++ b/src/game/authored_map.lua
@@ -42,6 +42,9 @@ local DEFAULT_CONTROL_CONFIGS = {
     crossbar = {
         label = "Crossbar Dial",
     },
+    merge = {
+        label = "Merged Bend Point",
+    },
 }
 
 local function distanceSquared(ax, ay, bx, by)
@@ -98,6 +101,14 @@ local function copyControlConfig(controlType)
 
     copy.type = controlType or "direct"
     return copy
+end
+
+local function isPassiveMergeControl(control)
+    local controlType = control
+    if type(control) == "table" then
+        controlType = control.type
+    end
+    return controlType == "merge"
 end
 
 local function deepCopy(value)
@@ -1012,16 +1023,27 @@ local function buildCompiledLevel(mapName, editorData)
             trains = trains,
         }, errors, table.concat(errors, " "), diagnostics
     end
-    local hasPlayableJunctions = #playableJunctions > 0
+    local hasPlayableJunctions = false
+    for _, junction in ipairs(playableJunctions) do
+        if not isPassiveMergeControl(junction.control) then
+            hasPlayableJunctions = true
+            break
+        end
+    end
+    local hasPassiveMergePoints = #playableJunctions > 0 and not hasPlayableJunctions
 
     return {
         title = mapName,
         description = "Custom map loaded from the editor.",
         hint = hasPlayableJunctions
             and "Click the junction center to switch inputs. Use the bottom selector to switch outputs."
+            or hasPassiveMergePoints
+            and "Merged bend points funnel multiple lanes into one shared track without a switch."
             or "Shared endpoints are not junctions. Only one train can safely occupy a line end at a time.",
         footer = hasPlayableJunctions
             and "Sequence trains from the editor pane and clear every goal on time."
+            or hasPassiveMergePoints
+            and "Merged lanes stay passive, so train spacing still matters on the shared track."
             or "Shared line ends stay contested even without a junction, so spacing still matters.",
         timeLimit = timeLimit,
         junctions = playableJunctions,

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -78,6 +78,7 @@ local CONTROL_LABELS = {
     relay = "R",
     trip = "1X",
     crossbar = "X",
+    merge = "M",
 }
 local CONTROL_NAMES = {
     direct = "Direct Lever",
@@ -87,6 +88,7 @@ local CONTROL_NAMES = {
     relay = "Relay Dial",
     trip = "Trip Switch",
     crossbar = "Crossbar Dial",
+    merge = "Merged Bend Point",
 }
 local CONTROL_FILL_COLORS = {
     direct = { 0.34, 0.84, 0.98 },
@@ -96,6 +98,7 @@ local CONTROL_FILL_COLORS = {
     relay = { 0.56, 0.72, 0.98 },
     trip = { 0.98, 0.6, 0.28 },
     crossbar = { 0.92, 0.38, 0.68 },
+    merge = { 0.86, 0.9, 0.96 },
 }
 local COLOR_OPTIONS = {
     { id = "blue", label = "Blue", color = { 0.33, 0.8, 0.98 } },
@@ -161,6 +164,9 @@ local DEFAULT_CONTROL_CONFIGS = {
     },
     crossbar = {
         label = "Crossbar Dial",
+    },
+    merge = {
+        label = "Merged Bend Point",
     },
 }
 
@@ -1574,6 +1580,9 @@ function mapEditor:refreshValidation(mapName)
         self.editingMapUuid
     )
     self:updatePreviewWorld(previewLevel)
+    for _, intersection in ipairs(self.intersections or {}) do
+        intersection.canMergeToBendPoint = self:isMergeBendPointCandidate(intersection)
+    end
     self:setValidationResults(buildError, buildErrors, buildDiagnostics)
     return level, buildError, self.validationErrors
 end
@@ -1964,8 +1973,6 @@ function mapEditor:openRouteTypePicker(route, segmentIndex, anchorX, anchorY)
 end
 
 function mapEditor:openJunctionPicker(intersection, clickX, clickY)
-    self:prepareIntersectionForDrag(intersection)
-
     local anchorX, anchorY = self:mapToScreen(intersection.x, intersection.y)
     local liveIntersection = self:getIntersectionById(intersection.id) or intersection
     self.colorPicker = {
@@ -2071,7 +2078,47 @@ function mapEditor:getJunctionPickerRootHover(x, y)
     return nil
 end
 
-function mapEditor:buildJunctionPickerEntries(branch, centerX, centerY, innerRadius, outerRadius)
+function mapEditor:isMergeBendPointCandidate(intersection)
+    if not intersection then
+        return false
+    end
+
+    local group = self:getSharedPointGroupForIntersection(intersection)
+    if not group or #group.colorIds <= 1 then
+        return false
+    end
+
+    local routeLookup = {}
+    for _, member in ipairs(group.members or {}) do
+        routeLookup[member.route and member.route.id or false] = true
+    end
+
+    for _, routeId in ipairs(intersection.routeIds or {}) do
+        if not routeLookup[routeId] then
+            return false
+        end
+    end
+
+    local previewJunction = self.previewWorld
+        and self.previewWorld.junctions
+        and self.previewWorld.junctions[intersection.id]
+        or nil
+    if previewJunction then
+        return #(previewJunction.inputs or {}) >= 1 and #(previewJunction.outputs or {}) == 1
+    end
+
+    return #(intersection.inputRouteIds or {}) >= 1 and #(intersection.outputEndpointIds or {}) == 1
+end
+
+function mapEditor:canIntersectionUseControlType(intersection, controlType)
+    if controlType ~= "merge" then
+        return true
+    end
+
+    return self:isMergeBendPointCandidate(intersection)
+end
+
+function mapEditor:buildJunctionPickerEntries(branch, centerX, centerY, innerRadius, outerRadius, intersection)
     local entries = {}
     local options = {}
 
@@ -2082,6 +2129,12 @@ function mapEditor:buildJunctionPickerEntries(branch, centerX, centerY, innerRad
             options[#options + 1] = {
                 id = controlType,
                 controlType = controlType,
+            }
+        end
+        if self:canIntersectionUseControlType(intersection, "merge") then
+            options[#options + 1] = {
+                id = "merge",
+                controlType = "merge",
             }
         end
     end
@@ -2144,7 +2197,8 @@ function mapEditor:getJunctionPickerLayout()
                 submenuCenterX,
                 submenuCenterY,
                 JUNCTION_MENU_RING_INNER_RADIUS,
-                outerRadius
+                outerRadius,
+                self.colorPicker.mode == "junction" and self:getIntersectionById(self.colorPicker.intersectionId) or nil
             ),
         }
     end
@@ -3541,7 +3595,10 @@ function mapEditor:getIntersectionControlType(intersection, previousMatches)
     end
 
     if bestControlType then
-        return bestControlType
+        if self:canIntersectionUseControlType(intersection, bestControlType) then
+            return bestControlType
+        end
+        return DEFAULT_CONTROL
     end
 
     return DEFAULT_CONTROL
@@ -3866,6 +3923,7 @@ function mapEditor:rebuildIntersections()
                 inputRouteIds = inputRouteIds,
                 outputRouteIds = outputRouteIds,
             }
+            intersection.canMergeToBendPoint = self:isMergeBendPointCandidate(intersection)
             local state = self:getJunctionState(intersection, previousIntersections)
             intersection.controlType = self:getIntersectionControlType(intersection, previousIntersections)
             intersection.passCount = math.max(1, math.min(MAX_TRIP_PASS_COUNT, (state and state.passCount) or DEFAULT_CONTROL_CONFIGS.trip.passCount))
@@ -4110,12 +4168,18 @@ function mapEditor:setIntersectionControlType(intersection, controlType)
         self:showStatus("Junctions currently support up to five inputs and five outputs.")
         return false
     end
+    if not self:canIntersectionUseControlType(intersection, controlType) then
+        self:showStatus("Only merged lanes that funnel into one output can become a bend point.")
+        return false
+    end
     if intersection.controlType == controlType then
         return false
     end
 
     intersection.controlType = controlType
-    if intersection.controlType == "relay" then
+    if intersection.controlType == "merge" then
+        intersection.activeOutputIndex = 1
+    elseif intersection.controlType == "relay" then
         self:syncIntersectionOutputToControl(intersection)
     elseif intersection.controlType == "crossbar" then
         self:syncIntersectionOutputToControl(intersection)

--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -42,8 +42,13 @@ local function hasOutputSelector(junction)
     return junction
         and #(junction.outputs or {}) > 1
         and junction.control
+        and junction.control.type ~= "merge"
         and junction.control.type ~= "relay"
         and junction.control.type ~= "crossbar"
+end
+
+local function isPassiveMergeJunction(junction)
+    return junction and junction.control and junction.control.type == "merge"
 end
 
 local function getColorById(colorId)
@@ -72,6 +77,35 @@ local function buildTrackStripeColors(colorIds, isActive)
     end
 
     return colors
+end
+
+local function collectPassiveMergeColorIds(junction)
+    local colorIds = {}
+    local seen = {}
+
+    for _, inputTrack in ipairs(junction and junction.inputs or {}) do
+        if #(inputTrack.colors or {}) > 0 then
+            for _, colorId in ipairs(inputTrack.colors or {}) do
+                if not seen[colorId] then
+                    seen[colorId] = true
+                    colorIds[#colorIds + 1] = colorId
+                end
+            end
+        elseif inputTrack.color then
+            for _, option in ipairs(COLOR_OPTIONS) do
+                if option.color[1] == inputTrack.color[1]
+                    and option.color[2] == inputTrack.color[2]
+                    and option.color[3] == inputTrack.color[3]
+                    and not seen[option.id] then
+                    seen[option.id] = true
+                    colorIds[#colorIds + 1] = option.id
+                    break
+                end
+            end
+        end
+    end
+
+    return colorIds
 end
 
 local function flattenPoints(points)
@@ -780,8 +814,40 @@ function renderer.drawActiveRouteIndicator(scene, junction, activeInput, activeO
     graphics.line(curvePoints)
 end
 
+local function drawPassiveMergeIndicator(scene, junction)
+    local graphics = love.graphics
+    local x = junction.mergePoint.x
+    local y = junction.mergePoint.y
+    local colorIds = collectPassiveMergeColorIds(junction)
+    local dotRadius = 6
+    local dotGap = 6
+    local rowWidth = (#colorIds * dotRadius * 2) + math.max(0, #colorIds - 1) * dotGap
+    local startX = x - rowWidth * 0.5 + dotRadius
+    local dotY = y + 22
+
+    graphics.setColor(0.05, 0.06, 0.08, 0.94)
+    graphics.circle("fill", x, y, 6)
+    graphics.setColor(0.97, 0.98, 1, 0.72)
+    graphics.setLineWidth(2)
+    graphics.circle("line", x, y, 6)
+
+    for colorIndex, colorId in ipairs(colorIds) do
+        local color = getColorById(colorId)
+        local dotX = startX + (colorIndex - 1) * (dotRadius * 2 + dotGap)
+        graphics.setColor(0.05, 0.06, 0.08, 0.98)
+        graphics.circle("fill", dotX, dotY, dotRadius + 3)
+        graphics.setColor(color[1], color[2], color[3], 1)
+        graphics.circle("fill", dotX, dotY, dotRadius)
+    end
+end
+
 function renderer.drawCrossing(scene, junction)
     local graphics = love.graphics
+    if isPassiveMergeJunction(junction) then
+        drawPassiveMergeIndicator(scene, junction)
+        return
+    end
+
     local activeInput = junction.inputs[junction.activeInputIndex]
     local activeOutputColor = scene:getOutputDisplayColor(junction, junction.activeOutputIndex, true)
     local activeInputColor = activeInput and activeInput.color or activeOutputColor
@@ -906,8 +972,10 @@ function renderer.drawScene(scene, options)
 
         renderer.drawCrossing(scene, junction)
 
-        for inputIndex = 1, #junction.inputs do
-            renderer.drawTrackSignal(scene, junction, inputIndex)
+        if not isPassiveMergeJunction(junction) then
+            for inputIndex = 1, #junction.inputs do
+                renderer.drawTrackSignal(scene, junction, inputIndex)
+            end
         end
     end
 

--- a/src/game/ui.lua
+++ b/src/game/ui.lua
@@ -1554,6 +1554,10 @@ local function appendUniqueControl(controls, seen, controlType)
     end
 end
 
+local function isPassiveMergeControlType(controlType)
+    return controlType == "merge"
+end
+
 local function mapHasLevelDeadline(descriptor)
     local level = descriptor and descriptor.previewLevel or nil
     return level and level.timeLimit ~= nil
@@ -1621,7 +1625,10 @@ getMapControlTypes = function(descriptor)
     local level = descriptor.previewLevel
 
     for _, junction in ipairs(level and level.junctions or {}) do
-        appendUniqueControl(controls, seen, junction.control and junction.control.type or "direct")
+        local controlType = junction.control and junction.control.type or "direct"
+        if not isPassiveMergeControlType(controlType) then
+            appendUniqueControl(controls, seen, controlType)
+        end
     end
 
     return controls
@@ -1656,6 +1663,7 @@ local function buildPreviewTracks(level)
             local point = nil
             local inputEdge = edgeLookup[(junction.inputEdgeIds or {})[1]]
             local outputEdge = edgeLookup[(junction.outputEdgeIds or {})[1]]
+            local controlType = junction.control and junction.control.type or "direct"
 
             if inputEdge and #(inputEdge.points or {}) > 0 then
                 point = inputEdge.points[#inputEdge.points]
@@ -1663,11 +1671,11 @@ local function buildPreviewTracks(level)
                 point = outputEdge.points[1]
             end
 
-            if point then
+            if point and not isPassiveMergeControlType(controlType) then
                 junctions[#junctions + 1] = {
                     x = point.x,
                     y = point.y,
-                    controlType = junction.control and junction.control.type or "direct",
+                    controlType = controlType,
                     outputCount = #(junction.outputEdgeIds or {}),
                 }
             end
@@ -1677,6 +1685,7 @@ local function buildPreviewTracks(level)
     end
 
     for _, junction in ipairs(level.junctions or {}) do
+        local controlType = junction.control and junction.control.type or "direct"
         for _, input in ipairs(junction.inputs or {}) do
             tracks[#tracks + 1] = {
                 points = input.inputPoints or {},
@@ -1701,11 +1710,11 @@ local function buildPreviewTracks(level)
             point = ((junction.outputs or {})[1].outputPoints)[1]
         end
 
-        if point then
+        if point and not isPassiveMergeControlType(controlType) then
             junctions[#junctions + 1] = {
                 x = point.x,
                 y = point.y,
-                controlType = junction.control and junction.control.type or "direct",
+                controlType = controlType,
                 outputCount = #(junction.outputs or {}),
             }
         end

--- a/src/game/world.lua
+++ b/src/game/world.lua
@@ -864,7 +864,9 @@ function world:buildJunction(definition, existing)
         outputs = outputs,
     }
 
-    if junction.control.type == "relay" and #junction.outputs > 0 then
+    if junction.control.type == "merge" and #junction.outputs > 0 then
+        junction.activeOutputIndex = 1
+    elseif junction.control.type == "relay" and #junction.outputs > 0 then
         junction.activeOutputIndex = clamp(junction.activeInputIndex, 1, #junction.outputs)
     elseif junction.control.type == "crossbar" and #junction.outputs > 0 then
         self:syncCrossbarOutput(junction)
@@ -939,6 +941,10 @@ local function getSelectorIconScale(junction)
     return 1 - press * 0.25
 end
 
+local function isPassiveMergeJunction(junction)
+    return junction and junction.control and junction.control.type == "merge"
+end
+
 function world:doesEdgeAcceptGoalColor(inputEdge, outputEdge, goalColor)
     if containsColorId(outputEdge and outputEdge.colors, goalColor) then
         return true
@@ -969,6 +975,11 @@ function world:getReachableOutputEdgesForInput(junction, inputEdgeId)
     end
 
     local controlType = junction.control and junction.control.type or "direct"
+    if controlType == "merge" then
+        local mergeOutput = junction.outputs[1]
+        return mergeOutput and { mergeOutput } or {}
+    end
+
     if controlType == "relay" then
         local relayOutput = junction.outputs[clamp(inputIndex, 1, #junction.outputs)]
         return relayOutput and { relayOutput } or {}
@@ -1355,6 +1366,10 @@ end
 function world:canActivateControl(junction, isPreparationPhase)
     local control = junction.control
 
+    if control.type == "merge" then
+        return false
+    end
+
     if isPreparationPhase and isPlayPhaseOnlyControl(control.type) then
         return false
     end
@@ -1368,6 +1383,10 @@ end
 
 function world:activatePreparationControl(junction)
     if not junction then
+        return false
+    end
+
+    if isPassiveMergeJunction(junction) then
         return false
     end
 
@@ -1385,6 +1404,10 @@ end
 
 function world:activateControl(junction)
     local control = junction.control
+
+    if control.type == "merge" then
+        return false
+    end
 
     if control.type == "direct" then
         return self:cycleInput(junction)
@@ -1454,6 +1477,10 @@ function world:activateControl(junction)
 end
 
 function world:isCrossingHit(junction, x, y)
+    if isPassiveMergeJunction(junction) then
+        return false
+    end
+
     return distanceSquared(x, y, junction.mergePoint.x, junction.mergePoint.y)
         <= junction.crossingRadius * junction.crossingRadius
 end
@@ -1601,6 +1628,10 @@ function world:getDesiredLeadDistance(train)
         return nil
     end
 
+    if isPassiveMergeJunction(junction) then
+        return nil
+    end
+
     local localProgress = self:getHeadLocalProgress(train)
     if localProgress >= currentEdge.path.length then
         return nil
@@ -1627,7 +1658,12 @@ function world:getEdgeSpeedScaleAtDistance(edge, distance)
 end
 
 function world:advanceTrainToNextEdge(train, junction, overflow)
-    local outputEdge = junction.outputs[clamp(junction.activeOutputIndex, 1, math.max(1, #junction.outputs))]
+    local outputEdge = nil
+    if isPassiveMergeJunction(junction) then
+        outputEdge = junction.outputs[1]
+    else
+        outputEdge = junction.outputs[clamp(junction.activeOutputIndex, 1, math.max(1, #junction.outputs))]
+    end
     if not outputEdge then
         self:completeTrain(train)
         return false
@@ -1723,7 +1759,16 @@ function world:updateTrain(train, dt)
         if currentEdge.targetType == "junction" then
             local junction = self.junctions[currentEdge.targetId]
             local activeInput = junction and junction.inputs[junction.activeInputIndex] or nil
-            if not junction or not activeInput or activeInput.id ~= currentEdge.id then
+            if not junction then
+                if overflow > 0 then
+                    train.actualDistance = math.max(0, (train.actualDistance or 0) - overflow)
+                end
+                local edgePrefix = self:getDistanceOnOccupiedEdges(self:getOccupiedEdges(train)) - currentEdge.path.length
+                train.headDistance = edgePrefix + currentEdge.path.length
+                train.currentSpeed = 0
+                break
+            end
+            if not isPassiveMergeJunction(junction) and (not activeInput or activeInput.id ~= currentEdge.id) then
                 if overflow > 0 then
                     train.actualDistance = math.max(0, (train.actualDistance or 0) - overflow)
                 end
@@ -2196,11 +2241,17 @@ function world:getRenderedTrackWindow(track)
     local trimEndDistance = track.path.length
 
     if track.sourceType == "junction" then
-        trimStartDistance = self.junctionTrackClearance
+        local sourceJunction = self.junctions[track.sourceId]
+        if not isPassiveMergeJunction(sourceJunction) then
+            trimStartDistance = self.junctionTrackClearance
+        end
     end
 
     if track.targetType == "junction" then
-        trimEndDistance = math.max(track.path.length - self.junctionTrackClearance, 0)
+        local targetJunction = self.junctions[track.targetId]
+        if not isPassiveMergeJunction(targetJunction) then
+            trimEndDistance = math.max(track.path.length - self.junctionTrackClearance, 0)
+        end
     end
 
     return trimStartDistance, trimEndDistance

--- a/tests/map_editor_merge_bend_point_test.lua
+++ b/tests/map_editor_merge_bend_point_test.lua
@@ -1,0 +1,254 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function assertFalse(value, label)
+    if value then
+        error(label, 2)
+    end
+end
+
+local function findMergeCandidateIntersection(editor)
+    for _, intersection in ipairs(editor.intersections or {}) do
+        if intersection.canMergeToBendPoint then
+            return intersection
+        end
+    end
+    return nil
+end
+
+local function findIntersectionByCompiledShape(editor, inputCount, outputCount)
+    for _, intersection in ipairs(editor.intersections or {}) do
+        local previewJunction = editor.previewWorld
+            and editor.previewWorld.junctions
+            and editor.previewWorld.junctions[intersection.id]
+            or nil
+        if previewJunction
+            and #(previewJunction.inputs or {}) == inputCount
+            and #(previewJunction.outputs or {}) == outputCount then
+            return intersection
+        end
+    end
+    return nil
+end
+
+local mergeLaneEditorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.18, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.18, colors = { "orange" } },
+        { id = "output_shared", kind = "output", x = 0.5, y = 0.86, colors = { "blue", "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_shared",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.18, y = 0.18 },
+                { x = 0.5, y = 0.46, sharedPointId = 1 },
+                { x = 0.5, y = 0.86 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_shared",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.82, y = 0.18 },
+                { x = 0.5, y = 0.46, sharedPointId = 1 },
+                { x = 0.5, y = 0.86 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(mergeLaneEditorData, "Merge Bend Point", nil, nil)
+
+local mergeIntersection = findMergeCandidateIntersection(editor)
+assertTrue(mergeIntersection ~= nil, "merged lanes that funnel into one output should offer a merge bend point option")
+assertTrue(editor:canIntersectionUseControlType(mergeIntersection, "merge"), "eligible merged lane should accept the merge bend point control")
+
+editor:openJunctionPicker(mergeIntersection, 640, 360)
+editor.colorPicker.branch = "junctions"
+
+local mergeOptionFound = false
+for _, entry in ipairs((editor:getJunctionPickerLayout().submenu or {}).entries or {}) do
+    if entry.option and entry.option.controlType == "merge" then
+        mergeOptionFound = true
+        break
+    end
+end
+assertTrue(mergeOptionFound, "junction picker should expose a merge bend point option for eligible merged lanes")
+
+assertTrue(editor:setIntersectionControlType(mergeIntersection, "merge"), "editor should allow switching an eligible merged lane to a merge bend point")
+assertEqual(findMergeCandidateIntersection(editor).controlType, "merge", "intersection should retain the merge bend point control type")
+assertEqual(editor.previewWorld.junctionOrder[1].control.type, "merge", "preview world should compile the passive merge control")
+
+local exported = editor:getExportData()
+assertEqual(exported.junctions[1].control, "merge", "exported editor data should persist the merge bend point control type")
+
+local reloadedEditor = mapEditor.new(1280, 720, nil)
+reloadedEditor:loadEditorData(exported, "Merge Bend Point Reloaded", nil, nil)
+local reloadedIntersection = findMergeCandidateIntersection(reloadedEditor)
+assertTrue(reloadedIntersection ~= nil, "reloaded editor should keep the merge bend point candidate")
+assertEqual(reloadedIntersection.controlType, "merge", "reloaded editor should preserve the merge bend point control")
+
+local crossingEditorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.2, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.82, y = 0.8, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.2, colors = { "orange" } },
+        { id = "output_left", kind = "output", x = 0.18, y = 0.8, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.18, y = 0.2 },
+                { x = 0.82, y = 0.8 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.82, y = 0.2 },
+                { x = 0.18, y = 0.8 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local crossingEditor = mapEditor.new(1280, 720, nil)
+crossingEditor:loadEditorData(crossingEditorData, "Crossing Junction", nil, nil)
+local crossingIntersection = crossingEditor.intersections[1]
+assertFalse(crossingEditor:canIntersectionUseControlType(crossingIntersection, "merge"), "regular crossings should not expose the merge bend point control")
+
+crossingEditor:openJunctionPicker(crossingIntersection, 640, 360)
+crossingEditor.colorPicker.branch = "junctions"
+for _, entry in ipairs((crossingEditor:getJunctionPickerLayout().submenu or {}).entries or {}) do
+    if entry.option and entry.option.controlType == "merge" then
+        error("regular crossings should not show the merge bend point option", 2)
+    end
+end
+
+local downstreamJunctionEditorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.16, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.16, colors = { "orange" } },
+        { id = "input_mid_left", kind = "input", x = 0.16, y = 0.66, colors = { "mint" } },
+        { id = "output_left", kind = "output", x = 0.22, y = 0.9, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.78, y = 0.9, colors = { "orange" } },
+        { id = "output_mid", kind = "output", x = 0.84, y = 0.66, colors = { "mint" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal", "normal", "normal" },
+            points = {
+                { x = 0.18, y = 0.16 },
+                { x = 0.5, y = 0.42, sharedPointId = 1 },
+                { x = 0.5, y = 0.58 },
+                { x = 0.22, y = 0.9 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal", "normal", "normal" },
+            points = {
+                { x = 0.82, y = 0.16 },
+                { x = 0.5, y = 0.42, sharedPointId = 1 },
+                { x = 0.5, y = 0.58 },
+                { x = 0.78, y = 0.9 },
+            },
+        },
+        {
+            id = "route_mint",
+            label = "route_mint",
+            color = "mint",
+            startEndpointId = "input_mid_left",
+            endEndpointId = "output_mid",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.16, y = 0.66 },
+                { x = 0.5, y = 0.58 },
+                { x = 0.84, y = 0.66 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local downstreamEditor = mapEditor.new(1280, 720, nil)
+downstreamEditor:loadEditorData(downstreamJunctionEditorData, "Merge Before Downstream Junction", nil, nil)
+local downstreamMergeIntersection = findIntersectionByCompiledShape(downstreamEditor, 1, 1)
+assertTrue(downstreamMergeIntersection ~= nil, "merged lane before a downstream junction should still expose the compiled 1-in/1-out shared-lane point")
+assertTrue(
+    #(downstreamMergeIntersection.outputEndpointIds or {}) > 1,
+    "regression setup should keep multiple final output endpoints so eligibility depends on local merged-lane topology"
+)
+assertTrue(
+    downstreamEditor:canIntersectionUseControlType(downstreamMergeIntersection, "merge"),
+    "merge bend point eligibility should follow the compiled local shared-lane topology, not the final endpoint count"
+)
+
+print("map editor merge bend point tests passed")

--- a/tests/world_merge_bend_point_test.lua
+++ b/tests/world_merge_bend_point_test.lua
@@ -1,0 +1,112 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local world = require("src.game.world")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function assertNear(actual, expected, epsilon, label)
+    if math.abs(actual - expected) > epsilon then
+        error(string.format("%s expected %.4f but got %.4f", label, expected, actual), 2)
+    end
+end
+
+local simulation = world.new(1200, 800, {
+    junctions = {
+        {
+            id = "merge_junction",
+            label = "merge",
+            control = {
+                type = "merge",
+            },
+            activeInputIndex = 1,
+            activeOutputIndex = 1,
+            inputs = {
+                {
+                    id = "merge_input_a",
+                    color = { 0.33, 0.80, 0.98 },
+                    colors = { "blue" },
+                    inputPoints = {
+                        { x = 0.22, y = 0.16 },
+                        { x = 0.34, y = 0.3 },
+                        { x = 0.5, y = 0.5 },
+                    },
+                },
+                {
+                    id = "merge_input_b",
+                    color = { 0.98, 0.70, 0.28 },
+                    colors = { "orange" },
+                    inputPoints = {
+                        { x = 0.78, y = 0.16 },
+                        { x = 0.66, y = 0.3 },
+                        { x = 0.5, y = 0.5 },
+                    },
+                },
+            },
+            outputs = {
+                {
+                    id = "merge_output_a",
+                    color = { 0.4, 0.92, 0.76 },
+                    colors = { "blue", "orange" },
+                    outputPoints = {
+                        { x = 0.5, y = 0.5 },
+                        { x = 0.5, y = 0.72 },
+                        { x = 0.5, y = 0.9 },
+                    },
+                },
+            },
+        },
+    },
+    trains = {
+        {
+            id = "merge_train",
+            junctionId = "merge_junction",
+            inputIndex = 2,
+            lineColor = "orange",
+            trainColor = "orange",
+            spawnTime = 0,
+            progress = 0,
+        },
+    },
+})
+
+local junction = simulation.junctions.merge_junction
+assertTrue(junction ~= nil, "simulation should build the merge bend point junction")
+assertEqual(simulation:handleClick(junction.mergePoint.x, junction.mergePoint.y, 1, true), false, "merge bend point should ignore preparation clicks")
+assertEqual(simulation:handleClick(junction.mergePoint.x, junction.mergePoint.y, 1, false), false, "merge bend point should ignore play clicks")
+assertEqual(simulation:isCrossingHit(junction, junction.mergePoint.x, junction.mergePoint.y), false, "merge bend point should not register as a clickable junction")
+
+local firstInputRendered = simulation:getRenderedTrackPoints(junction.inputs[1])
+local firstOutputRendered = simulation:getRenderedTrackPoints(junction.outputs[1])
+assertNear(firstInputRendered[#firstInputRendered].x, junction.mergePoint.x, 0.001, "merge bend point should not trim input tracks away from the merge")
+assertNear(firstInputRendered[#firstInputRendered].y, junction.mergePoint.y, 0.001, "merge bend point should keep input tracks touching the merge")
+assertNear(firstOutputRendered[1].x, junction.mergePoint.x, 0.001, "merge bend point should not trim output tracks away from the merge")
+assertNear(firstOutputRendered[1].y, junction.mergePoint.y, 0.001, "merge bend point should keep output tracks touching the merge")
+
+local train = simulation.trains[1]
+assertEqual(train.edgeId, "merge_junction_input_2", "train should start on the second input lane")
+assertEqual(simulation:getDesiredLeadDistance(train), nil, "merge bend point should not force trains to stop for an active input")
+
+local advancedToOutput = false
+for _ = 1, 240 do
+    simulation:updateTrain(train, 1 / 60)
+    if train.edgeId == "merge_junction_output_1" or train.completed then
+        advancedToOutput = true
+        break
+    end
+end
+
+assertTrue(advancedToOutput, "train should automatically pass through the merge bend point onto the shared output lane")
+
+print("world merge bend point tests passed")


### PR DESCRIPTION
## Requested Behavior
- Add an option in the junction radial menu to convert the special post-merge junction into a merged bend point instead of a clickable junction.
- Restrict that option to the exact merged-lane case after a merger, and allow switching it back to a normal junction.
- When rendered as a merged bend point, show color dots below the node to indicate the merged colors.

## Summary
- Added a new passive `merge` junction state in the editor, authored-map compiler, runtime world, and renderer.
- Kept the option hidden for ordinary junctions and exposed it only for eligible merged-lane topologies.
- Updated map preview/UI handling so merge nodes do not appear as normal clickable junction badges.
- Added regression coverage for editor eligibility and runtime pass-through behavior.

## Testing
- `love.exe tests/map_editor_merge_bend_point_test.lua`
- `love.exe tests/world_merge_bend_point_test.lua`
- `love.exe tests/map_editor_junction_state_test.lua`
- `love.exe tests/world_preparation_junction_setup_test.lua`