### PR TITLE
Update saved map play and upload actions

### DIFF
--- a/src/game/game.lua
+++ b/src/game/game.lua
@@ -451,6 +451,7 @@ function Game.new()
     self.activeUploadMapRequestId = nil
     self.activeUploadMapRequestStartedAt = nil
     self.activeUploadMapDescriptor = nil
+    self.activeUploadMapOrigin = nil
     self.activeScoreSubmitRequestId = nil
     self.activeScoreSubmitRequestStartedAt = nil
     self.resultsSummary = nil
@@ -1602,10 +1603,12 @@ function Game:updateLeaderboardFetchState()
             end
 
             if self.activeUploadMapRequestId ~= nil then
+                local uploadOrigin = self.activeUploadMapOrigin
                 self.activeUploadMapRequestId = nil
                 self.activeUploadMapRequestStartedAt = nil
                 self.activeUploadMapDescriptor = nil
-                self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_ERROR, threadError, "Upload failed")
+                self.activeUploadMapOrigin = nil
+                self:showUploadFailureMessage(uploadOrigin, threadError)
             end
 
             if self.activeScoreSubmitRequestId ~= nil then
@@ -1688,10 +1691,12 @@ function Game:updateLeaderboardFetchState()
     if self.activeUploadMapRequestId ~= nil and self.activeUploadMapRequestStartedAt ~= nil then
         local elapsedSeconds = getNowSeconds() - self.activeUploadMapRequestStartedAt
         if elapsedSeconds >= ONLINE_WRITE_TIMEOUT_SECONDS then
+            local uploadOrigin = self.activeUploadMapOrigin
             self.activeUploadMapRequestId = nil
             self.activeUploadMapRequestStartedAt = nil
             self.activeUploadMapDescriptor = nil
-            self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_ERROR, "The map upload timed out.", "Upload failed")
+            self.activeUploadMapOrigin = nil
+            self:showUploadFailureMessage(uploadOrigin, "The map upload timed out.")
         end
     end
 
@@ -1793,23 +1798,20 @@ function Game:updateLeaderboardFetchState()
             end
         elseif type(decodedResponse) == "table" and decodedResponse.kind == "upload_map" and decodedResponse.requestId == self.activeUploadMapRequestId then
             local uploadedMapDescriptor = self.activeUploadMapDescriptor
+            local uploadOrigin = self.activeUploadMapOrigin
             self.activeUploadMapRequestId = nil
             self.activeUploadMapRequestStartedAt = nil
             self.activeUploadMapDescriptor = nil
+            self.activeUploadMapOrigin = nil
             if decodedResponse.ok and type(decodedResponse.payload) == "table" then
-                self:clearLevelSelectActionState()
-                self:openLevelSelectUploadDialog(decodedResponse.payload, uploadedMapDescriptor)
+                self:showUploadSuccessMessage(uploadOrigin, decodedResponse.payload, uploadedMapDescriptor)
             else
                 local statusCode = tonumber(decodedResponse.status)
                 local failureMessage = decodedResponse.error or "The map upload failed."
                 if statusCode then
                     failureMessage = string.format("Map upload failed (HTTP %d): %s", statusCode, tostring(failureMessage))
                 end
-                self:setLevelSelectActionState(
-                    LEVEL_SELECT_ACTION_STATUS_ERROR,
-                    failureMessage,
-                    "Upload failed"
-                )
+                self:showUploadFailureMessage(uploadOrigin, failureMessage)
             end
         elseif type(decodedResponse) == "table" and decodedResponse.kind == "score_submit" and decodedResponse.requestId == self.activeScoreSubmitRequestId then
             self.activeScoreSubmitRequestId = nil
@@ -2268,6 +2270,106 @@ function Game:isUploadSelectedMapAvailable(mapDescriptor)
         and self:canUploadMapDescriptor(mapDescriptor or self:getSelectedLevelMap())
 end
 
+function Game:updateEditorSavedMapActionState()
+    local savedMapDescriptor = self.editor:getSavedMapDescriptor()
+    local canUploadSavedMap = false
+    if self:canUploadMapDescriptor(savedMapDescriptor) then
+        canUploadSavedMap = self:getUploadConfig().isConfigured
+    end
+
+    self.editor:setSavedMapUploadState(
+        canUploadSavedMap,
+        self.activeUploadMapRequestId ~= nil and self.activeUploadMapOrigin == "editor"
+    )
+end
+
+function Game:showUploadUnavailableMessage(origin, message, title)
+    if origin == "editor" then
+        self.editor:showStatus("Uploading is currently not possible.")
+        return
+    end
+
+    self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_ERROR, message, title or "Upload unavailable")
+end
+
+function Game:showUploadStartedMessage(origin)
+    if origin == "editor" then
+        self.editor:showStatus("Uploading the saved map...")
+        return
+    end
+
+    self:closeLevelSelectUploadDialog()
+    self:setLevelSelectActionState(
+        LEVEL_SELECT_ACTION_STATUS_INFO,
+        "Sending your map to the online library.",
+        "Uploading map"
+    )
+end
+
+function Game:showUploadSuccessMessage(origin, payload, mapDescriptor)
+    if origin == "editor" then
+        local resolvedPayload = type(payload) == "table" and payload or {}
+        local uploadedMapId = tostring(
+            resolvedPayload.internal_identifier
+                or resolvedPayload.internalIdentifier
+                or resolvedPayload.map_uuid
+                or resolvedPayload.mapUuid
+                or ""
+        )
+        if uploadedMapId ~= "" then
+            self.editor:showStatus("Map uploaded. ID: " .. uploadedMapId)
+        else
+            self.editor:showStatus("Map uploaded successfully.")
+        end
+        return
+    end
+
+    self:clearLevelSelectActionState()
+    self:openLevelSelectUploadDialog(payload, mapDescriptor)
+end
+
+function Game:showUploadFailureMessage(origin, message)
+    if origin == "editor" then
+        self.editor:showStatus(message)
+        return
+    end
+
+    self:setLevelSelectActionState(LEVEL_SELECT_ACTION_STATUS_ERROR, message, "Upload failed")
+end
+
+function Game:uploadMapDescriptor(mapDescriptor, origin)
+    local uploadOrigin = origin or "level_select"
+    local selectedMap = mapDescriptor or self:getSelectedLevelMap()
+    if not self:canUploadMapDescriptor(selectedMap) then
+        self:showUploadUnavailableMessage(uploadOrigin, "Only your own local user maps can be uploaded.")
+        return false
+    end
+
+    local onlineConfig = self:getUploadConfig()
+    if not onlineConfig.isConfigured then
+        self:showUploadUnavailableMessage(
+            uploadOrigin,
+            table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " ")
+        )
+        return false
+    end
+
+    local mapData, loadError = mapStorage.loadMap(selectedMap)
+    if not mapData or type(mapData.level) ~= "table" then
+        self:showUploadFailureMessage(uploadOrigin, loadError or "The selected map could not be uploaded.")
+        return false
+    end
+
+    if not self:beginUploadMapRequest(onlineConfig, mapData, selectedMap) then
+        self:showUploadFailureMessage(uploadOrigin, "A map upload is already in progress.")
+        return false
+    end
+
+    self.activeUploadMapOrigin = uploadOrigin
+    self:showUploadStartedMessage(uploadOrigin)
+    return true
+end
+
 function Game:canCloneMapDescriptor(mapDescriptor)
     return mapDescriptor ~= nil
         and mapDescriptor.source == "user"
@@ -2330,43 +2432,7 @@ function Game:cloneMapForEditing(mapDescriptor)
 end
 
 function Game:uploadSelectedMap()
-    local selectedMap = self:getSelectedLevelMap()
-    if not self:canUploadMapDescriptor(selectedMap) then
-        self:setLevelSelectActionState(
-            LEVEL_SELECT_ACTION_STATUS_ERROR,
-            "Only your own local user maps can be uploaded.",
-            "Upload unavailable"
-        )
-        return
-    end
-
-    local onlineConfig = self:getUploadConfig()
-    if not onlineConfig.isConfigured then
-        self:setLevelSelectActionState(
-            LEVEL_SELECT_ACTION_STATUS_ERROR,
-            table.concat(onlineConfig.errors or { "The online marketplace is not configured." }, " "),
-            "Upload unavailable"
-        )
-        return
-    end
-
-    local mapData, loadError = mapStorage.loadMap(selectedMap)
-    if not mapData or type(mapData.level) ~= "table" then
-        self:setLevelSelectActionState(
-            LEVEL_SELECT_ACTION_STATUS_ERROR,
-            loadError or "The selected map could not be uploaded.",
-            "Upload failed"
-        )
-        return
-    end
-
-    self:closeLevelSelectUploadDialog()
-    self:setLevelSelectActionState(
-        LEVEL_SELECT_ACTION_STATUS_INFO,
-        "Sending your map to the online library.",
-        "Uploading map"
-    )
-    self:beginUploadMapRequest(onlineConfig, mapData, selectedMap)
+    self:uploadMapDescriptor(self:getSelectedLevelMap(), "level_select")
 end
 
 function Game:downloadMarketplaceMap(mapDescriptor)
@@ -3272,6 +3338,15 @@ function Game:processEditorPlaytestRequest()
     end
 end
 
+function Game:processEditorUploadRequest()
+    local descriptor = self.editor:consumeUploadRequest()
+    if not descriptor then
+        return
+    end
+
+    self:uploadMapDescriptor(descriptor, "editor")
+end
+
 function Game:processEditorOpenBlankRequest()
     if not self.editor:consumeOpenBlankMapRequest() then
         return false
@@ -3340,11 +3415,13 @@ function Game:update(dt)
     end
 
     if self.screen == "editor" then
+        self:updateEditorSavedMapActionState()
         self.editor:update(dt)
         if self:processEditorOpenBlankRequest() then
             return
         end
         self:processEditorPlaytestRequest()
+        self:processEditorUploadRequest()
         return
     end
 

--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -1,5 +1,6 @@
 local mapStorage = require("src.game.map_storage")
 local authoredMap = require("src.game.authored_map")
+local json = require("src.game.json")
 local roadTypes = require("src.game.road_types")
 local uuid = require("src.game.uuid")
 local world = require("src.game.world")
@@ -68,6 +69,7 @@ local JUNCTION_MENU_TYPE_ICON_SIZE = 18 * JUNCTION_MENU_SIZE_MULTIPLIER
 local JUNCTION_MENU_SWATCH_RADIUS = 8 * JUNCTION_MENU_SIZE_MULTIPLIER
 local JUNCTION_MENU_EDGE_MARGIN = 8 * JUNCTION_MENU_SIZE_MULTIPLIER
 local EMPTY_MAP_VALIDATION_TEXT = "Draw at least one route before starting this map."
+local UPLOAD_UNAVAILABLE_MESSAGE = "Uploading is currently not possible."
 local ROAD_PATTERN_OUTLINE = { 0.04, 0.05, 0.07, 0.98 }
 local ROAD_PATTERN_FILL = { 0.97, 0.98, 1.0, 0.94 }
 local CONTROL_LABELS = {
@@ -255,6 +257,27 @@ local function buildRouteKey(routeIds)
 
     table.sort(sortedIds)
     return table.concat(sortedIds, "|"), sortedIds
+end
+
+local function buildBlankEditorData()
+    return {
+        mapSize = {
+            w = DEFAULT_NEW_MAP_WIDTH,
+            h = DEFAULT_NEW_MAP_HEIGHT,
+        },
+        timeLimit = nil,
+        endpoints = {},
+        routes = {},
+        junctions = {},
+        trains = {},
+    }
+end
+
+local function isLocalSavedMapDescriptor(descriptor)
+    return descriptor ~= nil
+        and descriptor.source == "user"
+        and descriptor.isRemoteImport ~= true
+        and descriptor.hasLevel == true
 end
 
 local function segmentLength(a, b)
@@ -796,8 +819,12 @@ function mapEditor.new(viewportW, viewportH, level, options)
     self.sourceInfo = nil
     self.lastSavedDescriptor = nil
     self.pendingPlaytestDescriptor = nil
+    self.pendingUploadDescriptor = nil
     self.pendingOpenBlankMap = false
     self.loadedMapPayload = nil
+    self.savedStateSnapshotJson = nil
+    self.savedMapUploadAvailable = false
+    self.savedMapUploadPending = false
     self.lastValidationError = nil
     self.validationErrors = {}
     self.previewWorld = nil
@@ -1578,17 +1605,65 @@ function mapEditor:refreshValidation(mapName)
     return level, buildError, self.validationErrors
 end
 
+function mapEditor:getSavedMapDescriptor()
+    if not isLocalSavedMapDescriptor(self.lastSavedDescriptor) then
+        return nil
+    end
+
+    return self.lastSavedDescriptor
+end
+
+function mapEditor:buildDirtyStateSnapshot()
+    return {
+        name = self.currentMapName,
+        mapUuid = self.editingMapUuid,
+        editor = self:getExportData(),
+    }
+end
+
+function mapEditor:updateSavedStateSnapshot()
+    self.savedStateSnapshotJson = json.encode(self:buildDirtyStateSnapshot())
+end
+
+function mapEditor:hasUnsavedChanges()
+    local savedSnapshotJson = self.savedStateSnapshotJson
+    if not savedSnapshotJson then
+        savedSnapshotJson = json.encode({
+            editor = buildBlankEditorData(),
+        })
+    end
+
+    return json.encode(self:buildDirtyStateSnapshot()) ~= savedSnapshotJson
+end
+
 function mapEditor:canPlaySavedMap()
-    return self.lastSavedDescriptor ~= nil and self.lastSavedDescriptor.hasLevel == true
+    return self:getSavedMapDescriptor() ~= nil and not self:hasUnsavedChanges()
+end
+
+function mapEditor:setSavedMapUploadState(isAvailable, isPending)
+    self.savedMapUploadAvailable = isAvailable == true
+    self.savedMapUploadPending = isPending == true
+end
+
+function mapEditor:canUploadSavedMap()
+    return self:getSavedMapDescriptor() ~= nil
+        and not self:hasUnsavedChanges()
+        and self.savedMapUploadAvailable == true
+        and self.savedMapUploadPending ~= true
 end
 
 function mapEditor:requestPlaytestFromSavedMap()
-    if not self:canPlaySavedMap() then
+    if self:getSavedMapDescriptor() == nil then
         self:showStatus("Save a playable map first, then test it from here.")
         return false
     end
 
-    self.pendingPlaytestDescriptor = self.lastSavedDescriptor
+    if self:hasUnsavedChanges() then
+        self:showStatus("Save the map again before starting the saved version.")
+        return false
+    end
+
+    self.pendingPlaytestDescriptor = self:getSavedMapDescriptor()
     self:showStatus("Starting test run from the saved map...")
     return true
 end
@@ -1596,6 +1671,38 @@ end
 function mapEditor:consumePlaytestRequest()
     local descriptor = self.pendingPlaytestDescriptor
     self.pendingPlaytestDescriptor = nil
+    return descriptor
+end
+
+function mapEditor:requestUploadFromSavedMap()
+    if self:getSavedMapDescriptor() == nil then
+        self:showStatus("Save a playable local map before uploading it.")
+        return false
+    end
+
+    if self:hasUnsavedChanges() then
+        self:showStatus("Save the map again before uploading it.")
+        return false
+    end
+
+    if self.savedMapUploadPending == true then
+        self:showStatus("This map is already uploading.")
+        return false
+    end
+
+    if self.savedMapUploadAvailable ~= true then
+        self:showStatus(UPLOAD_UNAVAILABLE_MESSAGE)
+        return false
+    end
+
+    self.pendingUploadDescriptor = self:getSavedMapDescriptor()
+    self:showStatus("Uploading the saved map...")
+    return true
+end
+
+function mapEditor:consumeUploadRequest()
+    local descriptor = self.pendingUploadDescriptor
+    self.pendingUploadDescriptor = nil
     return descriptor
 end
 
@@ -1675,8 +1782,18 @@ function mapEditor:getPlayTestButtonRect()
     return {
         x = self.sidePanel.x + PANEL_BUTTON_SIDE_MARGIN,
         y = self.sidePanel.y + self.sidePanel.h - (PANEL_BUTTON_BOTTOM_MARGIN + PANEL_BUTTON_HEIGHT * 5 + PANEL_BUTTON_GAP * 4),
-        w = self.sidePanel.w - PANEL_BUTTON_SIDE_MARGIN * 2,
+        w = (self.sidePanel.w - PANEL_BUTTON_SIDE_MARGIN * 2 - PANEL_BUTTON_GAP) * 0.5,
         h = PANEL_BUTTON_HEIGHT,
+    }
+end
+
+function mapEditor:getUploadMapButtonRect()
+    local playRect = self:getPlayTestButtonRect()
+    return {
+        x = playRect.x + playRect.w + PANEL_BUTTON_GAP,
+        y = playRect.y,
+        w = playRect.w,
+        h = playRect.h,
     }
 end
 
@@ -2799,6 +2916,7 @@ function mapEditor:loadEditorData(editorData, mapName, sourceInfo, levelData)
     end
 
     self:rebuildIntersections()
+    self:updateSavedStateSnapshot()
     self:showStatus("Map loaded into the editor.")
 end
 
@@ -2942,10 +3060,12 @@ function mapEditor:saveMap(name)
     self.sourceInfo = record
     self.lastSavedDescriptor = record.hasLevel and record or nil
     self.loadedMapPayload = payload
+    self.pendingUploadDescriptor = nil
     self.hoveredValidationIndex = nil
+    self:updateSavedStateSnapshot()
     self:closeDialog()
     if level then
-        self:showStatus((wasBuiltinTemplate and "Saved copy: " or "Saved map: ") .. trimmedName .. " to " .. mapStorage.getSaveDirectory() .. ". Press Play Saved Map (P) to test.")
+        self:showStatus((wasBuiltinTemplate and "Saved copy: " or "Saved map: ") .. trimmedName .. " to " .. mapStorage.getSaveDirectory() .. ".")
     else
         self:showStatus("Saved map: " .. trimmedName .. ". Remaining issues: " .. buildError)
     end
@@ -2958,6 +3078,7 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
     self.editingMapUuid = mapData and mapData.mapUuid or nil
     self.lastSavedDescriptor = sourceInfo and sourceInfo.hasLevel and sourceInfo or nil
     self.pendingPlaytestDescriptor = nil
+    self.pendingUploadDescriptor = nil
 
     if not mapData then
         self.level = nil
@@ -2988,6 +3109,7 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
         self:updateLayout()
         self:resetCameraToFit()
         self:rebuildIntersections()
+        self:updateSavedStateSnapshot()
         return
     end
 
@@ -3002,6 +3124,7 @@ function mapEditor:resetFromMap(mapData, sourceInfo)
     self:resetFromLevel(mapData.level)
     self.sourceInfo = sourceInfo
     self.loadedMapPayload = mapData
+    self:updateSavedStateSnapshot()
 end
 
 function mapEditor:resetFromLevel(level)
@@ -5013,6 +5136,12 @@ function mapEditor:keypressed(key)
         return true
     end
 
+    if key == "u" then
+        self:commitTextField()
+        self:requestUploadFromSavedMap()
+        return true
+    end
+
     if key == "c" then
         self:commitTextField()
         self.sidePanelMode = self.sidePanelMode == "sequencer" and "default" or "sequencer"
@@ -5083,6 +5212,11 @@ function mapEditor:mousepressed(screenX, screenY, button)
 
         if pointInRect(screenX, screenY, self:getPlayTestButtonRect()) then
             self:requestPlaytestFromSavedMap()
+            return true
+        end
+
+        if pointInRect(screenX, screenY, self:getUploadMapButtonRect()) then
+            self:requestUploadFromSavedMap()
             return true
         end
 
@@ -6723,7 +6857,8 @@ function mapEditor:drawDefaultSidePanel(game)
     end
 
     love.graphics.setFont(game.fonts.small)
-    self:drawPanelButton(self:getPlayTestButtonRect(), "Play Saved Map (P)", { 0.64, 0.86, 0.98 }, not self:canPlaySavedMap())
+    self:drawPanelButton(self:getPlayTestButtonRect(), "Play Map (P)", { 0.64, 0.86, 0.98 }, not self:canPlaySavedMap())
+    self:drawPanelButton(self:getUploadMapButtonRect(), "Upload Map (U)", { 0.99, 0.78, 0.32 }, not self:canUploadSavedMap())
     self:drawPanelButton(self:getSaveButtonRect(), "Save Map (S)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getOpenButtonRect(), "Open Map (O)", { 0.33, 0.8, 0.98 })
     self:drawPanelButton(self:getSequencerButtonRect(), "Train Sequencer (C)", { 0.48, 0.92, 0.62 })

--- a/tests/map_editor_saved_map_actions_test.lua
+++ b/tests/map_editor_saved_map_actions_test.lua
@@ -1,0 +1,104 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+
+local mapEditor = require("src.game.map_editor")
+
+local DEFAULT_MAP_WIDTH = 1920
+local DEFAULT_MAP_HEIGHT = 1080
+local CHANGED_TIME_LIMIT = 30
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function assertFalse(value, label)
+    if value then
+        error(label, 2)
+    end
+end
+
+local savedMapData = {
+    name = "Saved Map",
+    mapUuid = "saved-map-uuid",
+    editor = {
+        mapSize = {
+            w = DEFAULT_MAP_WIDTH,
+            h = DEFAULT_MAP_HEIGHT,
+        },
+        timeLimit = nil,
+        endpoints = {},
+        routes = {},
+        junctions = {},
+        trains = {},
+    },
+    level = {
+        title = "Saved Map",
+        edges = {
+            {
+                id = "edge_1",
+                colors = { "blue" },
+            },
+        },
+        trains = {
+            {
+                id = "train_1",
+                edgeId = "edge_1",
+                goalColor = "blue",
+            },
+        },
+    },
+}
+
+local savedDescriptor = {
+    source = "user",
+    isRemoteImport = false,
+    hasLevel = true,
+    mapUuid = savedMapData.mapUuid,
+}
+
+local editor = mapEditor.new(DEFAULT_MAP_WIDTH, DEFAULT_MAP_HEIGHT, nil)
+editor:resetFromMap(savedMapData, savedDescriptor)
+editor:setSavedMapUploadState(true, false)
+
+assertFalse(editor:hasUnsavedChanges(), "freshly loaded saved maps should start clean")
+assertTrue(editor:canPlaySavedMap(), "clean saved maps should be playable")
+assertTrue(editor:canUploadSavedMap(), "clean saved maps should be uploadable when upload is available")
+
+editor:resetFromMap(savedMapData, savedDescriptor)
+
+assertFalse(editor:hasUnsavedChanges(), "reloading the same saved map should stay clean after editor state reconstruction")
+
+editor.timeLimit = CHANGED_TIME_LIMIT
+
+assertTrue(editor:hasUnsavedChanges(), "editor changes should mark the saved map state dirty")
+assertFalse(editor:canPlaySavedMap(), "dirty saved maps should not be playable until saved again")
+assertFalse(editor:canUploadSavedMap(), "dirty saved maps should not be uploadable until saved again")
+assertFalse(editor:requestUploadFromSavedMap(), "upload requests should be rejected for dirty saved maps")
+
+editor:resetFromMap(savedMapData, savedDescriptor)
+editor:setSavedMapUploadState(false, false)
+
+assertFalse(editor:requestUploadFromSavedMap(), "upload requests should be rejected when upload is unavailable")
+assertTrue(editor.statusText == "Uploading is currently not possible.", "upload unavailability should use the generic status message")
+
+editor:resetFromMap(savedMapData, {
+    source = "builtin",
+    isRemoteImport = false,
+    hasLevel = true,
+    mapUuid = savedMapData.mapUuid,
+})
+editor:setSavedMapUploadState(true, false)
+
+assertFalse(editor:canPlaySavedMap(), "builtin maps should not count as playable saved maps in the editor")
+assertFalse(editor:canUploadSavedMap(), "builtin maps should not count as uploadable saved maps in the editor")
+
+print("map editor saved map action tests passed")


### PR DESCRIPTION
### Requested Behavior
- Add saved-map play support after saving a map.
- Split the saved map action into `Play Map` and `Upload Map` buttons.
- Allow upload only for saved maps with local env config present.
- Gray out play and upload again after any editor change until the map is saved again.
- Hide the missing-env detail from the editor upload message.

### Summary
- Added saved-state tracking in the editor so play and upload stay disabled when the map is dirty.
- Split the editor action row into half-width play and upload buttons.
- Routed editor uploads through the existing upload pipeline with editor-specific status handling.
- Kept upload availability generic in the editor when local config is missing.

### Testing
- `love tests/love_runner tests/map_editor_saved_map_actions_test.lua`
- `love tests/love_runner tests/map_editor_sequencer_click_consumption_test.lua`