### PR TITLE
Fix relay and crossbar junction ordering

### DIFF
--- a/src/game/editor/map_editor_input.lua
+++ b/src/game/editor/map_editor_input.lua
@@ -338,13 +338,152 @@ function mapEditor:syncIntersectionOutputToControl(intersection)
         return
     end
 
-    if intersection.controlType == "relay" then
-        intersection.activeOutputIndex = math.min(intersection.activeInputIndex or 1, outputCount)
-    elseif intersection.controlType == "crossbar" then
-        intersection.activeOutputIndex = math.max(1, outputCount - (intersection.activeInputIndex or 1) + 1)
+    if intersection.controlType == "relay" or intersection.controlType == "crossbar" then
+        intersection.activeOutputIndex = self:getDirectionalIntersectionOutputIndex(intersection, intersection.controlType)
     else
         intersection.activeOutputIndex = clamp(intersection.activeOutputIndex or 1, 1, outputCount)
     end
+end
+
+function mapEditor:getIntersectionRouteOuterPoint(route, magnetKind)
+    if not route or not route.points or #route.points <= 0 then
+        return nil
+    end
+
+    if magnetKind == "end" then
+        return route.points[#route.points]
+    end
+
+    return route.points[1]
+end
+
+function mapEditor:getIntersectionAngle(point, intersection)
+    if not point or not intersection then
+        return 0
+    end
+
+    local dx = (point.x or 0) - (intersection.x or 0)
+    local dy = (point.y or 0) - (intersection.y or 0)
+    if math.atan2 then
+        return math.atan2(dy, dx)
+    end
+
+    if math.abs(dx) <= 0.0001 then
+        return dy >= 0 and (math.pi * 0.5) or (-math.pi * 0.5)
+    end
+
+    local angle = math.atan(dy / dx)
+    if dx < 0 then
+        angle = angle + math.pi
+    end
+    if angle > math.pi then
+        angle = angle - math.pi * 2
+    end
+    return angle
+end
+
+function mapEditor:buildIntersectionRouteEntries(intersection, routeIds, magnetKind)
+    local entries = {}
+
+    for index, routeId in ipairs(routeIds or {}) do
+        local route = self:getRouteById(routeId)
+        local outerPoint = self:getIntersectionRouteOuterPoint(route, magnetKind)
+        entries[#entries + 1] = {
+            index = index,
+            routeId = routeId,
+            outerPoint = outerPoint,
+            angle = self:getIntersectionAngle(outerPoint, intersection),
+        }
+    end
+
+    return entries
+end
+
+function mapEditor:sortIntersectionEntriesByPosition(entries)
+    table.sort(entries, function(first, second)
+        local firstPoint = first and first.outerPoint or nil
+        local secondPoint = second and second.outerPoint or nil
+        if not firstPoint or not secondPoint then
+            return (first and first.index or 0) < (second and second.index or 0)
+        end
+
+        local xDiff = math.abs((firstPoint.x or 0) - (secondPoint.x or 0))
+        if xDiff > 0.0001 then
+            return (firstPoint.x or 0) < (secondPoint.x or 0)
+        end
+
+        local yDiff = math.abs((firstPoint.y or 0) - (secondPoint.y or 0))
+        if yDiff > 0.0001 then
+            return (firstPoint.y or 0) < (secondPoint.y or 0)
+        end
+
+        return (first.index or 0) < (second.index or 0)
+    end)
+end
+
+function mapEditor:sortIntersectionEntriesByCycle(entries)
+    table.sort(entries, function(first, second)
+        local angleDiff = math.abs((first.angle or 0) - (second.angle or 0))
+        if angleDiff > 0.0001 then
+            return (first.angle or 0) < (second.angle or 0)
+        end
+
+        local firstPoint = first and first.outerPoint or nil
+        local secondPoint = second and second.outerPoint or nil
+        if not firstPoint or not secondPoint then
+            return (first and first.index or 0) < (second and second.index or 0)
+        end
+
+        local xDiff = math.abs((firstPoint.x or 0) - (secondPoint.x or 0))
+        if xDiff > 0.0001 then
+            return (firstPoint.x or 0) < (secondPoint.x or 0)
+        end
+
+        return (first.index or 0) < (second.index or 0)
+    end)
+end
+
+function mapEditor:getNextIntersectionInputIndex(intersection)
+    local entries = self:buildIntersectionRouteEntries(intersection, intersection and intersection.inputRouteIds or {}, "start")
+    self:sortIntersectionEntriesByCycle(entries)
+    if #entries <= 1 then
+        return 1
+    end
+
+    for orderIndex, entry in ipairs(entries) do
+        if entry.index == (intersection.activeInputIndex or 1) then
+            local nextEntry = entries[orderIndex + 1] or entries[1]
+            return nextEntry.index
+        end
+    end
+
+    return entries[1].index
+end
+
+function mapEditor:getDirectionalIntersectionOutputIndex(intersection, controlType)
+    local inputEntries = self:buildIntersectionRouteEntries(intersection, intersection and intersection.inputRouteIds or {}, "start")
+    local outputEntries = self:buildIntersectionRouteEntries(intersection, intersection and intersection.outputRouteIds or {}, "end")
+    self:sortIntersectionEntriesByPosition(inputEntries)
+    self:sortIntersectionEntriesByPosition(outputEntries)
+
+    local inputRank = nil
+    for rank, entry in ipairs(inputEntries) do
+        if entry.index == (intersection.activeInputIndex or 1) then
+            inputRank = rank
+            break
+        end
+    end
+
+    if not inputRank or #outputEntries <= 0 then
+        return clamp(intersection.activeOutputIndex or 1, 1, math.max(1, #(intersection.outputEndpointIds or {})))
+    end
+
+    local targetRank = inputRank
+    if controlType == "crossbar" then
+        targetRank = #outputEntries - inputRank + 1
+    end
+    targetRank = clamp(targetRank, 1, #outputEntries)
+    return outputEntries[targetRank].index
 end
 
 function mapEditor:cycleIntersectionInput(intersection)
@@ -363,9 +502,13 @@ function mapEditor:cycleIntersectionInput(intersection)
         return false
     end
 
-    intersection.activeInputIndex = (intersection.activeInputIndex or 1) + 1
-    if intersection.activeInputIndex > inputCount then
-        intersection.activeInputIndex = 1
+    if intersection.controlType == "relay" or intersection.controlType == "crossbar" then
+        intersection.activeInputIndex = self:getNextIntersectionInputIndex(intersection)
+    else
+        intersection.activeInputIndex = (intersection.activeInputIndex or 1) + 1
+        if intersection.activeInputIndex > inputCount then
+            intersection.activeInputIndex = 1
+        end
     end
 
     self:syncIntersectionOutputToControl(intersection)

--- a/src/game/gameplay/railway_world.lua
+++ b/src/game/gameplay/railway_world.lua
@@ -60,6 +60,265 @@ local function dot(ax, ay, bx, by)
     return ax * bx + ay * by
 end
 
+local function getEdgeDirectionNearJunction(edge, mergePoint, startsAtJunction)
+    local points = edge and edge.path and edge.path.points or nil
+    if not points or #points <= 0 or not mergePoint then
+        return nil, nil
+    end
+
+    local anchorIndex = startsAtJunction and 1 or #points
+    local step = startsAtJunction and 1 or -1
+    local anchor = points[anchorIndex]
+    local baseX = anchor and anchor.x or mergePoint.x
+    local baseY = anchor and anchor.y or mergePoint.y
+
+    for index = anchorIndex + step, startsAtJunction and #points or 1, step do
+        local point = points[index]
+        if point then
+            local dx = point.x - baseX
+            local dy = point.y - baseY
+            local lengthSquared = dx * dx + dy * dy
+            if lengthSquared > 0.0001 then
+                return normalize(dx, dy)
+            end
+        end
+    end
+
+    return nil, nil
+end
+
+local function getEdgeOuterPoint(edge, mergePoint)
+    local points = edge and edge.path and edge.path.points or nil
+    if not points or #points <= 0 then
+        return nil
+    end
+
+    local bestPoint = nil
+    local bestDistance = -1
+    local baseX = mergePoint and mergePoint.x or 0
+    local baseY = mergePoint and mergePoint.y or 0
+
+    for _, point in ipairs(points) do
+        local distance = distanceSquared(point.x, point.y, baseX, baseY)
+        if distance > bestDistance + 0.0001 then
+            bestDistance = distance
+            bestPoint = point
+        end
+    end
+
+    return bestPoint
+end
+
+local function getRelayFallbackOutputIndex(junction, inputIndex)
+    return clamp(inputIndex, 1, math.max(1, #(junction and junction.outputs or {})))
+end
+
+local function getCrossbarFallbackOutputIndex(junction, inputIndex)
+    local outputCount = math.max(1, #(junction and junction.outputs or {}))
+    return clamp(outputCount - inputIndex + 1, 1, outputCount)
+end
+
+local function compareEdgeOuterPoint(a, b)
+    if not a and not b then
+        return false
+    end
+    if not a then
+        return false
+    end
+    if not b then
+        return true
+    end
+
+    local xDiff = math.abs((a.outerPoint.x or 0) - (b.outerPoint.x or 0))
+    if xDiff > 0.0001 then
+        return (a.outerPoint.x or 0) < (b.outerPoint.x or 0)
+    end
+
+    local yDiff = math.abs((a.outerPoint.y or 0) - (b.outerPoint.y or 0))
+    if yDiff > 0.0001 then
+        return (a.outerPoint.y or 0) < (b.outerPoint.y or 0)
+    end
+
+    return (a.index or 0) < (b.index or 0)
+end
+
+local function buildSortedEntries(edges, mergePoint)
+    local entries = {}
+
+    for index, edge in ipairs(edges or {}) do
+        entries[#entries + 1] = {
+            index = index,
+            edge = edge,
+            outerPoint = getEdgeOuterPoint(edge, mergePoint),
+        }
+    end
+
+    table.sort(entries, compareEdgeOuterPoint)
+    return entries
+end
+
+local function angleFromMerge(point, mergePoint)
+    if not point or not mergePoint then
+        return 0
+    end
+
+    local dx = (point.x or 0) - mergePoint.x
+    local dy = (point.y or 0) - mergePoint.y
+    if math.atan2 then
+        return math.atan2(dy, dx)
+    end
+
+    if math.abs(dx) <= 0.0001 then
+        return dy >= 0 and (math.pi * 0.5) or (-math.pi * 0.5)
+    end
+
+    local angle = math.atan(dy / dx)
+    if dx < 0 then
+        angle = angle + math.pi
+    end
+    if angle > math.pi then
+        angle = angle - math.pi * 2
+    end
+    return angle
+end
+
+local function compareEdgeCycleOrder(a, b)
+    if not a and not b then
+        return false
+    end
+    if not a then
+        return false
+    end
+    if not b then
+        return true
+    end
+
+    local angleDiff = math.abs((a.angle or 0) - (b.angle or 0))
+    if angleDiff > 0.0001 then
+        return (a.angle or 0) < (b.angle or 0)
+    end
+
+    return compareEdgeOuterPoint(a, b)
+end
+
+local function buildCycleEntries(edges, mergePoint)
+    local entries = {}
+
+    for index, edge in ipairs(edges or {}) do
+        local outerPoint = getEdgeOuterPoint(edge, mergePoint)
+        entries[#entries + 1] = {
+            index = index,
+            edge = edge,
+            outerPoint = outerPoint,
+            angle = angleFromMerge(outerPoint, mergePoint),
+        }
+    end
+
+    table.sort(entries, compareEdgeCycleOrder)
+    return entries
+end
+
+local function getNextCycledInputIndex(junction)
+    local cycleEntries = buildCycleEntries(junction and junction.inputs or {}, junction and junction.mergePoint or nil)
+    if #cycleEntries <= 1 then
+        return 1
+    end
+
+    for orderIndex, entry in ipairs(cycleEntries) do
+        if entry.index == junction.activeInputIndex then
+            local nextEntry = cycleEntries[orderIndex + 1] or cycleEntries[1]
+            return nextEntry.index
+        end
+    end
+
+    return cycleEntries[1].index
+end
+
+local function getDirectionalOutputIndex(junction, inputIndex, controlType)
+    local outputs = junction and junction.outputs or {}
+    local inputs = junction and junction.inputs or {}
+    local inputEdge = inputs[inputIndex]
+    if not inputEdge or #outputs <= 0 then
+        return 1
+    end
+
+    local sortedInputs = buildSortedEntries(inputs, junction.mergePoint)
+    local sortedOutputs = buildSortedEntries(outputs, junction.mergePoint)
+    local inputRank = nil
+    for rank, entry in ipairs(sortedInputs) do
+        if entry.index == inputIndex then
+            inputRank = rank
+            break
+        end
+    end
+
+    if inputRank and #sortedOutputs > 0 then
+        local targetRank = inputRank
+        if controlType == "crossbar" then
+            targetRank = #sortedOutputs - inputRank + 1
+        end
+        targetRank = clamp(targetRank, 1, #sortedOutputs)
+        return sortedOutputs[targetRank].index
+    end
+
+    local inputDirX, inputDirY = getEdgeDirectionNearJunction(inputEdge, junction.mergePoint, false)
+    if not inputDirX or not inputDirY then
+        if controlType == "crossbar" then
+            return getCrossbarFallbackOutputIndex(junction, inputIndex)
+        end
+        return getRelayFallbackOutputIndex(junction, inputIndex)
+    end
+
+    local targetX = inputDirX
+    local targetY = -inputDirY
+    if controlType == "crossbar" then
+        targetX = -inputDirX
+        targetY = -inputDirY
+    end
+
+    local inputOuterPoint = getEdgeOuterPoint(inputEdge, junction.mergePoint)
+    local targetPointX = nil
+    local targetPointY = nil
+    if inputOuterPoint then
+        targetPointX = inputOuterPoint.x
+        targetPointY = (junction.mergePoint.y * 2) - inputOuterPoint.y
+        if controlType == "crossbar" then
+            targetPointX = (junction.mergePoint.x * 2) - inputOuterPoint.x
+        end
+    end
+
+    local bestIndex = nil
+    local bestDistance = math.huge
+    local bestScore = -math.huge
+    for outputIndex, outputEdge in ipairs(outputs) do
+        local outputDirX, outputDirY = getEdgeDirectionNearJunction(outputEdge, junction.mergePoint, true)
+        if outputDirX and outputDirY then
+            local score = dot(targetX, targetY, outputDirX, outputDirY)
+            local distance = math.huge
+            local outputOuterPoint = getEdgeOuterPoint(outputEdge, junction.mergePoint)
+            if targetPointX and targetPointY and outputOuterPoint then
+                distance = distanceSquared(outputOuterPoint.x, outputOuterPoint.y, targetPointX, targetPointY)
+            end
+
+            if distance + 0.0001 < bestDistance
+                or (math.abs(distance - bestDistance) <= 0.0001 and score > bestScore + 0.0001) then
+                bestDistance = distance
+                bestScore = score
+                bestIndex = outputIndex
+            end
+        end
+    end
+
+    if bestIndex then
+        return bestIndex
+    end
+
+    if controlType == "crossbar" then
+        return getCrossbarFallbackOutputIndex(junction, inputIndex)
+    end
+    return getRelayFallbackOutputIndex(junction, inputIndex)
+end
+
 local function carriagesOverlap(firstCar, secondCar, carriageLength, carriageHeight)
     local halfLength = (carriageLength or 0) * 0.5
     local halfHeight = (carriageHeight or 0) * 0.5
@@ -866,7 +1125,7 @@ function world:buildJunction(definition, existing)
     }
 
     if junction.control.type == "relay" and #junction.outputs > 0 then
-        junction.activeOutputIndex = clamp(junction.activeInputIndex, 1, #junction.outputs)
+        self:syncRelayOutput(junction)
     elseif junction.control.type == "crossbar" and #junction.outputs > 0 then
         self:syncCrossbarOutput(junction)
     end
@@ -1020,13 +1279,12 @@ function world:getReachableOutputEdgesForInput(junction, inputEdgeId)
 
     local controlType = junction.control and junction.control.type or "direct"
     if controlType == "relay" then
-        local relayOutput = junction.outputs[clamp(inputIndex, 1, #junction.outputs)]
+        local relayOutput = junction.outputs[getDirectionalOutputIndex(junction, inputIndex, "relay")]
         return relayOutput and { relayOutput } or {}
     end
 
     if controlType == "crossbar" then
-        local mirroredOutputIndex = clamp(#junction.outputs - inputIndex + 1, 1, #junction.outputs)
-        local crossbarOutput = junction.outputs[mirroredOutputIndex]
+        local crossbarOutput = junction.outputs[getDirectionalOutputIndex(junction, inputIndex, "crossbar")]
         return crossbarOutput and { crossbarOutput } or {}
     end
 
@@ -1377,6 +1635,12 @@ function world:cycleInput(junction)
         return false
     end
 
+    local controlType = junction.control and junction.control.type or "direct"
+    if controlType == "relay" or controlType == "crossbar" then
+        junction.activeInputIndex = getNextCycledInputIndex(junction)
+        return true
+    end
+
     junction.activeInputIndex = junction.activeInputIndex + 1
     if junction.activeInputIndex > #junction.inputs then
         junction.activeInputIndex = 1
@@ -1404,7 +1668,7 @@ function world:syncRelayOutput(junction)
         return
     end
 
-    junction.activeOutputIndex = clamp(junction.activeInputIndex, 1, #junction.outputs)
+    junction.activeOutputIndex = getDirectionalOutputIndex(junction, junction.activeInputIndex, "relay")
 end
 
 function world:syncCrossbarOutput(junction)
@@ -1412,7 +1676,7 @@ function world:syncCrossbarOutput(junction)
         return
     end
 
-    junction.activeOutputIndex = clamp(#junction.outputs - junction.activeInputIndex + 1, 1, #junction.outputs)
+    junction.activeOutputIndex = getDirectionalOutputIndex(junction, junction.activeInputIndex, "crossbar")
 end
 
 local function isPlayPhaseOnlyControl(controlType)

--- a/tests/map_editor_directional_junction_cycle_test.lua
+++ b/tests/map_editor_directional_junction_cycle_test.lua
@@ -1,0 +1,156 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+love.timer = love.timer or {
+    getTime = function()
+        return 0
+    end,
+}
+love.filesystem = love.filesystem or {}
+love.keyboard = love.keyboard or {
+    isDown = function()
+        return false
+    end,
+}
+love.mouse = love.mouse or {
+    isDown = function()
+        return false
+    end,
+}
+
+local mapEditor = require("src.game.editor.map_editor")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function assertTrue(value, label)
+    if not value then
+        error(label, 2)
+    end
+end
+
+local editorData = {
+    endpoints = {
+        { id = "input_blue", kind = "input", x = 0.2805, y = 0.1536, colors = { "blue" } },
+        { id = "output_blue", kind = "output", x = 0.7523, y = 0.8943, colors = { "blue" } },
+        { id = "input_yellow", kind = "input", x = 0.7817, y = 0.1953, colors = { "yellow" } },
+        { id = "output_yellow", kind = "output", x = 0.2089, y = 0.8839, colors = { "yellow" } },
+        { id = "input_mint", kind = "input", x = 0.4401, y = 0.1390, colors = { "mint" } },
+        { id = "output_mint", kind = "output", x = 0.5903, y = 0.9214, colors = { "mint" } },
+        { id = "input_rose", kind = "input", x = 0.6235, y = 0.1346, colors = { "rose" } },
+        { id = "output_rose", kind = "output", x = 0.4038, y = 0.8995, colors = { "rose" } },
+        { id = "input_orange", kind = "input", x = 0.7714, y = 0.7287, colors = { "orange" } },
+        { id = "output_orange", kind = "output", x = 0.2710, y = 0.3217, colors = { "orange" } },
+    },
+    routes = {
+        {
+            id = "route_blue",
+            label = "route_blue",
+            color = "blue",
+            startEndpointId = "input_blue",
+            endEndpointId = "output_blue",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.2805, y = 0.1536 },
+                { x = 0.5129, y = 0.5184 },
+                { x = 0.7523, y = 0.8943 },
+            },
+        },
+        {
+            id = "route_yellow",
+            label = "route_yellow",
+            color = "yellow",
+            startEndpointId = "input_yellow",
+            endEndpointId = "output_yellow",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.7817, y = 0.1953 },
+                { x = 0.5129, y = 0.5184 },
+                { x = 0.2089, y = 0.8839 },
+            },
+        },
+        {
+            id = "route_mint",
+            label = "route_mint",
+            color = "mint",
+            startEndpointId = "input_mint",
+            endEndpointId = "output_mint",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.4401, y = 0.1390 },
+                { x = 0.5129, y = 0.5184 },
+                { x = 0.5903, y = 0.9214 },
+            },
+        },
+        {
+            id = "route_rose",
+            label = "route_rose",
+            color = "rose",
+            startEndpointId = "input_rose",
+            endEndpointId = "output_rose",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.6235, y = 0.1346 },
+                { x = 0.5129, y = 0.5184 },
+                { x = 0.4038, y = 0.8995 },
+            },
+        },
+        {
+            id = "route_orange",
+            label = "route_orange",
+            color = "orange",
+            startEndpointId = "input_orange",
+            endEndpointId = "output_orange",
+            segmentRoadTypes = { "normal" },
+            points = {
+                { x = 0.7714, y = 0.7287 },
+                { x = 0.5129, y = 0.5184 },
+                { x = 0.2710, y = 0.3217 },
+            },
+        },
+    },
+    junctions = {},
+    trains = {},
+}
+
+local editor = mapEditor.new(1280, 720, nil)
+editor:loadEditorData(editorData, "Directional Junction Cycle Regression", nil, nil)
+
+assertEqual(#(editor.intersections or {}), 1, "crossing routes should produce one intersection")
+local intersection = editor.intersections[1]
+
+editor:setIntersectionControlType(intersection, "crossbar")
+assertEqual(intersection.activeInputIndex, 1, "crossbar starts on blue")
+assertEqual(intersection.activeOutputIndex, 3, "crossbar blue should map to blue on the preview intersection")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "crossbar should cycle to the second lane")
+assertEqual(intersection.activeInputIndex, 2, "crossbar second lane should be mint")
+assertEqual(intersection.activeOutputIndex, 5, "crossbar mint should map to mint")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "crossbar should cycle to the third lane")
+assertEqual(intersection.activeInputIndex, 3, "crossbar third lane should be rose")
+assertEqual(intersection.activeOutputIndex, 4, "crossbar rose should map to rose")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "crossbar should cycle to yellow before orange")
+assertEqual(intersection.activeInputIndex, 5, "crossbar fourth visual lane should be yellow")
+assertEqual(intersection.activeOutputIndex, 2, "crossbar yellow should map to yellow")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "crossbar should cycle to orange last")
+assertEqual(intersection.activeInputIndex, 4, "crossbar fifth visual lane should be orange")
+assertEqual(intersection.activeOutputIndex, 1, "crossbar orange should map to orange")
+
+editor:setIntersectionControlType(intersection, "relay")
+intersection.activeInputIndex = 3
+editor:syncIntersectionOutputToControl(intersection)
+assertEqual(intersection.activeOutputIndex, 4, "relay rose should map to rose")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "relay should cycle from rose to yellow before orange")
+assertEqual(intersection.activeInputIndex, 5, "relay fourth visual lane should be yellow")
+
+assertTrue(editor:cycleIntersectionInput(intersection), "relay should cycle from yellow to orange last")
+assertEqual(intersection.activeInputIndex, 4, "relay fifth visual lane should be orange")
+
+print("map editor directional junction cycle tests passed")

--- a/tests/world_directional_junction_mapping_test.lua
+++ b/tests/world_directional_junction_mapping_test.lua
@@ -1,0 +1,491 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+love = love or {}
+
+local world = require("src.game.gameplay.railway_world")
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %q but got %q", label, expected, actual), 2)
+    end
+end
+
+local function buildSimulation(controlType)
+    return world.new(1200, 800, {
+        junctions = {
+            {
+                id = controlType .. "_directional",
+                label = controlType,
+                control = {
+                    type = controlType,
+                },
+                activeInputIndex = 1,
+                activeOutputIndex = 1,
+                inputs = {
+                    {
+                        id = controlType .. "_input_top_left",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        inputPoints = {
+                            { x = 0.20, y = 0.10 },
+                            { x = 0.32, y = 0.28 },
+                            { x = 0.50, y = 0.50 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_top_right",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "yellow" },
+                        inputPoints = {
+                            { x = 0.80, y = 0.10 },
+                            { x = 0.68, y = 0.28 },
+                            { x = 0.50, y = 0.50 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = controlType .. "_output_bottom_right",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "blue", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.50, y = 0.50 },
+                            { x = 0.68, y = 0.72 },
+                            { x = 0.80, y = 0.90 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_bottom_left",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.50, y = 0.50 },
+                            { x = 0.32, y = 0.72 },
+                            { x = 0.20, y = 0.90 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {},
+    })
+end
+
+local function buildRankedLaneSimulation(controlType)
+    return world.new(1200, 800, {
+        junctions = {
+            {
+                id = controlType .. "_ranked",
+                label = controlType,
+                control = {
+                    type = controlType,
+                },
+                activeInputIndex = 1,
+                activeOutputIndex = 1,
+                inputs = {
+                    {
+                        id = controlType .. "_input_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "yellow" },
+                        inputPoints = {
+                            { x = 0.28, y = 0.22 },
+                            { x = 0.40, y = 0.55 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "mint" },
+                        inputPoints = {
+                            { x = 0.34, y = 0.22 },
+                            { x = 0.40, y = 0.55 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "rose" },
+                        inputPoints = {
+                            { x = 0.50, y = 0.22 },
+                            { x = 0.40, y = 0.55 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "orange" },
+                        inputPoints = {
+                            { x = 0.63, y = 0.22 },
+                            { x = 0.40, y = 0.55 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = controlType .. "_output_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "yellow", "mint", "rose", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.40, y = 0.55 },
+                            { x = 0.30, y = 0.78 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "yellow", "mint", "rose", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.40, y = 0.55 },
+                            { x = 0.37, y = 0.79 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "yellow", "mint", "rose", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.40, y = 0.55 },
+                            { x = 0.45, y = 0.79 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "yellow", "mint", "rose", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.40, y = 0.55 },
+                            { x = 0.51, y = 0.80 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {},
+    })
+end
+
+local function buildAsymmetricRankedSimulation(controlType)
+    return world.new(1200, 800, {
+        junctions = {
+            {
+                id = controlType .. "_asymmetric",
+                label = controlType,
+                control = {
+                    type = controlType,
+                },
+                activeInputIndex = 1,
+                activeOutputIndex = 1,
+                inputs = {
+                    {
+                        id = controlType .. "_input_blue",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        inputPoints = {
+                            { x = 0.36, y = 0.21 },
+                            { x = 0.46, y = 0.54 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "mint" },
+                        inputPoints = {
+                            { x = 0.40, y = 0.21 },
+                            { x = 0.46, y = 0.54 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "rose" },
+                        inputPoints = {
+                            { x = 0.54, y = 0.18 },
+                            { x = 0.46, y = 0.54 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "yellow" },
+                        inputPoints = {
+                            { x = 0.60, y = 0.25 },
+                            { x = 0.46, y = 0.54 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "orange" },
+                        inputPoints = {
+                            { x = 0.67, y = 0.70 },
+                            { x = 0.46, y = 0.54 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = controlType .. "_output_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "blue", "mint", "rose", "yellow", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.46, y = 0.54 },
+                            { x = 0.25, y = 0.37 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "blue", "mint", "rose", "yellow", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.46, y = 0.54 },
+                            { x = 0.29, y = 0.90 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "blue", "mint", "rose", "yellow", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.46, y = 0.54 },
+                            { x = 0.39, y = 0.90 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "blue", "mint", "rose", "yellow", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.46, y = 0.54 },
+                            { x = 0.53, y = 0.93 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_blue",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue", "mint", "rose", "yellow", "orange" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.46, y = 0.54 },
+                            { x = 0.59, y = 0.92 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {},
+    })
+end
+
+local function buildAsymmetricCycleSimulation(controlType)
+    return world.new(1200, 800, {
+        junctions = {
+            {
+                id = controlType .. "_cycle",
+                label = controlType,
+                control = {
+                    type = controlType,
+                },
+                activeInputIndex = 3,
+                activeOutputIndex = 1,
+                inputs = {
+                    {
+                        id = controlType .. "_input_blue",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue" },
+                        inputPoints = {
+                            { x = 0.28, y = 0.15 },
+                            { x = 0.51, y = 0.52 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "mint" },
+                        inputPoints = {
+                            { x = 0.44, y = 0.14 },
+                            { x = 0.51, y = 0.52 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "rose" },
+                        inputPoints = {
+                            { x = 0.62, y = 0.13 },
+                            { x = 0.51, y = 0.52 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "orange" },
+                        inputPoints = {
+                            { x = 0.77, y = 0.73 },
+                            { x = 0.51, y = 0.52 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_input_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "yellow" },
+                        inputPoints = {
+                            { x = 0.78, y = 0.20 },
+                            { x = 0.51, y = 0.52 },
+                        },
+                    },
+                },
+                outputs = {
+                    {
+                        id = controlType .. "_output_orange",
+                        color = { 0.98, 0.70, 0.28 },
+                        colors = { "blue", "mint", "rose", "orange", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.51, y = 0.52 },
+                            { x = 0.27, y = 0.32 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_yellow",
+                        color = { 0.98, 0.82, 0.34 },
+                        colors = { "blue", "mint", "rose", "orange", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.51, y = 0.52 },
+                            { x = 0.21, y = 0.88 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_blue",
+                        color = { 0.33, 0.80, 0.98 },
+                        colors = { "blue", "mint", "rose", "orange", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.51, y = 0.52 },
+                            { x = 0.75, y = 0.89 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_rose",
+                        color = { 0.98, 0.48, 0.62 },
+                        colors = { "blue", "mint", "rose", "orange", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.51, y = 0.52 },
+                            { x = 0.40, y = 0.90 },
+                        },
+                    },
+                    {
+                        id = controlType .. "_output_mint",
+                        color = { 0.40, 0.92, 0.76 },
+                        colors = { "blue", "mint", "rose", "orange", "yellow" },
+                        adoptInputColor = true,
+                        outputPoints = {
+                            { x = 0.51, y = 0.52 },
+                            { x = 0.59, y = 0.92 },
+                        },
+                    },
+                },
+            },
+        },
+        trains = {},
+    })
+end
+
+local relaySimulation = buildSimulation("relay")
+local relayJunction = relaySimulation.junctions.relay_directional
+
+assertEqual(
+    relayJunction.activeOutputIndex,
+    2,
+    "relay should reflect the top-left input across the y axis even when outputs are shuffled"
+)
+
+local relayReachableFirst = relaySimulation:getReachableOutputEdgesForInput(relayJunction, relayJunction.inputs[1].id)
+assertEqual(relayReachableFirst[1].id, relayJunction.outputs[2].id, "relay reachable output should stay on the same x side for the top-left input")
+
+relayJunction.activeInputIndex = 2
+relaySimulation:syncRelayOutput(relayJunction)
+assertEqual(relayJunction.activeOutputIndex, 1, "relay should reflect the top-right input onto the bottom-right output")
+
+local relayReachableSecond = relaySimulation:getReachableOutputEdgesForInput(relayJunction, relayJunction.inputs[2].id)
+assertEqual(relayReachableSecond[1].id, relayJunction.outputs[1].id, "relay reachable output should stay on the same x side for the top-right input")
+
+local crossbarSimulation = buildSimulation("crossbar")
+local crossbarJunction = crossbarSimulation.junctions.crossbar_directional
+
+assertEqual(
+    crossbarJunction.activeOutputIndex,
+    1,
+    "crossbar should choose the fully opposite diagonal for the top-left input even when outputs are shuffled"
+)
+
+local crossbarReachableFirst = crossbarSimulation:getReachableOutputEdgesForInput(crossbarJunction, crossbarJunction.inputs[1].id)
+assertEqual(crossbarReachableFirst[1].id, crossbarJunction.outputs[1].id, "crossbar reachable output should be diagonally opposite for the top-left input")
+
+crossbarJunction.activeInputIndex = 2
+crossbarSimulation:syncCrossbarOutput(crossbarJunction)
+assertEqual(crossbarJunction.activeOutputIndex, 2, "crossbar should choose the fully opposite diagonal for the top-right input")
+
+local crossbarReachableSecond = crossbarSimulation:getReachableOutputEdgesForInput(crossbarJunction, crossbarJunction.inputs[2].id)
+assertEqual(crossbarReachableSecond[1].id, crossbarJunction.outputs[2].id, "crossbar reachable output should be diagonally opposite for the top-right input")
+
+local rankedRelaySimulation = buildRankedLaneSimulation("relay")
+local rankedRelayJunction = rankedRelaySimulation.junctions.relay_ranked
+
+assertEqual(rankedRelaySimulation:getReachableOutputEdgesForInput(rankedRelayJunction, rankedRelayJunction.inputs[1].id)[1].id, rankedRelayJunction.outputs[1].id, "relay should keep the first horizontal lane rank")
+assertEqual(rankedRelaySimulation:getReachableOutputEdgesForInput(rankedRelayJunction, rankedRelayJunction.inputs[2].id)[1].id, rankedRelayJunction.outputs[2].id, "relay should keep the second horizontal lane rank")
+assertEqual(rankedRelaySimulation:getReachableOutputEdgesForInput(rankedRelayJunction, rankedRelayJunction.inputs[3].id)[1].id, rankedRelayJunction.outputs[3].id, "relay should keep the third horizontal lane rank")
+assertEqual(rankedRelaySimulation:getReachableOutputEdgesForInput(rankedRelayJunction, rankedRelayJunction.inputs[4].id)[1].id, rankedRelayJunction.outputs[4].id, "relay should keep the fourth horizontal lane rank")
+
+local rankedCrossbarSimulation = buildRankedLaneSimulation("crossbar")
+local rankedCrossbarJunction = rankedCrossbarSimulation.junctions.crossbar_ranked
+
+assertEqual(rankedCrossbarSimulation:getReachableOutputEdgesForInput(rankedCrossbarJunction, rankedCrossbarJunction.inputs[1].id)[1].id, rankedCrossbarJunction.outputs[4].id, "crossbar should reverse the horizontal lane rank for the first input")
+assertEqual(rankedCrossbarSimulation:getReachableOutputEdgesForInput(rankedCrossbarJunction, rankedCrossbarJunction.inputs[2].id)[1].id, rankedCrossbarJunction.outputs[3].id, "crossbar should reverse the horizontal lane rank for the second input")
+assertEqual(rankedCrossbarSimulation:getReachableOutputEdgesForInput(rankedCrossbarJunction, rankedCrossbarJunction.inputs[3].id)[1].id, rankedCrossbarJunction.outputs[2].id, "crossbar should reverse the horizontal lane rank for the third input")
+assertEqual(rankedCrossbarSimulation:getReachableOutputEdgesForInput(rankedCrossbarJunction, rankedCrossbarJunction.inputs[4].id)[1].id, rankedCrossbarJunction.outputs[1].id, "crossbar should reverse the horizontal lane rank for the fourth input")
+
+local asymmetricRelaySimulation = buildAsymmetricRankedSimulation("relay")
+local asymmetricRelayJunction = asymmetricRelaySimulation.junctions.relay_asymmetric
+
+assertEqual(asymmetricRelaySimulation:getReachableOutputEdgesForInput(asymmetricRelayJunction, asymmetricRelayJunction.inputs[1].id)[1].id, asymmetricRelayJunction.outputs[1].id, "relay should keep the first global horizontal rank")
+assertEqual(asymmetricRelaySimulation:getReachableOutputEdgesForInput(asymmetricRelayJunction, asymmetricRelayJunction.inputs[2].id)[1].id, asymmetricRelayJunction.outputs[2].id, "relay should keep the second global horizontal rank")
+assertEqual(asymmetricRelaySimulation:getReachableOutputEdgesForInput(asymmetricRelayJunction, asymmetricRelayJunction.inputs[3].id)[1].id, asymmetricRelayJunction.outputs[3].id, "relay should keep the third global horizontal rank")
+assertEqual(asymmetricRelaySimulation:getReachableOutputEdgesForInput(asymmetricRelayJunction, asymmetricRelayJunction.inputs[4].id)[1].id, asymmetricRelayJunction.outputs[4].id, "relay should keep the fourth global horizontal rank")
+assertEqual(asymmetricRelaySimulation:getReachableOutputEdgesForInput(asymmetricRelayJunction, asymmetricRelayJunction.inputs[5].id)[1].id, asymmetricRelayJunction.outputs[5].id, "relay should rerank the fifth added line instead of keeping a one-item side bucket")
+
+local asymmetricCrossbarSimulation = buildAsymmetricRankedSimulation("crossbar")
+local asymmetricCrossbarJunction = asymmetricCrossbarSimulation.junctions.crossbar_asymmetric
+
+assertEqual(asymmetricCrossbarSimulation:getReachableOutputEdgesForInput(asymmetricCrossbarJunction, asymmetricCrossbarJunction.inputs[1].id)[1].id, asymmetricCrossbarJunction.outputs[5].id, "crossbar should reverse the global horizontal rank for the first asymmetric input")
+assertEqual(asymmetricCrossbarSimulation:getReachableOutputEdgesForInput(asymmetricCrossbarJunction, asymmetricCrossbarJunction.inputs[2].id)[1].id, asymmetricCrossbarJunction.outputs[4].id, "crossbar should reverse the global horizontal rank for the second asymmetric input")
+assertEqual(asymmetricCrossbarSimulation:getReachableOutputEdgesForInput(asymmetricCrossbarJunction, asymmetricCrossbarJunction.inputs[3].id)[1].id, asymmetricCrossbarJunction.outputs[3].id, "crossbar should reverse the global horizontal rank for the third asymmetric input")
+assertEqual(asymmetricCrossbarSimulation:getReachableOutputEdgesForInput(asymmetricCrossbarJunction, asymmetricCrossbarJunction.inputs[4].id)[1].id, asymmetricCrossbarJunction.outputs[2].id, "crossbar should reverse the global horizontal rank for the fourth asymmetric input")
+assertEqual(asymmetricCrossbarSimulation:getReachableOutputEdgesForInput(asymmetricCrossbarJunction, asymmetricCrossbarJunction.inputs[5].id)[1].id, asymmetricCrossbarJunction.outputs[1].id, "crossbar should reverse the global horizontal rank for the fifth asymmetric input")
+
+local relayCycleSimulation = buildAsymmetricCycleSimulation("relay")
+local relayCycleJunction = relayCycleSimulation.junctions.relay_cycle
+relayCycleSimulation:cycleInput(relayCycleJunction)
+assertEqual(relayCycleJunction.activeInputIndex, 5, "relay should cycle from rose to yellow before the bottom-right orange lane")
+relayCycleSimulation:cycleInput(relayCycleJunction)
+assertEqual(relayCycleJunction.activeInputIndex, 4, "relay should cycle from yellow to orange after exhausting the top-side lanes")
+
+local crossbarCycleSimulation = buildAsymmetricCycleSimulation("crossbar")
+local crossbarCycleJunction = crossbarCycleSimulation.junctions.crossbar_cycle
+crossbarCycleSimulation:cycleInput(crossbarCycleJunction)
+assertEqual(crossbarCycleJunction.activeInputIndex, 5, "crossbar should cycle from rose to yellow before the bottom-right orange lane")
+crossbarCycleSimulation:cycleInput(crossbarCycleJunction)
+assertEqual(crossbarCycleJunction.activeInputIndex, 4, "crossbar should cycle from yellow to orange after exhausting the top-side lanes")
+
+print("world directional junction mapping tests passed")


### PR DESCRIPTION
## Requested Behavior
Make relay and crossbar junctions choose outputs based on the junction geometry instead of raw lane order. Relay should keep the same-side y-axis pairing, while crossbar should use the full x/y opposite pairing. The cycle order should also follow the visual radial order so newly added lanes do not fall out of sequence.

## Summary
- Updated relay and crossbar routing to use geometry-aware lane matching instead of index-based pairing
- Fixed junction cycling in both gameplay and editor paths so relay/crossbar move through lanes in visual order
- Added regression coverage for asymmetric 5-lane junctions and the editor preview/state flow

## Testing
- Added and ran focused unit/regression tests for directional junction mapping
- Verified the editor cycle behavior against the saved `crossbow_relay_test` map shape
- Existing world preparation and minimum-distance crossbar tests still pass