### PR TITLE
Add a map editor hitbox overlay toggle

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -48,6 +48,23 @@ local PANEL_BUTTON_GAP = 12
 local PANEL_BUTTON_BOTTOM_MARGIN = 22
 local STATUS_TOAST_MARGIN = 18
 local STATUS_TOAST_FADE_TIME = 0.35
+local POINT_HIT_RADIUS = 12
+local INTERSECTION_HIT_RADIUS = 22
+local INTERSECTION_UNSUPPORTED_HIT_RADIUS = 18
+local SEGMENT_HIT_RADIUS = 16
+local SEGMENT_HIT_MIN_T = 0.08
+local SEGMENT_HIT_MAX_T = 0.92
+local HITBOX_OVERLAY_FILL_ALPHA = 0.18
+local HITBOX_OVERLAY_OUTLINE_ALPHA = 0.94
+local HITBOX_OVERLAY_LABEL_BACKGROUND_ALPHA = 0.92
+local HITBOX_OVERLAY_LABEL_TEXT_ALPHA = 0.98
+local HITBOX_OVERLAY_LABEL_OFFSET_Y = 22
+local HITBOX_OVERLAY_LABEL_PADDING_X = 6
+local HITBOX_OVERLAY_LABEL_PADDING_Y = 4
+local HITBOX_OVERLAY_LABEL_CORNER_RADIUS = 6
+local HITBOX_OVERLAY_RECT_CORNER_RADIUS = 6
+local HITBOX_OVERLAY_STROKE_WIDTH = 2
+local HITBOX_OVERLAY_EPSILON = 0.0001
 local DRAG_START_DISTANCE_SQUARED = 25
 local INTERSECTION_SELECTOR_OFFSET_Y = 36
 local INTERSECTION_SELECTOR_CLICK_RADIUS = 16
@@ -213,6 +230,10 @@ local function distanceSquared(ax, ay, bx, by)
     local dx = ax - bx
     local dy = ay - by
     return dx * dx + dy * dy
+end
+
+local function lerp(a, b, t)
+    return a + (b - a) * t
 end
 
 local function copyPoint(point)
@@ -833,6 +854,7 @@ function mapEditor.new(viewportW, viewportH, level, options)
     self.validationScroll = 0
     self.validationScrollDrag = nil
     self.validationColorDisplayMode = "swatch"
+    self.hitboxOverlayVisible = false
 
     self:updateLayout()
     self:resetCameraToFit()
@@ -1690,11 +1712,23 @@ function mapEditor:getSequencerButtonRect()
 end
 
 function mapEditor:getResetButtonRect()
+    local fullWidth = self.sidePanel.w - PANEL_BUTTON_SIDE_MARGIN * 2
+    local buttonWidth = (fullWidth - PANEL_BUTTON_GAP) * 0.5
     return {
         x = self.sidePanel.x + PANEL_BUTTON_SIDE_MARGIN,
         y = self.sidePanel.y + self.sidePanel.h - (PANEL_BUTTON_BOTTOM_MARGIN + PANEL_BUTTON_HEIGHT * 2 + PANEL_BUTTON_GAP),
-        w = self.sidePanel.w - PANEL_BUTTON_SIDE_MARGIN * 2,
+        w = buttonWidth,
         h = PANEL_BUTTON_HEIGHT,
+    }
+end
+
+function mapEditor:getHitboxToggleRect()
+    local resetRect = self:getResetButtonRect()
+    return {
+        x = resetRect.x + resetRect.w + PANEL_BUTTON_GAP,
+        y = resetRect.y,
+        w = resetRect.w,
+        h = resetRect.h,
     }
 end
 
@@ -3185,9 +3219,9 @@ function mapEditor:update(dt)
 end
 
 function mapEditor:findIntersectionHit(x, y)
-    local radiusScale = 1 / math.max(self.camera.zoom, 0.0001)
+    local radiusScale = 1 / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
     for _, intersection in ipairs(self.intersections) do
-        local radius = (intersection.unsupported and 18 or 22) * radiusScale
+        local radius = (intersection.unsupported and INTERSECTION_UNSUPPORTED_HIT_RADIUS or INTERSECTION_HIT_RADIUS) * radiusScale
         if distanceSquared(x, y, intersection.x, intersection.y) <= radius * radius then
             return intersection
         end
@@ -3210,7 +3244,7 @@ function mapEditor:getMagnetHitRect(point, magnetKind)
 end
 
 function mapEditor:findPointHit(x, y)
-    local radiusScale = 1 / math.max(self.camera.zoom, 0.0001)
+    local radiusScale = 1 / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
     for routeIndex = #self.routes, 1, -1 do
         local route = self.routes[routeIndex]
         for pointIndex = #route.points, 1, -1 do
@@ -3229,7 +3263,7 @@ function mapEditor:findPointHit(x, y)
                 if isMagnet then
                     hit = pointInRect(x, y, self:getMagnetHitRect(point, magnetKind))
                 else
-                    local radius = 12 * radiusScale
+                    local radius = POINT_HIT_RADIUS * radiusScale
                     hit = distanceSquared(x, y, point.x, point.y) <= radius * radius
                 end
 
@@ -3461,7 +3495,7 @@ end
 
 function mapEditor:findSegmentHit(x, y)
     local bestHit = nil
-    local segmentRadius = 16 / math.max(self.camera.zoom, 0.0001)
+    local segmentRadius = SEGMENT_HIT_RADIUS / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
     local bestDistance = segmentRadius * segmentRadius
 
     for routeIndex = #self.routes, 1, -1 do
@@ -3471,7 +3505,7 @@ function mapEditor:findSegmentHit(x, y)
             local b = route.points[pointIndex + 1]
             local closestX, closestY, t, distance = closestPointOnSegment(x, y, a, b)
 
-            if distance < bestDistance and t > 0.08 and t < 0.92 then
+            if distance < bestDistance and t > SEGMENT_HIT_MIN_T and t < SEGMENT_HIT_MAX_T then
                 bestDistance = distance
                 bestHit = {
                     route = route,
@@ -3484,6 +3518,167 @@ function mapEditor:findSegmentHit(x, y)
     end
 
     return bestHit
+end
+
+function mapEditor:getPointHitRadius()
+    return POINT_HIT_RADIUS / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
+end
+
+function mapEditor:getIntersectionHitRadius(intersection)
+    local baseRadius = intersection and intersection.unsupported and INTERSECTION_UNSUPPORTED_HIT_RADIUS or INTERSECTION_HIT_RADIUS
+    return baseRadius / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
+end
+
+function mapEditor:getOutputSelectorHitRect(intersection)
+    return {
+        x = intersection.x - INTERSECTION_SELECTOR_CLICK_RADIUS,
+        y = intersection.y + INTERSECTION_SELECTOR_OFFSET_Y - INTERSECTION_SELECTOR_CLICK_RADIUS,
+        w = INTERSECTION_SELECTOR_CLICK_RADIUS * 2,
+        h = INTERSECTION_SELECTOR_CLICK_RADIUS * 2,
+    }
+end
+
+function mapEditor:getRouteDebugName(route)
+    local routeName = tostring(route and (route.label or route.id) or "")
+    if routeName == "" then
+        return "route"
+    end
+    return routeName
+end
+
+function mapEditor:getHitboxOverlayColor(index)
+    local option = COLOR_OPTIONS[((index - 1) % #COLOR_OPTIONS) + 1]
+    return option and option.color or COLOR_OPTIONS[1].color
+end
+
+function mapEditor:buildSegmentHitboxPolygon(pointA, pointB)
+    local dx = pointB.x - pointA.x
+    local dy = pointB.y - pointA.y
+    local length = math.sqrt(dx * dx + dy * dy)
+
+    if length <= HITBOX_OVERLAY_EPSILON then
+        return nil
+    end
+
+    local startX = lerp(pointA.x, pointB.x, SEGMENT_HIT_MIN_T)
+    local startY = lerp(pointA.y, pointB.y, SEGMENT_HIT_MIN_T)
+    local endX = lerp(pointA.x, pointB.x, SEGMENT_HIT_MAX_T)
+    local endY = lerp(pointA.y, pointB.y, SEGMENT_HIT_MAX_T)
+    local normalX = -dy / length
+    local normalY = dx / length
+    local halfWidth = SEGMENT_HIT_RADIUS / math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
+
+    return {
+        points = {
+            startX + normalX * halfWidth, startY + normalY * halfWidth,
+            endX + normalX * halfWidth, endY + normalY * halfWidth,
+            endX - normalX * halfWidth, endY - normalY * halfWidth,
+            startX - normalX * halfWidth, startY - normalY * halfWidth,
+        },
+        labelX = (startX + endX) * 0.5,
+        labelY = (startY + endY) * 0.5,
+    }
+end
+
+function mapEditor:getHitboxOverlayEntries()
+    local entries = {}
+
+    for routeIndex = #self.routes, 1, -1 do
+        local route = self.routes[routeIndex]
+        local routeName = self:getRouteDebugName(route)
+
+        for pointIndex = #route.points, 1, -1 do
+            local point = route.points[pointIndex]
+            local isMagnet = pointIndex == 1 or pointIndex == #route.points
+            local isSharedJunctionPoint = not isMagnet and point.sharedPointId and self:getSharedPointGroupForPoint(route, pointIndex)
+
+            if not isSharedJunctionPoint then
+                local label = nil
+                local rect = nil
+
+                if pointIndex == 1 then
+                    rect = self:getMagnetHitRect(point, "start")
+                    label = string.format("%s start", routeName)
+                elseif pointIndex == #route.points then
+                    rect = self:getMagnetHitRect(point, "end")
+                    label = string.format("%s end", routeName)
+                else
+                    local radius = self:getPointHitRadius()
+                    rect = {
+                        x = point.x - radius,
+                        y = point.y - radius,
+                        w = radius * 2,
+                        h = radius * 2,
+                    }
+                    label = string.format("%s bend %d", routeName, pointIndex)
+                end
+
+                entries[#entries + 1] = {
+                    kind = "rect",
+                    rect = rect,
+                    label = label,
+                    labelX = rect.x + rect.w * 0.5,
+                    labelY = rect.y + rect.h * 0.5,
+                }
+            end
+        end
+    end
+
+    for _, intersection in ipairs(self.intersections) do
+        if self:isIntersectionOutputSelectorHit(intersection, intersection.x, intersection.y + INTERSECTION_SELECTOR_OFFSET_Y) then
+            local rect = self:getOutputSelectorHitRect(intersection)
+            entries[#entries + 1] = {
+                kind = "rect",
+                rect = rect,
+                label = string.format("%s output", tostring(intersection.routeKey or intersection.id or "junction")),
+                labelX = rect.x + rect.w * 0.5,
+                labelY = rect.y + rect.h * 0.5,
+            }
+        end
+    end
+
+    for _, intersection in ipairs(self.intersections) do
+        local radius = self:getIntersectionHitRadius(intersection)
+        entries[#entries + 1] = {
+            kind = "rect",
+            rect = {
+                x = intersection.x - radius,
+                y = intersection.y - radius,
+                w = radius * 2,
+                h = radius * 2,
+            },
+            label = string.format("%s %s", tostring(intersection.routeKey or intersection.id or "junction"), intersection.controlType or "junction"),
+            labelX = intersection.x,
+            labelY = intersection.y,
+        }
+    end
+
+    for routeIndex = #self.routes, 1, -1 do
+        local route = self.routes[routeIndex]
+        local routeName = self:getRouteDebugName(route)
+
+        for segmentIndex = 1, #route.points - 1 do
+            local polygon = self:buildSegmentHitboxPolygon(route.points[segmentIndex], route.points[segmentIndex + 1])
+            if polygon then
+                entries[#entries + 1] = {
+                    kind = "polygon",
+                    points = polygon.points,
+                    label = string.format("%s segment %d", routeName, segmentIndex),
+                    labelX = polygon.labelX,
+                    labelY = polygon.labelY,
+                }
+            end
+        end
+    end
+
+    local totalEntries = #entries
+    for index, entry in ipairs(entries) do
+        entry.zIndex = totalEntries - index + 1
+        entry.color = self:getHitboxOverlayColor(index)
+        entry.label = string.format("Z%d %s", entry.zIndex, entry.label)
+    end
+
+    return entries
 end
 
 function mapEditor:deleteSelection()
@@ -5026,6 +5221,12 @@ function mapEditor:keypressed(key)
         return true
     end
 
+    if key == "f3" then
+        self.hitboxOverlayVisible = not self.hitboxOverlayVisible
+        self:showStatus(self.hitboxOverlayVisible and "Hitbox overlay shown." or "Hitbox overlay hidden.")
+        return true
+    end
+
     return false
 end
 
@@ -5094,6 +5295,12 @@ function mapEditor:mousepressed(screenX, screenY, button)
 
         if pointInRect(screenX, screenY, self:getResetButtonRect()) then
             self:openResetDialog()
+            return true
+        end
+
+        if pointInRect(screenX, screenY, self:getHitboxToggleRect()) then
+            self.hitboxOverlayVisible = not self.hitboxOverlayVisible
+            self:showStatus(self.hitboxOverlayVisible and "Hitbox overlay shown." or "Hitbox overlay hidden.")
             return true
         end
 
@@ -5853,6 +6060,13 @@ function mapEditor:drawPanelButton(rect, label, accentColor, isDisabled)
     graphics.printf(label, rect.x, rect.y + math.floor((rect.h - font:getHeight()) * 0.5), rect.w, "center")
 end
 
+function mapEditor:drawHitboxToggle(game)
+    local graphics = love.graphics
+    local rect = self:getHitboxToggleRect()
+    local accentColor = self.hitboxOverlayVisible and { 0.48, 0.92, 0.62 } or { 0.36, 0.42, 0.5 }
+    self:drawPanelButton(rect, "Hitboxes (F3)", accentColor)
+end
+
 function mapEditor:drawGrid()
     if not self.gridVisible then
         return
@@ -6179,6 +6393,88 @@ function mapEditor:drawValidationMarkers()
                 end
             end
         end
+    end
+end
+
+function mapEditor:drawHitboxOverlay(game)
+    if not self.hitboxOverlayVisible then
+        return
+    end
+
+    local graphics = love.graphics
+    local font = game.fonts.small
+    local zoom = math.max(self.camera.zoom, HITBOX_OVERLAY_EPSILON)
+    local inverseZoom = 1 / zoom
+
+    love.graphics.setFont(font)
+
+    for _, entry in ipairs(self:getHitboxOverlayEntries()) do
+        local color = entry.color
+
+        graphics.setColor(color[1], color[2], color[3], HITBOX_OVERLAY_FILL_ALPHA)
+        if entry.kind == "polygon" then
+            graphics.polygon("fill", entry.points)
+        else
+            graphics.rectangle(
+                "fill",
+                entry.rect.x,
+                entry.rect.y,
+                entry.rect.w,
+                entry.rect.h,
+                HITBOX_OVERLAY_RECT_CORNER_RADIUS,
+                HITBOX_OVERLAY_RECT_CORNER_RADIUS
+            )
+        end
+
+        graphics.setColor(color[1], color[2], color[3], HITBOX_OVERLAY_OUTLINE_ALPHA)
+        graphics.setLineWidth(HITBOX_OVERLAY_STROKE_WIDTH * inverseZoom)
+        if entry.kind == "polygon" then
+            graphics.polygon("line", entry.points)
+        else
+            graphics.rectangle(
+                "line",
+                entry.rect.x,
+                entry.rect.y,
+                entry.rect.w,
+                entry.rect.h,
+                HITBOX_OVERLAY_RECT_CORNER_RADIUS,
+                HITBOX_OVERLAY_RECT_CORNER_RADIUS
+            )
+        end
+
+        local labelWidth = font:getWidth(entry.label) + HITBOX_OVERLAY_LABEL_PADDING_X * 2
+        local labelHeight = font:getHeight() + HITBOX_OVERLAY_LABEL_PADDING_Y * 2
+
+        graphics.push()
+        graphics.translate(entry.labelX, entry.labelY)
+        graphics.scale(inverseZoom, inverseZoom)
+        graphics.setColor(0.05, 0.06, 0.08, HITBOX_OVERLAY_LABEL_BACKGROUND_ALPHA)
+        graphics.rectangle(
+            "fill",
+            -labelWidth * 0.5,
+            -HITBOX_OVERLAY_LABEL_OFFSET_Y - labelHeight,
+            labelWidth,
+            labelHeight,
+            HITBOX_OVERLAY_LABEL_CORNER_RADIUS,
+            HITBOX_OVERLAY_LABEL_CORNER_RADIUS
+        )
+        graphics.setColor(color[1], color[2], color[3], HITBOX_OVERLAY_OUTLINE_ALPHA)
+        graphics.rectangle(
+            "line",
+            -labelWidth * 0.5,
+            -HITBOX_OVERLAY_LABEL_OFFSET_Y - labelHeight,
+            labelWidth,
+            labelHeight,
+            HITBOX_OVERLAY_LABEL_CORNER_RADIUS,
+            HITBOX_OVERLAY_LABEL_CORNER_RADIUS
+        )
+        graphics.setColor(0.97, 0.98, 1, HITBOX_OVERLAY_LABEL_TEXT_ALPHA)
+        graphics.print(
+            entry.label,
+            -labelWidth * 0.5 + HITBOX_OVERLAY_LABEL_PADDING_X,
+            -HITBOX_OVERLAY_LABEL_OFFSET_Y - labelHeight + HITBOX_OVERLAY_LABEL_PADDING_Y
+        )
+        graphics.pop()
     end
 end
 
@@ -6728,6 +7024,7 @@ function mapEditor:drawDefaultSidePanel(game)
     self:drawPanelButton(self:getOpenButtonRect(), "Open Map (O)", { 0.33, 0.8, 0.98 })
     self:drawPanelButton(self:getSequencerButtonRect(), "Train Sequencer (C)", { 0.48, 0.92, 0.62 })
     self:drawPanelButton(self:getResetButtonRect(), "Reset (R)", { 0.99, 0.78, 0.32 })
+    self:drawHitboxToggle(game)
     self:drawPanelButton(self:getOpenUserMapsButtonRect(), "Open User Maps Folder", { 0.98, 0.82, 0.34 })
 end
 
@@ -6767,6 +7064,8 @@ function mapEditor:draw(game)
     for _, route in ipairs(self.routes) do
         self:drawRouteHandles(route, self.selectedRouteId)
     end
+
+    self:drawHitboxOverlay(game)
 
     graphics.pop()
 

--- a/tests/map_editor_hitbox_overlay_test.lua
+++ b/tests/map_editor_hitbox_overlay_test.lua
@@ -1,0 +1,108 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_a", kind = "input", x = 636 / 1280, y = 400 / 720, colors = { "blue" } },
+        { id = "output_a", kind = "output", x = 644 / 1280, y = 400 / 720, colors = { "blue" } },
+        { id = "input_b", kind = "input", x = 636 / 1280, y = 360 / 720, colors = { "orange" } },
+        { id = "output_b", kind = "output", x = 644 / 1280, y = 360 / 720, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_a",
+            label = "route_a",
+            color = "blue",
+            startEndpointId = "input_a",
+            endEndpointId = "output_a",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 636 / 1280, y = 400 / 720 },
+                { x = 640 / 1280, y = 360 / 720 },
+                { x = 644 / 1280, y = 400 / 720 },
+            },
+        },
+        {
+            id = "route_b",
+            label = "route_b",
+            color = "orange",
+            startEndpointId = "input_b",
+            endEndpointId = "output_b",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 636 / 1280, y = 360 / 720 },
+                { x = 640 / 1280, y = 400 / 720 },
+                { x = 644 / 1280, y = 360 / 720 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Hitbox Overlay", nil, nil)
+
+local resetRect = editor:getResetButtonRect()
+local toggleRect = editor:getHitboxToggleRect()
+assertEqual(resetRect.w, toggleRect.w, "reset and hitbox toggle should split the bottom row evenly")
+assertTrue(toggleRect.x > resetRect.x + resetRect.w, "hitbox toggle should sit to the right of reset")
+
+assertEqual(editor.hitboxOverlayVisible, false, "hitbox overlay starts hidden")
+assertTrue(editor:keypressed("f3"), "f3 should be handled by the editor")
+assertEqual(editor.hitboxOverlayVisible, true, "f3 enables the hitbox overlay")
+
+local entries = editor:getHitboxOverlayEntries()
+assertTrue(#entries > 0, "hitbox overlay should expose entries for the current map")
+assertTrue(entries[1].zIndex > entries[#entries].zIndex, "overlay z-indices should descend through hit order")
+assertTrue(entries[1].label:find("route_b end", 1, true) ~= nil, "top hitbox should match the last route end magnet")
+
+local sawSegment = false
+local sawIntersection = false
+for _, entry in ipairs(entries) do
+    if entry.label:find("segment", 1, true) then
+        sawSegment = true
+    end
+    if entry.label:find("direct", 1, true) then
+        sawIntersection = true
+    end
+end
+
+assertTrue(sawSegment, "overlay should include segment hitboxes")
+assertTrue(sawIntersection, "overlay should include junction hitboxes")
+
+assertTrue(editor:keypressed("f3"), "f3 should also disable the hitbox overlay")
+assertEqual(editor.hitboxOverlayVisible, false, "f3 disables the hitbox overlay")
+
+print("map editor hitbox overlay tests passed")


### PR DESCRIPTION
## Requested Behavior
- Add an `F3` hitbox overlay in the map editor without creating a new tab.
- Show the overlay as on-canvas boxes with distinct colors and clear z-order.
- Keep the control in the editor UI as a toggle so users can see whether hitboxes are on or off.

## Summary
- Added an `F3` toggle and a bottom-panel hitbox button in the map editor.
- Rendered hitbox overlays for route points, segments, intersections, and output selectors with z-order labeling.
- Split the reset row to make room for the new hitbox toggle and kept the button styling consistent with the existing editor controls.

## Testing
- Not run (not requested)