### PR TITLE
Fix road junction state rendering

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -3884,6 +3884,7 @@ function mapEditor:rebuildIntersections()
         return a.x < b.x
     end)
 
+    self:materializeIntersectionPoints()
     self:refreshValidation()
 end
 
@@ -4003,13 +4004,13 @@ end
 
 function mapEditor:ensureRoutePointAtIntersection(route, intersectionPoint)
     if not route or not route.points or #route.points < 2 then
-        return nil, nil
+        return nil, nil, false
     end
 
     for pointIndex = 2, #route.points - 1 do
         local point = route.points[pointIndex]
         if distanceSquared(point.x, point.y, intersectionPoint.x, intersectionPoint.y) <= INTERSECTION_POINT_TOLERANCE_SQUARED then
-            return pointIndex, point
+            return pointIndex, point, false
         end
     end
 
@@ -4019,21 +4020,61 @@ function mapEditor:ensureRoutePointAtIntersection(route, intersectionPoint)
         local hitPoint = pointOnSegment(intersectionPoint, pointA, pointB, INTERSECTION_POINT_TOLERANCE_SQUARED)
         if hitPoint then
             if distanceSquared(hitPoint.x, hitPoint.y, pointA.x, pointA.y) <= INTERNAL_POINT_MATCH_DISTANCE_SQUARED and segmentIndex > 1 then
-                return segmentIndex, pointA
+                return segmentIndex, pointA, false
             end
             if distanceSquared(hitPoint.x, hitPoint.y, pointB.x, pointB.y) <= INTERNAL_POINT_MATCH_DISTANCE_SQUARED
                 and (segmentIndex + 1) < #route.points then
-                return segmentIndex + 1, pointB
+                return segmentIndex + 1, pointB, false
             end
 
             local insertIndex = segmentIndex + 1
             table.insert(route.points, insertIndex, hitPoint)
             self:splitRouteSegmentStyle(route, segmentIndex)
-            return insertIndex, route.points[insertIndex]
+            return insertIndex, route.points[insertIndex], true
         end
     end
 
-    return nil, nil
+    return nil, nil, false
+end
+
+function mapEditor:materializeIntersectionPoints()
+    for _, intersection in ipairs(self.intersections or {}) do
+        local members = {}
+        local sharedPointId = nil
+
+        for _, routeId in ipairs(intersection.routeIds or {}) do
+            local route = self:getRouteById(routeId)
+            local pointIndex, point = self:ensureRoutePointAtIntersection(route, intersection)
+            if route and pointIndex and point then
+                members[#members + 1] = {
+                    route = route,
+                    pointIndex = pointIndex,
+                    point = point,
+                }
+                if point.sharedPointId and not sharedPointId then
+                    sharedPointId = point.sharedPointId
+                end
+            end
+        end
+
+        if #members >= 2 then
+            if not sharedPointId then
+                sharedPointId = self.nextSharedPointId
+                self.nextSharedPointId = self.nextSharedPointId + 1
+            end
+
+            for _, member in ipairs(members) do
+                if member.point.sharedPointId and member.point.sharedPointId ~= sharedPointId then
+                    self:reassignSharedPointGroup(member.point.sharedPointId, sharedPointId)
+                end
+                if member.point.sharedPointId ~= sharedPointId then
+                    member.point.sharedPointId = sharedPointId
+                end
+            end
+
+            self:updateSharedPointGroup(sharedPointId, intersection.x, intersection.y)
+        end
+    end
 end
 
 function mapEditor:prepareIntersectionForDrag(intersection)
@@ -5588,7 +5629,7 @@ function mapEditor:drawRoutePatternStroke(pointA, pointB, roadTypeId, alpha)
     local normalY = directionX
     local markerSpacing = roadTypeConfig.markerSpacing
     local markerSize = roadTypeConfig.markerSize
-    local markerDistance = markerSpacing * 0.5
+    local markerDistance = length <= markerSpacing and length * 0.5 or markerSpacing * 0.5
     local outlineWidth = roadTypeConfig.markerWidth + 2
     local fillWidth = roadTypeConfig.markerWidth
 

--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -448,7 +448,11 @@ function renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
         if roadTypeConfig.pattern ~= "plain" then
             local sectionStartDistance = math.max(startDistance, section.startDistance)
             local sectionEndDistance = math.min(endDistance, section.endDistance)
-            local markerDistance = sectionStartDistance + roadTypeConfig.markerSpacing * 0.5
+            local visibleSectionLength = math.max(sectionEndDistance - sectionStartDistance, 0)
+            local markerDistance = sectionStartDistance
+                + (visibleSectionLength <= roadTypeConfig.markerSpacing
+                    and visibleSectionLength * 0.5
+                    or roadTypeConfig.markerSpacing * 0.5)
             local markerSize = roadTypeConfig.markerSize
             local outlineWidth = roadTypeConfig.markerWidth + 2
             local fillWidth = roadTypeConfig.markerWidth
@@ -547,10 +551,12 @@ function renderer.drawInputTrack(scene, track, isActive)
     graphics.line(points)
 
     if stripeColors then
-        renderer.drawStripedTrack(scene, points, scene.trackWidth, stripeColors, trackAlpha)
+        scene:drawStripedTrack(points, scene.trackWidth, stripeColors, trackAlpha)
     else
-        renderer.drawTrackLine(scene, points, scene.trackWidth, trackColor, trackAlpha)
+        scene:drawTrackLine(points, scene.trackWidth, trackColor, trackAlpha)
     end
+
+    scene:drawTrackRoadTypeMarkers(track, isActive)
 end
 
 function renderer.drawStandaloneTrack(scene, track, isActive)
@@ -576,12 +582,12 @@ function renderer.drawStandaloneTrack(scene, track, isActive)
     graphics.line(points)
 
     if stripeColors then
-        renderer.drawStripedTrack(scene, points, scene.trackWidth, stripeColors, trackAlpha)
+        scene:drawStripedTrack(points, scene.trackWidth, stripeColors, trackAlpha)
     else
-        renderer.drawTrackLine(scene, points, scene.trackWidth, trackColor, trackAlpha)
+        scene:drawTrackLine(points, scene.trackWidth, trackColor, trackAlpha)
     end
 
-    renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+    scene:drawTrackRoadTypeMarkers(track, isActive)
 end
 
 function renderer.drawOutputTrack(scene, junction, outputIndex, isActive)
@@ -601,12 +607,12 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive)
     graphics.line(points)
 
     if stripeColors then
-        renderer.drawStripedTrack(scene, points, scene.sharedWidth, stripeColors, isActive and 0.98 or 0.7)
+        scene:drawStripedTrack(points, scene.sharedWidth, stripeColors, isActive and 0.98 or 0.7)
     else
-        renderer.drawTrackLine(scene, points, scene.sharedWidth, color, isActive and 0.98 or 0.7)
+        scene:drawTrackLine(points, scene.sharedWidth, color, isActive and 0.98 or 0.7)
     end
 
-    renderer.drawTrackRoadTypeMarkers(scene, outputTrack, isActive)
+    scene:drawTrackRoadTypeMarkers(outputTrack, isActive)
 end
 
 function renderer.drawControlOverlay(scene, junction)

--- a/tests/map_editor_intersection_road_type_split_test.lua
+++ b/tests/map_editor_intersection_road_type_split_test.lua
@@ -1,0 +1,127 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local MAP_WIDTH = 1280
+local MAP_HEIGHT = 720
+local LEFT_X = 0.18
+local RIGHT_X = 0.82
+local TOP_Y = 0.20
+local BOTTOM_Y = 0.80
+local CENTER_X = 0.50
+local CENTER_Y = 0.50
+
+local editorData = {
+    endpoints = {
+        { id = "input_fast", kind = "input", x = LEFT_X, y = TOP_Y, colors = { "blue" } },
+        { id = "output_fast", kind = "output", x = RIGHT_X, y = BOTTOM_Y, colors = { "blue" } },
+        { id = "input_slow", kind = "input", x = RIGHT_X, y = TOP_Y, colors = { "orange" } },
+        { id = "output_slow", kind = "output", x = LEFT_X, y = BOTTOM_Y, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_fast",
+            label = "route_fast",
+            color = "blue",
+            startEndpointId = "input_fast",
+            endEndpointId = "output_fast",
+            segmentRoadTypes = { "fast" },
+            points = {
+                { x = LEFT_X, y = TOP_Y },
+                { x = RIGHT_X, y = BOTTOM_Y },
+            },
+        },
+        {
+            id = "route_slow",
+            label = "route_slow",
+            color = "orange",
+            startEndpointId = "input_slow",
+            endEndpointId = "output_slow",
+            segmentRoadTypes = { "slow" },
+            points = {
+                { x = RIGHT_X, y = TOP_Y },
+                { x = LEFT_X, y = BOTTOM_Y },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(MAP_WIDTH, MAP_HEIGHT, nil)
+editor:loadEditorData(editorData, "Intersection Road Type Split", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 1, "crossing routes should still build one junction")
+
+local fastRoute = editor:getRouteById("route_fast")
+local slowRoute = editor:getRouteById("route_slow")
+
+assertEqual(#(fastRoute.points or {}), 3, "fast route should gain a bend point at the junction")
+assertEqual(#(slowRoute.points or {}), 3, "slow route should gain a bend point at the junction")
+assertEqual(#(fastRoute.segmentRoadTypes or {}), 2, "fast route should split into two styled segments")
+assertEqual(#(slowRoute.segmentRoadTypes or {}), 2, "slow route should split into two styled segments")
+assertEqual(fastRoute.segmentRoadTypes[1], "fast", "fast route should keep the original style before the junction")
+assertEqual(fastRoute.segmentRoadTypes[2], "fast", "fast route should copy the original style after the junction")
+assertEqual(slowRoute.segmentRoadTypes[1], "slow", "slow route should keep the original style before the junction")
+assertEqual(slowRoute.segmentRoadTypes[2], "slow", "slow route should copy the original style after the junction")
+
+local fastBend = fastRoute.points[2]
+local slowBend = slowRoute.points[2]
+
+assertTrue(fastBend.sharedPointId ~= nil, "fast route junction bend point should be shared")
+assertEqual(fastBend.sharedPointId, slowBend.sharedPointId, "both routes should share the same junction bend point id")
+assertTrue(math.abs(fastBend.x / MAP_WIDTH - CENTER_X) < 0.0001, "fast route bend point should land on the junction x position")
+assertTrue(math.abs(fastBend.y / MAP_HEIGHT - CENTER_Y) < 0.0001, "fast route bend point should land on the junction y position")
+
+local exported = editor:getExportData()
+local exportedFastRoute = nil
+local exportedSlowRoute = nil
+
+for _, route in ipairs(exported.routes or {}) do
+    if route.id == "route_fast" then
+        exportedFastRoute = route
+    elseif route.id == "route_slow" then
+        exportedSlowRoute = route
+    end
+end
+
+assertTrue(exportedFastRoute ~= nil, "fast route should still export")
+assertTrue(exportedSlowRoute ~= nil, "slow route should still export")
+assertEqual(#(exportedFastRoute.points or {}), 3, "exported fast route should keep the junction bend point")
+assertEqual(#(exportedSlowRoute.points or {}), 3, "exported slow route should keep the junction bend point")
+assertEqual(exportedFastRoute.segmentRoadTypes[1], "fast", "exported fast route should keep the first split road type")
+assertEqual(exportedFastRoute.segmentRoadTypes[2], "fast", "exported fast route should keep the second split road type")
+assertEqual(exportedSlowRoute.segmentRoadTypes[1], "slow", "exported slow route should keep the first split road type")
+assertEqual(exportedSlowRoute.segmentRoadTypes[2], "slow", "exported slow route should keep the second split road type")
+
+print("map editor intersection road type split tests passed")

--- a/tests/track_scene_renderer_short_section_marker_test.lua
+++ b/tests/track_scene_renderer_short_section_marker_test.lua
@@ -1,0 +1,61 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.graphics = love.graphics or {}
+love.filesystem = love.filesystem or {}
+
+love.graphics.setColor = function()
+end
+love.graphics.setLineWidth = function()
+end
+love.graphics.line = function()
+end
+love.filesystem.getInfo = function()
+    return false
+end
+
+local renderer = require("src.game.track_scene_renderer")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local calls = {}
+local originalDrawTrackPatternSegment = renderer.drawTrackPatternSegment
+
+renderer.drawTrackPatternSegment = function(_, startX, startY, endX, endY)
+    calls[#calls + 1] = {
+        startX = startX,
+        startY = startY,
+        endX = endX,
+        endY = endY,
+    }
+end
+
+local scene = {
+    getRenderedTrackWindow = function()
+        return 0, 20
+    end,
+    pointOnPath = function(_, _, distance)
+        return distance, 0, 0
+    end,
+}
+
+local track = {
+    styleSections = {
+        {
+            roadType = "fast",
+            startDistance = 0,
+            endDistance = 20,
+        },
+    },
+}
+
+renderer.drawTrackRoadTypeMarkers(scene, track, true)
+renderer.drawTrackPatternSegment = originalDrawTrackPatternSegment
+
+assertEqual(#calls, 2, "short visible fast sections should still draw one chevron marker")
+
+print("track scene renderer short section marker tests passed")


### PR DESCRIPTION
## Requested Behavior
- Keep the requested road type visible from a start point into a junction and from a junction to the next junction or end point.
- Ensure each split lane keeps its own state and updates visually when the lane is changed.
- Preserve the road type display after routes are split at junctions.

## Summary
- Materialized intersection points during editor rebuild so junctions become real bend points on participating routes.
- Updated road type marker placement so short visible sections still render a marker instead of disappearing.
- Restored road type marker drawing for input tracks, which covers routes leading into junctions.
- Kept preview rendering consistent by routing track drawing through the scene wrappers.

## Testing
- `tests/map_editor_intersection_road_type_split_test.lua`
- `tests/track_scene_renderer_short_section_marker_test.lua`
- `tests/track_scene_renderer_layout_test.lua`
- `tests/world_input_track_markers_test.lua`