### PR TITLE
Fix road state rendering and junction drag interactions

### DIFF
--- a/src/game/map_editor.lua
+++ b/src/game/map_editor.lua
@@ -52,9 +52,12 @@ local STATUS_TOAST_FADE_TIME = 0.35
 local POINT_HIT_RADIUS = 12
 local INTERSECTION_HIT_RADIUS = 22
 local INTERSECTION_UNSUPPORTED_HIT_RADIUS = 18
+local MAGNET_HIT_RADIUS = 18
 local SEGMENT_HIT_RADIUS = 16
-local SEGMENT_HIT_MIN_T = 0.08
-local SEGMENT_HIT_MAX_T = 0.92
+local SEGMENT_HIT_MIN_HALF_WIDTH = 8
+local SEGMENT_HIT_HALF_WIDTH_RATIO = 0.3
+local SEGMENT_HIT_MIN_INSET = 4
+local SEGMENT_HIT_INSET_RATIO = 0.22
 local HITBOX_OVERLAY_FILL_ALPHA = 0.18
 local HITBOX_OVERLAY_OUTLINE_ALPHA = 0.94
 local HITBOX_OVERLAY_LABEL_BACKGROUND_ALPHA = 0.92
@@ -74,6 +77,7 @@ local INTERSECTION_POINT_TOLERANCE_SQUARED = 9
 local INTERNAL_POINT_MATCH_DISTANCE_SQUARED = 1
 local INTERSECTION_SHARED_POINT_DISTANCE_SQUARED = 12 * 12
 local INTERSECTION_STATE_MATCH_DISTANCE_SQUARED = 24 * 24
+local MAX_INTERSECTION_MATERIALIZE_PASSES = 3
 local JUNCTION_MENU_SIZE_MULTIPLIER = 1.5
 local JUNCTION_MENU_POP_DURATION = 0.14
 local JUNCTION_MENU_ROOT_RADIUS = 36 * JUNCTION_MENU_SIZE_MULTIPLIER
@@ -3352,17 +3356,8 @@ function mapEditor:findIntersectionHit(x, y)
     return nil
 end
 
-function mapEditor:getMagnetHitRect(point, magnetKind)
-    local width = magnetKind == "start" and 58 or 46
-    local height = 24
-    local padding = 8
-
-    return {
-        x = point.x - width * 0.5 - padding,
-        y = point.y - height * 0.5 - padding,
-        w = width + padding * 2,
-        h = height + padding * 2,
-    }
+function mapEditor:getMagnetHitRadius()
+    return MAGNET_HIT_RADIUS
 end
 
 function mapEditor:findPointHit(x, y)
@@ -3382,7 +3377,8 @@ function mapEditor:findPointHit(x, y)
 
                 local hit = false
                 if isMagnet then
-                    hit = pointInRect(x, y, self:getMagnetHitRect(point, magnetKind))
+                    local radius = self:getMagnetHitRadius()
+                    hit = distanceSquared(x, y, point.x, point.y) <= radius * radius
                 else
                     local radius = self:getPointHitRadius()
                     hit = distanceSquared(x, y, point.x, point.y) <= radius * radius
@@ -3405,7 +3401,9 @@ function mapEditor:findBendPointAt(x, y, excludeRouteId, excludePointIndex)
         local route = self.routes[routeIndex]
         for pointIndex = #route.points - 1, 2, -1 do
             local point = route.points[pointIndex]
+            local isSharedJunctionPoint = point.sharedPointId and self:getSharedPointGroupForPoint(route, pointIndex)
             if not (route.id == excludeRouteId and pointIndex == excludePointIndex)
+                and not isSharedJunctionPoint
                 and distanceSquared(x, y, point.x, point.y) <= radiusSquared then
                 return route, pointIndex, point
             end
@@ -3525,6 +3523,54 @@ function mapEditor:updateSharedPointGroup(sharedPointId, x, y)
             end
         end
     end
+
+    self:collapseRoutesForSharedPoint(sharedPointId)
+end
+
+function mapEditor:pruneSharedPointFromRoutes(sharedPointId, preservedRouteIds)
+    if not sharedPointId then
+        return
+    end
+
+    local preservedLookup = {}
+    for _, routeId in ipairs(preservedRouteIds or {}) do
+        preservedLookup[routeId] = true
+    end
+
+    for _, route in ipairs(self.routes) do
+        if not preservedLookup[route.id] then
+            for pointIndex = #route.points - 1, 2, -1 do
+                local point = route.points[pointIndex]
+                if point.sharedPointId == sharedPointId then
+                    table.remove(route.points, pointIndex)
+                    self:mergeRouteSegmentStyle(route, pointIndex)
+                end
+            end
+        end
+    end
+end
+
+function mapEditor:collapseRoutesForSharedPoint(sharedPointId)
+    if not sharedPointId then
+        return
+    end
+
+    for _, route in ipairs(self.routes) do
+        local pointIndex = 2
+        while pointIndex <= #route.points - 1 do
+            local point = route.points[pointIndex]
+            local previousPoint = route.points[pointIndex - 1]
+
+            if point.sharedPointId == sharedPointId
+                and previousPoint
+                and distanceSquared(point.x, point.y, previousPoint.x, previousPoint.y) <= INTERNAL_POINT_MATCH_DISTANCE_SQUARED then
+                table.remove(route.points, pointIndex)
+                self:mergeRouteSegmentStyle(route, pointIndex)
+            else
+                pointIndex = pointIndex + 1
+            end
+        end
+    end
 end
 
 function mapEditor:restoreSharedPointsForRoutes(routeIds)
@@ -3616,17 +3662,21 @@ end
 
 function mapEditor:findSegmentHit(x, y)
     local bestHit = nil
-    local segmentRadius = SEGMENT_HIT_RADIUS
-    local bestDistance = segmentRadius * segmentRadius
+    local bestDistance = SEGMENT_HIT_RADIUS * SEGMENT_HIT_RADIUS
 
     for routeIndex = #self.routes, 1, -1 do
         local route = self.routes[routeIndex]
         for pointIndex = 1, #route.points - 1 do
             local a = route.points[pointIndex]
             local b = route.points[pointIndex + 1]
+            local metrics = self:getSegmentHitMetrics(route, pointIndex)
             local closestX, closestY, t, distance = closestPointOnSegment(x, y, a, b)
+            local projectionDistance = metrics.length * t
 
-            if distance < bestDistance and t > SEGMENT_HIT_MIN_T and t < SEGMENT_HIT_MAX_T then
+            if distance < bestDistance
+                and distance <= metrics.halfWidth * metrics.halfWidth
+                and projectionDistance > metrics.startInset
+                and projectionDistance < metrics.length - metrics.endInset then
                 bestDistance = distance
                 bestHit = {
                     route = route,
@@ -3647,6 +3697,9 @@ end
 
 function mapEditor:getIntersectionHitRadius(intersection)
     local baseRadius = intersection and intersection.unsupported and INTERSECTION_UNSUPPORTED_HIT_RADIUS or INTERSECTION_HIT_RADIUS
+    if not (intersection and intersection.unsupported) and self.previewWorld and self.previewWorld.crossingRadius then
+        baseRadius = math.max(INTERSECTION_HIT_RADIUS, self.previewWorld.crossingRadius - 4)
+    end
     return baseRadius
 end
 
@@ -3672,22 +3725,27 @@ function mapEditor:getHitboxOverlayColor(index)
     return option and option.color or COLOR_OPTIONS[1].color
 end
 
-function mapEditor:buildSegmentHitboxPolygon(pointA, pointB)
+function mapEditor:buildSegmentHitboxPolygon(route, segmentIndex)
+    local pointA = route.points[segmentIndex]
+    local pointB = route.points[segmentIndex + 1]
     local dx = pointB.x - pointA.x
     local dy = pointB.y - pointA.y
-    local length = math.sqrt(dx * dx + dy * dy)
+    local metrics = self:getSegmentHitMetrics(route, segmentIndex)
+    local length = metrics.length
 
-    if length <= HITBOX_OVERLAY_EPSILON then
+    if length <= HITBOX_OVERLAY_EPSILON or metrics.startInset + metrics.endInset >= length - HITBOX_OVERLAY_EPSILON then
         return nil
     end
 
-    local startX = lerp(pointA.x, pointB.x, SEGMENT_HIT_MIN_T)
-    local startY = lerp(pointA.y, pointB.y, SEGMENT_HIT_MIN_T)
-    local endX = lerp(pointA.x, pointB.x, SEGMENT_HIT_MAX_T)
-    local endY = lerp(pointA.y, pointB.y, SEGMENT_HIT_MAX_T)
+    local startRatio = metrics.startInset / length
+    local endRatio = (length - metrics.endInset) / length
+    local startX = lerp(pointA.x, pointB.x, startRatio)
+    local startY = lerp(pointA.y, pointB.y, startRatio)
+    local endX = lerp(pointA.x, pointB.x, endRatio)
+    local endY = lerp(pointA.y, pointB.y, endRatio)
     local normalX = -dy / length
     local normalY = dx / length
-    local halfWidth = SEGMENT_HIT_RADIUS
+    local halfWidth = metrics.halfWidth
 
     return {
         points = {
@@ -3698,6 +3756,52 @@ function mapEditor:buildSegmentHitboxPolygon(pointA, pointB)
         },
         labelX = (startX + endX) * 0.5,
         labelY = (startY + endY) * 0.5,
+    }
+end
+
+function mapEditor:getSegmentEndpointInset(route, pointIndex)
+    local point = route and route.points and route.points[pointIndex] or nil
+    if not point then
+        return 0
+    end
+
+    if pointIndex == 1 or pointIndex == #route.points then
+        return self:getMagnetHitRadius()
+    end
+
+    if point.sharedPointId then
+        local _, intersection = self:getSharedPointGroupForPoint(route, pointIndex)
+        if intersection then
+            return self:getIntersectionHitRadius(intersection)
+        end
+    end
+
+    return self:getPointHitRadius()
+end
+
+function mapEditor:getSegmentHitMetrics(route, segmentIndex)
+    local pointA = route.points[segmentIndex]
+    local pointB = route.points[segmentIndex + 1]
+    local dx = pointB.x - pointA.x
+    local dy = pointB.y - pointA.y
+    local length = math.sqrt(dx * dx + dy * dy)
+    local halfWidth = math.min(SEGMENT_HIT_RADIUS, math.max(SEGMENT_HIT_MIN_HALF_WIDTH, length * SEGMENT_HIT_HALF_WIDTH_RATIO))
+    local defaultInset = math.max(SEGMENT_HIT_MIN_INSET, math.min(SEGMENT_HIT_RADIUS, length * SEGMENT_HIT_INSET_RATIO))
+    local startInset = math.max(defaultInset, self:getSegmentEndpointInset(route, segmentIndex))
+    local endInset = math.max(defaultInset, self:getSegmentEndpointInset(route, segmentIndex + 1))
+    local maxInsetSum = math.max(length - HITBOX_OVERLAY_EPSILON, 0)
+
+    if startInset + endInset > maxInsetSum and maxInsetSum > 0 then
+        local scale = maxInsetSum / (startInset + endInset)
+        startInset = startInset * scale
+        endInset = endInset * scale
+    end
+
+    return {
+        length = length,
+        halfWidth = halfWidth,
+        startInset = startInset,
+        endInset = endInset,
     }
 end
 
@@ -3715,32 +3819,44 @@ function mapEditor:getHitboxOverlayEntries()
 
             if not isSharedJunctionPoint then
                 local label = nil
-                local rect = nil
+                local entry = nil
 
                 if pointIndex == 1 then
-                    rect = self:getMagnetHitRect(point, "start")
+                    local radius = self:getMagnetHitRadius()
+                    entry = {
+                        kind = "circle",
+                        x = point.x,
+                        y = point.y,
+                        radius = radius,
+                    }
                     label = string.format("%s start", routeName)
                 elseif pointIndex == #route.points then
-                    rect = self:getMagnetHitRect(point, "end")
+                    local radius = self:getMagnetHitRadius()
+                    entry = {
+                        kind = "circle",
+                        x = point.x,
+                        y = point.y,
+                        radius = radius,
+                    }
                     label = string.format("%s end", routeName)
                 else
                     local radius = self:getPointHitRadius()
-                    rect = {
-                        x = point.x - radius,
-                        y = point.y - radius,
-                        w = radius * 2,
-                        h = radius * 2,
+                    entry = {
+                        kind = "rect",
+                        rect = {
+                            x = point.x - radius,
+                            y = point.y - radius,
+                            w = radius * 2,
+                            h = radius * 2,
+                        },
                     }
                     label = string.format("%s bend %d", routeName, pointIndex)
                 end
 
-                entries[#entries + 1] = {
-                    kind = "rect",
-                    rect = rect,
-                    label = label,
-                    labelX = rect.x + rect.w * 0.5,
-                    labelY = rect.y + rect.h * 0.5,
-                }
+                entry.label = label
+                entry.labelX = point.x
+                entry.labelY = point.y
+                entries[#entries + 1] = entry
             end
         end
     end
@@ -3761,13 +3877,10 @@ function mapEditor:getHitboxOverlayEntries()
     for _, intersection in ipairs(self.intersections) do
         local radius = self:getIntersectionHitRadius(intersection)
         entries[#entries + 1] = {
-            kind = "rect",
-            rect = {
-                x = intersection.x - radius,
-                y = intersection.y - radius,
-                w = radius * 2,
-                h = radius * 2,
-            },
+            kind = "circle",
+            x = intersection.x,
+            y = intersection.y,
+            radius = radius,
             label = string.format("%s %s", tostring(intersection.routeKey or intersection.id or "junction"), intersection.controlType or "junction"),
             labelX = intersection.x,
             labelY = intersection.y,
@@ -3779,7 +3892,7 @@ function mapEditor:getHitboxOverlayEntries()
         local routeName = self:getRouteDebugName(route)
 
         for segmentIndex = 1, #route.points - 1 do
-            local polygon = self:buildSegmentHitboxPolygon(route.points[segmentIndex], route.points[segmentIndex + 1])
+            local polygon = self:buildSegmentHitboxPolygon(route, segmentIndex)
             if polygon then
                 entries[#entries + 1] = {
                     kind = "polygon",
@@ -4081,7 +4194,8 @@ function mapEditor:isSharedEndpointIntersection(groupedIntersection)
         or (allAtSharedEnd and sharedEndEndpointId ~= nil)
 end
 
-function mapEditor:rebuildIntersections()
+function mapEditor:rebuildIntersections(passIndex)
+    passIndex = passIndex or 1
     local previousIntersections = self.intersections or {}
     local grouped = {}
 
@@ -4200,6 +4314,18 @@ function mapEditor:rebuildIntersections()
         return a.x < b.x
     end)
 
+    if not self.deferIntersectionMaterialization and passIndex < MAX_INTERSECTION_MATERIALIZE_PASSES then
+        local changed = false
+
+        for _, intersection in ipairs(self.intersections) do
+            changed = self:materializeIntersectionSharedPoints(intersection) or changed
+        end
+
+        if changed then
+            return self:rebuildIntersections(passIndex + 1)
+        end
+    end
+
     self:refreshValidation()
 end
 
@@ -4263,15 +4389,19 @@ function mapEditor:updateDraggedPoint(x, y)
             self.drag.sharedPointId = preparedDrag.sharedPointId
             self.drag.routeId = preparedDrag.routeId
             self.drag.pointIndex = preparedDrag.pointIndex
+            self.drag.primaryRouteIds = copyArray(preparedDrag.routeIds or {})
             self.selectedRouteId = preparedDrag.routeId
             self.selectedPointIndex = preparedDrag.pointIndex
         end
 
         local clampedX, clampedY = self:clampPoint(x, y, false)
+        self:pruneSharedPointFromRoutes(self.drag.sharedPointId, self.drag.primaryRouteIds)
         self:updateSharedPointGroup(self.drag.sharedPointId, clampedX, clampedY)
         self:closeColorPicker()
         self:closeRouteTypePicker()
+        self.deferIntersectionMaterialization = true
         self:rebuildIntersections()
+        self.deferIntersectionMaterialization = false
         return
     end
 
@@ -4314,18 +4444,20 @@ function mapEditor:updateDraggedPoint(x, y)
         end
     end
     self:closeColorPicker()
+    self.deferIntersectionMaterialization = true
     self:rebuildIntersections()
+    self.deferIntersectionMaterialization = false
 end
 
 function mapEditor:ensureRoutePointAtIntersection(route, intersectionPoint)
     if not route or not route.points or #route.points < 2 then
-        return nil, nil
+        return nil, nil, false
     end
 
     for pointIndex = 2, #route.points - 1 do
         local point = route.points[pointIndex]
         if distanceSquared(point.x, point.y, intersectionPoint.x, intersectionPoint.y) <= INTERSECTION_POINT_TOLERANCE_SQUARED then
-            return pointIndex, point
+            return pointIndex, point, false
         end
     end
 
@@ -4335,21 +4467,21 @@ function mapEditor:ensureRoutePointAtIntersection(route, intersectionPoint)
         local hitPoint = pointOnSegment(intersectionPoint, pointA, pointB, INTERSECTION_POINT_TOLERANCE_SQUARED)
         if hitPoint then
             if distanceSquared(hitPoint.x, hitPoint.y, pointA.x, pointA.y) <= INTERNAL_POINT_MATCH_DISTANCE_SQUARED and segmentIndex > 1 then
-                return segmentIndex, pointA
+                return segmentIndex, pointA, false
             end
             if distanceSquared(hitPoint.x, hitPoint.y, pointB.x, pointB.y) <= INTERNAL_POINT_MATCH_DISTANCE_SQUARED
                 and (segmentIndex + 1) < #route.points then
-                return segmentIndex + 1, pointB
+                return segmentIndex + 1, pointB, false
             end
 
             local insertIndex = segmentIndex + 1
             table.insert(route.points, insertIndex, hitPoint)
             self:splitRouteSegmentStyle(route, segmentIndex)
-            return insertIndex, route.points[insertIndex]
+            return insertIndex, route.points[insertIndex], true
         end
     end
 
-    return nil, nil
+    return nil, nil, false
 end
 
 function mapEditor:prepareIntersectionForDrag(intersection)
@@ -4397,7 +4529,59 @@ function mapEditor:prepareIntersectionForDrag(intersection)
         sharedPointId = sharedPointId,
         routeId = members[1].route.id,
         pointIndex = members[1].pointIndex,
+        routeIds = copyArray(intersection.routeIds or {}),
     }
+end
+
+function mapEditor:materializeIntersectionSharedPoints(intersection)
+    if not intersection then
+        return false
+    end
+
+    local members = {}
+    local sharedPointId = nil
+    local changed = false
+
+    for _, routeId in ipairs(intersection.routeIds or {}) do
+        local route = self:getRouteById(routeId)
+        local pointIndex, point, inserted = self:ensureRoutePointAtIntersection(route, intersection)
+        if route and pointIndex and point then
+            members[#members + 1] = {
+                route = route,
+                pointIndex = pointIndex,
+                point = point,
+            }
+            changed = changed or inserted
+
+            if point.sharedPointId and not sharedPointId then
+                sharedPointId = point.sharedPointId
+            end
+        end
+    end
+
+    if #members < 2 then
+        return changed
+    end
+
+    if not sharedPointId then
+        sharedPointId = self.nextSharedPointId
+        self.nextSharedPointId = self.nextSharedPointId + 1
+        changed = true
+    end
+
+    for _, member in ipairs(members) do
+        if member.point.sharedPointId and member.point.sharedPointId ~= sharedPointId then
+            self:reassignSharedPointGroup(member.point.sharedPointId, sharedPointId)
+            changed = true
+        end
+        if member.point.sharedPointId ~= sharedPointId then
+            changed = true
+        end
+        member.point.sharedPointId = sharedPointId
+    end
+
+    self:updateSharedPointGroup(sharedPointId, intersection.x, intersection.y)
+    return changed
 end
 
 function mapEditor:isIntersectionOutputSelectorHit(intersection, x, y)
@@ -4668,9 +4852,10 @@ function mapEditor:splitSharedJunctionColor(intersection, colorId, startMouseX, 
         isMagnet = false,
         magnetKind = nil,
         splitOriginSharedPointId = group.sharedPointId,
+        pickupMode = true,
+        awaitingPickupRelease = true,
     }
     self:closeColorPicker()
-    self:rebuildIntersections()
     self:showStatus("Drag to split that color out of the merger lane.")
     return true
 end
@@ -4870,7 +5055,8 @@ function mapEditor:handleColorPickerClick(x, y, button)
             if hitEntry then
                 if layout.submenu.branch == "disconnect" then
                     if self.colorPicker.mode == "junction" then
-                        self:splitSharedJunctionColor(intersection, hitEntry.option.id, rawX, rawY)
+                        local mapX, mapY = self:screenToMap(rawX, rawY)
+                        self:splitSharedJunctionColor(intersection, hitEntry.option.id, mapX, mapY)
                     elseif self.colorPicker.mode == "route_end" then
                         local mapX, mapY = self:screenToMap(rawX, rawY)
                         self:splitEndpointColor(route, "end", hitEntry.option.id, mapX, mapY)
@@ -5378,6 +5564,10 @@ function mapEditor:mousepressed(screenX, screenY, button)
         self:commitTextField()
     end
 
+    if button == 1 and self.drag and self.drag.pickupMode then
+        return true
+    end
+
     if self.colorPicker and self:handleColorPickerClick(screenX, screenY, button) then
         return true
     end
@@ -5583,6 +5773,18 @@ function mapEditor:mousepressed(screenX, screenY, button)
     return false
 end
 
+function mapEditor:isCameraScrollLocked()
+    if self.colorPicker and self.colorPicker.mode == "junction" then
+        return true
+    end
+
+    if self.drag and self.drag.kind == "intersection" then
+        return true
+    end
+
+    return false
+end
+
 function mapEditor:wheelmoved(screenX, screenY, _, y)
     if self.dialog and self.dialog.type == "open" then
         if y > 0 then
@@ -5594,6 +5796,10 @@ function mapEditor:wheelmoved(screenX, screenY, _, y)
             return true
         end
         return false
+    end
+
+    if self:isCameraScrollLocked() then
+        return true
     end
 
     if pointInRect(screenX, screenY, self.sidePanel) then
@@ -5702,6 +5908,11 @@ function mapEditor:mousereleased(screenX, screenY, button)
 
     if not self.drag then
         return false
+    end
+
+    if button == 1 and self.drag.pickupMode and self.drag.awaitingPickupRelease then
+        self.drag.awaitingPickupRelease = false
+        return true
     end
 
     local x, y = self:screenToMap(screenX, screenY)
@@ -6048,7 +6259,7 @@ function mapEditor:drawRoute(route, selectedRouteId)
     end
 
     graphics.setLineStyle("smooth")
-    graphics.setLineJoin("bevel")
+    graphics.setLineJoin("none")
     graphics.setColor(0.11, 0.14, 0.18, 1)
     graphics.setLineWidth(selectedRouteId == route.id and 16 or 13)
     graphics.line(points)
@@ -6546,6 +6757,8 @@ function mapEditor:drawHitboxOverlay(game)
         graphics.setColor(color[1], color[2], color[3], HITBOX_OVERLAY_FILL_ALPHA)
         if entry.kind == "polygon" then
             graphics.polygon("fill", entry.points)
+        elseif entry.kind == "circle" then
+            graphics.circle("fill", entry.x, entry.y, entry.radius)
         else
             graphics.rectangle(
                 "fill",
@@ -6562,6 +6775,8 @@ function mapEditor:drawHitboxOverlay(game)
         graphics.setLineWidth(HITBOX_OVERLAY_STROKE_WIDTH * inverseZoom)
         if entry.kind == "polygon" then
             graphics.polygon("line", entry.points)
+        elseif entry.kind == "circle" then
+            graphics.circle("line", entry.x, entry.y, entry.radius)
         else
             graphics.rectangle(
                 "line",

--- a/src/game/track_scene_renderer.lua
+++ b/src/game/track_scene_renderer.lua
@@ -542,6 +542,7 @@ function renderer.drawInputTrack(scene, track, isActive)
     local points = flattenPoints(renderedPoints)
 
     graphics.setLineStyle("rough")
+    graphics.setLineJoin("none")
     graphics.setColor(0.17, 0.21, 0.24, 0.95)
     graphics.setLineWidth(scene.trackWidth + 10)
     graphics.line(points)
@@ -551,6 +552,8 @@ function renderer.drawInputTrack(scene, track, isActive)
     else
         renderer.drawTrackLine(scene, points, scene.trackWidth, trackColor, trackAlpha)
     end
+
+    renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
 end
 
 function renderer.drawStandaloneTrack(scene, track, isActive)
@@ -571,6 +574,7 @@ function renderer.drawStandaloneTrack(scene, track, isActive)
     local points = flattenPoints(renderedPoints)
 
     graphics.setLineStyle("rough")
+    graphics.setLineJoin("none")
     graphics.setColor(0.17, 0.21, 0.24, 0.95)
     graphics.setLineWidth(scene.trackWidth + 10)
     graphics.line(points)
@@ -596,6 +600,7 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive)
 
     local points = flattenPoints(renderedPoints)
 
+    graphics.setLineJoin("none")
     graphics.setColor(0.17, 0.21, 0.24, 0.95)
     graphics.setLineWidth(scene.sharedWidth + 10)
     graphics.line(points)

--- a/tests/map_editor_bendpoint_live_intersection_test.lua
+++ b/tests/map_editor_bendpoint_live_intersection_test.lua
@@ -1,0 +1,109 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_a", kind = "input", x = 0.12, y = 0.65, colors = { "blue" } },
+        { id = "output_a", kind = "output", x = 0.85, y = 0.22, colors = { "blue" } },
+        { id = "input_b", kind = "input", x = 0.56, y = 0.14, colors = { "orange" } },
+        { id = "output_b", kind = "output", x = 0.56, y = 0.86, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_drag",
+            label = "route_drag",
+            color = "blue",
+            startEndpointId = "input_a",
+            endEndpointId = "output_a",
+            segmentRoadTypes = { "normal", "normal" },
+            points = {
+                { x = 0.12, y = 0.65 },
+                { x = 0.24, y = 0.82 },
+                { x = 0.85, y = 0.22 },
+            },
+        },
+        {
+            id = "route_static",
+            label = "route_static",
+            color = "orange",
+            startEndpointId = "input_b",
+            endEndpointId = "output_b",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.56, y = 0.14 },
+                { x = 0.56, y = 0.86 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Bendpoint Live Intersection", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 0, "initial layout should not start with a junction")
+
+local routeDrag = editor:getRouteById("route_drag")
+local routeStatic = editor:getRouteById("route_static")
+local bendPoint = routeDrag.points[2]
+local startScreenX, startScreenY = editor:mapToScreen(bendPoint.x, bendPoint.y)
+
+editor:mousepressed(startScreenX, startScreenY, 1)
+
+local dragTargets = {
+    { x = editor.mapSize.w * 0.48, y = editor.mapSize.h * 0.60 },
+    { x = editor.mapSize.w * 0.54, y = editor.mapSize.h * 0.56 },
+    { x = editor.mapSize.w * 0.60, y = editor.mapSize.h * 0.52 },
+}
+
+local previousScreenX = startScreenX
+local previousScreenY = startScreenY
+
+for _, target in ipairs(dragTargets) do
+    local screenX, screenY = editor:mapToScreen(target.x, target.y)
+    editor:mousemoved(screenX, screenY, screenX - previousScreenX, screenY - previousScreenY)
+    previousScreenX = screenX
+    previousScreenY = screenY
+
+    assertTrue(#(editor.intersections or {}) <= 1, "live bend drag should keep the crossing count bounded")
+    assertEqual(#routeStatic.points, 2, "crossed route should not gain new bend points during live drag")
+end
+
+editor:mousereleased(previousScreenX, previousScreenY, 1)
+
+assertTrue(#(editor.intersections or {}) <= 1, "release should leave at most one resolved crossing")
+assertTrue(#routeStatic.points <= 3, "crossed route may materialize one final junction point after release")
+
+print("map editor bendpoint live intersection tests passed")

--- a/tests/map_editor_hitbox_overlay_test.lua
+++ b/tests/map_editor_hitbox_overlay_test.lua
@@ -84,10 +84,11 @@ local editorData = {
             color = "orange",
             startEndpointId = "input_b",
             endEndpointId = "output_b",
-            segmentRoadTypes = { "normal", "normal" },
+            segmentRoadTypes = { "normal", "normal", "normal" },
             points = {
                 { x = 636 / 1280, y = 360 / 720 },
                 { x = 640 / 1280, y = 400 / 720 },
+                { x = 660 / 1280, y = 388 / 720 },
                 { x = 644 / 1280, y = 360 / 720 },
             },
         },
@@ -127,7 +128,7 @@ end
 assertTrue(sawSegment, "overlay should include segment hitboxes")
 assertTrue(sawIntersection, "overlay should include junction hitboxes")
 
-local defaultBendEntry = findOverlayEntry(entries, "route_b bend 2")
+local defaultBendEntry = findOverlayEntry(entries, "route_b bend 3")
 local defaultSegmentEntry = findOverlayEntry(entries, "route_b segment 1")
 assertTrue(defaultBendEntry ~= nil, "overlay should expose bend hitboxes by label")
 assertTrue(defaultSegmentEntry ~= nil, "overlay should expose segment hitboxes by label")
@@ -137,7 +138,7 @@ local defaultSegmentThickness = polygonEdgeLength(defaultSegmentEntry.points, 1,
 
 editor.camera.zoom = 0.5
 local zoomedOutEntries = editor:getHitboxOverlayEntries()
-local zoomedOutBendEntry = findOverlayEntry(zoomedOutEntries, "route_b bend 2")
+local zoomedOutBendEntry = findOverlayEntry(zoomedOutEntries, "route_b bend 3")
 local zoomedOutSegmentEntry = findOverlayEntry(zoomedOutEntries, "route_b segment 1")
 assertNear(zoomedOutBendEntry.rect.w, defaultBendWidth, 0.0001, "bend hitbox width should stay stable when zooming out")
 assertNear(
@@ -149,7 +150,7 @@ assertNear(
 
 editor.camera.zoom = 2
 local zoomedInEntries = editor:getHitboxOverlayEntries()
-local zoomedInBendEntry = findOverlayEntry(zoomedInEntries, "route_b bend 2")
+local zoomedInBendEntry = findOverlayEntry(zoomedInEntries, "route_b bend 3")
 local zoomedInSegmentEntry = findOverlayEntry(zoomedInEntries, "route_b segment 1")
 assertNear(zoomedInBendEntry.rect.w, defaultBendWidth, 0.0001, "bend hitbox width should stay stable when zooming in")
 assertNear(

--- a/tests/map_editor_intersection_drag_stability_test.lua
+++ b/tests/map_editor_intersection_drag_stability_test.lua
@@ -1,0 +1,129 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.2, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.82, y = 0.8, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.2, colors = { "orange" } },
+        { id = "output_left", kind = "output", x = 0.18, y = 0.8, colors = { "orange" } },
+        { id = "input_top", kind = "input", x = 0.5, y = 0.64, colors = { "yellow" } },
+        { id = "output_bottom", kind = "output", x = 0.5, y = 0.92, colors = { "yellow" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.18, y = 0.2 },
+                { x = 0.82, y = 0.8 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.82, y = 0.2 },
+                { x = 0.18, y = 0.8 },
+            },
+        },
+        {
+            id = "route_yellow",
+            label = "route_yellow",
+            color = "yellow",
+            startEndpointId = "input_top",
+            endEndpointId = "output_bottom",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.5, y = 0.64 },
+                { x = 0.5, y = 0.92 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Intersection Drag Stability", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 1, "initial crossing should produce one junction")
+
+local intersection = editor.intersections[1]
+local startScreenX, startScreenY = editor:mapToScreen(intersection.x, intersection.y)
+
+editor:mousepressed(startScreenX, startScreenY, 1)
+
+local dragTargets = {
+    { x = editor.mapSize.w * 0.5, y = editor.mapSize.h * 0.70 },
+    { x = editor.mapSize.w * 0.5, y = editor.mapSize.h * 0.76 },
+    { x = editor.mapSize.w * 0.5, y = editor.mapSize.h * 0.82 },
+}
+
+local previousScreenX = startScreenX
+local previousScreenY = startScreenY
+
+for _, target in ipairs(dragTargets) do
+    local screenX, screenY = editor:mapToScreen(target.x, target.y)
+    editor:mousemoved(screenX, screenY, screenX - previousScreenX, screenY - previousScreenY)
+    previousScreenX = screenX
+    previousScreenY = screenY
+
+    assertEqual(#(editor.intersections or {}), 1, "live intersection drag should keep one resolved junction")
+    assertTrue(#editor:getRouteById("route_blue").points <= 3, "blue route should stay bounded during live drag")
+    assertTrue(#editor:getRouteById("route_orange").points <= 3, "orange route should stay bounded during live drag")
+    assertEqual(#editor:getRouteById("route_yellow").points, 2, "crossed route should not gain bend points during live junction drag")
+end
+
+editor:mousereleased(previousScreenX, previousScreenY, 1)
+
+assertEqual(#(editor.intersections or {}), 1, "dragging a junction onto another road should converge to one shared junction")
+assertTrue(#editor:getRouteById("route_blue").points <= 3, "blue route should not accumulate runaway junction points")
+assertTrue(#editor:getRouteById("route_orange").points <= 3, "orange route should not accumulate runaway junction points")
+assertTrue(#editor:getRouteById("route_yellow").points <= 3, "yellow route may materialize one final junction point after release")
+
+local movedIntersection = editor.intersections[1]
+local finalTarget = dragTargets[#dragTargets]
+assertTrue(math.abs(movedIntersection.x - finalTarget.x) < 8, "junction should stay near the dragged x target")
+assertTrue(math.abs(movedIntersection.y - finalTarget.y) < 8, "junction should stay near the dragged y target")
+
+print("map editor intersection drag stability tests passed")

--- a/tests/map_editor_junction_disconnect_drag_test.lua
+++ b/tests/map_editor_junction_disconnect_drag_test.lua
@@ -1,0 +1,130 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local function assertClose(actual, expected, tolerance, label)
+    if math.abs(actual - expected) > tolerance then
+        error(string.format("%s expected %.4f but got %.4f", label, expected, actual), 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.2, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.82, y = 0.8, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.2, colors = { "orange" } },
+        { id = "output_left", kind = "output", x = 0.18, y = 0.8, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.18, y = 0.2 },
+                { x = 0.82, y = 0.8 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.82, y = 0.2 },
+                { x = 0.18, y = 0.8 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Junction Disconnect Drag Regression", nil, nil)
+
+local intersection = editor.intersections[1]
+assertTrue(intersection ~= nil, "crossing routes should produce one junction")
+
+local centerScreenX, centerScreenY = editor:mapToScreen(intersection.x, intersection.y)
+editor:mousepressed(centerScreenX, centerScreenY, 2)
+assertTrue(editor.colorPicker ~= nil and editor.colorPicker.mode == "junction", "right-clicking a junction should open the radial menu")
+
+local rootScale = editor:getJunctionPickerPopupScale()
+local disconnectRootClickX = centerScreenX - 12 * rootScale
+local disconnectRootClickY = centerScreenY
+assertTrue(editor:handleColorPickerClick(disconnectRootClickX, disconnectRootClickY, 1), "left-side root click should open the disconnect branch")
+assertTrue(editor.colorPicker.branch == "disconnect", "left-side root click should select the disconnect branch")
+
+editor:update(0.08)
+
+local layout = editor:getJunctionPickerLayout()
+local blueEntry = nil
+for _, entry in ipairs(layout.submenu.entries or {}) do
+    if entry.option.id == "blue" then
+        blueEntry = entry
+        break
+    end
+end
+
+assertTrue(blueEntry ~= nil, "disconnect branch should list the blue route color")
+
+local originX, originY = editor:getJunctionPickerPopupOrigin()
+local submenuScale = editor:getJunctionPickerPopupScale()
+local submenuClickX = originX + (blueEntry.centerX - originX) * submenuScale
+local submenuClickY = originY + (blueEntry.centerY - originY) * submenuScale
+
+assertTrue(editor:handleColorPickerClick(submenuClickX, submenuClickY, 1), "disconnect submenu click should be handled")
+assertTrue(editor.drag ~= nil and editor.drag.kind == "point", "disconnecting a route from a junction should immediately start a bend-point drag")
+editor:mousereleased(submenuClickX, submenuClickY, 1)
+assertTrue(editor.drag ~= nil and editor.drag.kind == "point", "the initial release after disconnecting should keep the bend point in hand")
+
+local targetMapX = intersection.x - 32
+local targetMapY = intersection.y - 18
+local targetScreenX, targetScreenY = editor:mapToScreen(targetMapX, targetMapY)
+editor:mousemoved(targetScreenX, targetScreenY, targetScreenX - submenuClickX, targetScreenY - submenuClickY)
+editor:mousepressed(targetScreenX, targetScreenY, 1)
+editor:mousereleased(targetScreenX, targetScreenY, 1)
+
+local blueRoute = editor:getRouteById("route_blue")
+local orangeRoute = editor:getRouteById("route_orange")
+local bluePoint = blueRoute.points[2]
+local orangePoint = orangeRoute.points[2]
+local tolerance = 0.001
+local intersectionTolerance = 1.5
+
+assertClose(bluePoint.x, targetMapX, tolerance, "disconnect drag should move the detached blue bend point")
+assertClose(bluePoint.y, targetMapY, tolerance, "disconnect drag should move the detached blue bend point")
+assertClose(orangePoint.x, intersection.x, intersectionTolerance, "disconnect drag should leave the other route on the original junction")
+assertClose(orangePoint.y, intersection.y, intersectionTolerance, "disconnect drag should leave the other route on the original junction")
+
+print("map editor junction disconnect drag tests passed")

--- a/tests/map_editor_junction_state_test.lua
+++ b/tests/map_editor_junction_state_test.lua
@@ -106,6 +106,9 @@ local wheelIntersection = editor.intersections[1]
 local wheelScreenX, wheelScreenY = editor:mapToScreen(wheelIntersection.x, wheelIntersection.y)
 editor:mousepressed(wheelScreenX, wheelScreenY, 2)
 assertTrue(editor.colorPicker ~= nil and editor.colorPicker.mode == "junction", "right-clicking a junction should open the radial menu")
+local zoomBeforePickerScroll = editor.camera.zoom
+assertTrue(editor:wheelmoved(wheelScreenX, wheelScreenY, 0, 1), "wheel input should be handled while the junction radial menu is open")
+assertEqual(editor.camera.zoom, zoomBeforePickerScroll, "wheel zoom should stay locked while the junction radial menu is open")
 
 local rootScale = editor:getJunctionPickerPopupScale()
 local rootClickX = wheelScreenX + 12 * rootScale
@@ -150,6 +153,9 @@ local dragStartScreenX, dragStartScreenY = reloadedEditor:mapToScreen(beforeX, b
 local dragEndScreenX, dragEndScreenY = reloadedEditor:mapToScreen(beforeX + 16, beforeY + 8)
 
 reloadedEditor:mousepressed(dragStartScreenX, dragStartScreenY, 1)
+local zoomBeforeDragScroll = reloadedEditor.camera.zoom
+assertTrue(reloadedEditor:wheelmoved(dragStartScreenX, dragStartScreenY, 0, 1), "wheel input should be handled while dragging a junction")
+assertEqual(reloadedEditor.camera.zoom, zoomBeforeDragScroll, "wheel zoom should stay locked while dragging a junction")
 reloadedEditor:mousemoved(dragEndScreenX, dragEndScreenY, dragEndScreenX - dragStartScreenX, dragEndScreenY - dragStartScreenY)
 reloadedEditor:mousereleased(dragEndScreenX, dragEndScreenY, 1)
 

--- a/tests/map_editor_route_segment_split_test.lua
+++ b/tests/map_editor_route_segment_split_test.lua
@@ -1,0 +1,107 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_left", kind = "input", x = 0.18, y = 0.2, colors = { "blue" } },
+        { id = "output_right", kind = "output", x = 0.82, y = 0.8, colors = { "blue" } },
+        { id = "input_right", kind = "input", x = 0.82, y = 0.2, colors = { "orange" } },
+        { id = "output_left", kind = "output", x = 0.18, y = 0.8, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_left",
+            endEndpointId = "output_right",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.18, y = 0.2 },
+                { x = 0.82, y = 0.8 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_right",
+            endEndpointId = "output_left",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.82, y = 0.2 },
+                { x = 0.18, y = 0.8 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Route Segment Split Regression", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 1, "crossing routes should produce one junction")
+
+local routeBlue = editor:getRouteById("route_blue")
+local routeOrange = editor:getRouteById("route_orange")
+
+assertEqual(#routeBlue.points, 3, "junction crossing should split the blue route into two editor segments")
+assertEqual(#routeOrange.points, 3, "junction crossing should split the orange route into two editor segments")
+assertEqual(#routeBlue.segmentRoadTypes, 2, "blue route should keep one road type entry per split segment")
+assertEqual(#routeOrange.segmentRoadTypes, 2, "orange route should keep one road type entry per split segment")
+assertTrue(routeBlue.points[2].sharedPointId ~= nil, "split blue route should create a shared junction point")
+assertEqual(routeBlue.points[2].sharedPointId, routeOrange.points[2].sharedPointId, "split routes should share one junction point id")
+
+editor:setRouteSegmentRoadType(routeBlue, 2, "fast")
+
+assertEqual(routeBlue.segmentRoadTypes[1], "normal", "changing the second segment should not change the first segment")
+assertEqual(routeBlue.segmentRoadTypes[2], "fast", "changing the second segment should only update that section")
+
+local previewFirst = editor.previewWorld and editor.previewWorld.edges and editor.previewWorld.edges.route_blue_segment_1
+local previewSecond = editor.previewWorld and editor.previewWorld.edges and editor.previewWorld.edges.route_blue_segment_2
+
+assertTrue(previewFirst ~= nil, "preview world should keep the pre-junction road section")
+assertTrue(previewSecond ~= nil, "preview world should keep the post-junction road section")
+assertEqual(previewFirst.roadType, "normal", "pre-junction section should keep its original road type")
+assertEqual(previewSecond.roadType, "fast", "post-junction section should use the updated road type")
+assertEqual(previewFirst.styleSections[1].roadType, "normal", "pre-junction style section should stay normal")
+assertEqual(previewSecond.styleSections[1].roadType, "fast", "post-junction style section should become fast")
+
+local intersection = editor.intersections[1]
+local hiddenRoute, hiddenPointIndex = editor:findBendPointAt(intersection.x, intersection.y, nil, nil)
+
+assertTrue(hiddenRoute == nil and hiddenPointIndex == nil, "junction shared points should stay hidden from bend merge targeting")
+
+print("map editor route segment split tests passed")

--- a/tests/map_editor_shared_point_collapse_test.lua
+++ b/tests/map_editor_shared_point_collapse_test.lua
@@ -1,0 +1,69 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editor = mapEditor.new(1280, 720, nil)
+local route = editor:createRoute(
+    {
+        { x = 100, y = 100 },
+        { x = 200, y = 200, sharedPointId = 1 },
+        { x = 240, y = 240, sharedPointId = 1 },
+        { x = 400, y = 300 },
+    },
+    { 0.33, 0.8, 0.98 },
+    "route_test",
+    "route_test",
+    "blue",
+    { "blue" },
+    { "blue" },
+    "start_endpoint",
+    "end_endpoint",
+    { "normal", "normal", "normal" }
+)
+
+assertEqual(#route.points, 4, "setup should start with two consecutive shared points")
+assertEqual(#route.segmentRoadTypes, 3, "setup should keep one road type per segment")
+
+editor:updateSharedPointGroup(1, 220, 220)
+
+assertEqual(#route.points, 3, "shared point collapse should remove duplicate consecutive points")
+assertEqual(#route.segmentRoadTypes, 2, "shared point collapse should remove the redundant segment road type")
+assertTrue(
+    not (
+        math.abs(route.points[2].x - route.points[1].x) <= 1
+        and math.abs(route.points[2].y - route.points[1].y) <= 1
+    ),
+    "collapsed route should not leave a zero-length segment behind"
+)
+
+print("map editor shared point collapse tests passed")

--- a/tests/world_input_track_markers_test.lua
+++ b/tests/world_input_track_markers_test.lua
@@ -17,6 +17,7 @@ love.filesystem.getInfo = function()
 end
 
 local world = require("src.game.world")
+local trackSceneRenderer = require("src.game.track_scene_renderer")
 
 local function assertTrue(value, label)
     if not value then
@@ -29,13 +30,6 @@ local simulation = world.new(100, 100, {
     junctions = {},
     trains = {},
 })
-
-local markersCalled = 0
-simulation.drawTrackRoadTypeMarkers = function(_, track, isActive)
-    markersCalled = markersCalled + 1
-    assertTrue(track.id == "input_track", "input track markers should receive the input track")
-    assertTrue(isActive == true, "input track markers should preserve the active state")
-end
 
 simulation.drawTrackLine = function()
 end
@@ -74,7 +68,25 @@ local inputTrack = {
     targetType = "junction",
 }
 
-simulation:drawInputTrack(inputTrack, true)
+local originalDrawTrackRoadTypeMarkers = trackSceneRenderer.drawTrackRoadTypeMarkers
+local markersCalled = 0
+
+trackSceneRenderer.drawTrackRoadTypeMarkers = function(scene, track, isActive)
+    markersCalled = markersCalled + 1
+    assertTrue(scene == simulation, "input track markers should receive the active world")
+    assertTrue(track.id == "input_track", "input track markers should receive the input track")
+    assertTrue(isActive == true, "input track markers should preserve the active state")
+end
+
+local ok, err = pcall(function()
+    simulation:drawInputTrack(inputTrack, true)
+end)
+
+trackSceneRenderer.drawTrackRoadTypeMarkers = originalDrawTrackRoadTypeMarkers
+
+if not ok then
+    error(err, 0)
+end
 
 assertTrue(markersCalled == 1, "input tracks should render road type markers once")
 


### PR DESCRIPTION
## Requested Behavior

- Fix road state rendering so route type changes apply to the correct road sections instead of the whole road.
- Prevent intersections and bound points from being created repeatedly while dragging.
- Make junction and bend-point drags update live without leaving trails of new intersections or segments.
- Keep road, start, end, and intersection hitboxes consistent and stable while zooming.
- Make the junction disconnect action hand off a movable bend point instead of removing it immediately.
- Stop mouse-wheel zoom while the junction wheel is open or while an intersection is being updated.

## Summary

- Added stable per-segment road state handling at junction splits and collapsed duplicate shared points that could make roads disappear.
- Fixed live drag behavior so bend-point and junction movement update existing intersections instead of spawning new ones.
- Tightened hit detection for road endpoints, intersections, and segments so click targets match the visible geometry.
- Updated junction disconnect flow so the detached point stays in hand and can be moved.
- Locked camera wheel zoom while the junction radial menu is open or a junction is actively dragged.
- Restored road type markers for input tracks in the scene renderer.

## Testing

- Added and updated unit regressions for route splitting, shared-point collapse, live intersection dragging, junction disconnect dragging, hitbox overlays, and input track markers.
- Verified the junction state, junction disconnect drag, and intersection drag stability tests locally with Love.