### PR TITLE
Fix multiline visibility for shared junction lanes

### DIFF
--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -925,20 +925,21 @@ function renderer.drawScene(scene, options)
     for _, junction in ipairs(scene.junctionOrder or {}) do
         for outputIndex = 1, #junction.outputs do
             local outputTrack = junction.outputs[outputIndex]
-            renderer.drawOutputTrack(scene, junction, outputIndex, outputTrack and highlightedEdgeIds[outputTrack.id] == true)
-            if outputTrack then
+            if outputTrack and not drawnEdgeIds[outputTrack.id] then
+                renderer.drawOutputTrack(scene, junction, outputIndex, highlightedEdgeIds[outputTrack.id] == true)
                 drawnEdgeIds[outputTrack.id] = true
             end
         end
+    end
 
+    for _, junction in ipairs(scene.junctionOrder or {}) do
         for inputIndex = 1, #junction.inputs do
             local inputTrack = junction.inputs[inputIndex]
-            renderer.drawInputTrack(scene, inputTrack, inputTrack and highlightedEdgeIds[inputTrack.id] == true)
-            if inputTrack then
+            if inputTrack and not drawnEdgeIds[inputTrack.id] then
+                renderer.drawInputTrack(scene, inputTrack, highlightedEdgeIds[inputTrack.id] == true)
                 drawnEdgeIds[inputTrack.id] = true
             end
         end
-
     end
 
     for _, track in pairs(scene.edges or {}) do

--- a/tests/track_scene_renderer_layering_test.lua
+++ b/tests/track_scene_renderer_layering_test.lua
@@ -179,4 +179,93 @@ assertTrue(crossingIndex ~= nil, "crossing should be rendered")
 assertTrue(crossingIndex > standaloneIndex, "crossing should render after standalone lanes so the junction stays on top")
 assertEqual(drawOrder[#drawOrder], "selector:junction_alpha", "output selector should stay on the final overlay pass")
 
+drawOrder = {}
+
+renderer.drawOutputTrack = function(_, junction, outputIndex, _)
+    local track = junction.outputs[outputIndex]
+    drawOrder[#drawOrder + 1] = "output:" .. tostring(track and track.id)
+end
+renderer.drawInputTrack = function(_, track, _)
+    drawOrder[#drawOrder + 1] = "input:" .. tostring(track and track.id)
+end
+renderer.drawStandaloneTrack = function(_, track, _)
+    drawOrder[#drawOrder + 1] = "standalone:" .. tostring(track.id)
+end
+renderer.drawCrossing = function()
+end
+renderer.drawTrackSignal = function()
+end
+renderer.drawTrain = function()
+end
+renderer.drawOutputSelector = function()
+end
+
+renderer.drawScene({
+    viewport = { w = 320, h = 200 },
+    junctionOrder = {
+        {
+            id = "junction_upper",
+            outputs = {},
+            inputs = {
+                { id = "shared_edge", signalPoint = { x = 0, y = 0 } },
+                { id = "upper_input", signalPoint = { x = 0, y = 0 } },
+            },
+            control = { type = "direct" },
+            mergePoint = { x = 20, y = 20 },
+            crossingRadius = 24,
+            activeInputIndex = 1,
+            activeOutputIndex = 1,
+        },
+        {
+            id = "junction_lower",
+            outputs = {
+                { id = "shared_edge" },
+            },
+            inputs = {
+                { id = "lower_input", signalPoint = { x = 0, y = 0 } },
+            },
+            control = { type = "direct" },
+            mergePoint = { x = 20, y = 60 },
+            crossingRadius = 24,
+            activeInputIndex = 1,
+            activeOutputIndex = 1,
+        },
+    },
+    edges = {},
+    trains = {},
+    getHighlightedEdgeIds = function()
+        return {}
+    end,
+}, {})
+
+renderer.drawOutputTrack = originalDrawOutputTrack
+renderer.drawInputTrack = originalDrawInputTrack
+renderer.drawStandaloneTrack = originalDrawStandaloneTrack
+renderer.drawCrossing = originalDrawCrossing
+renderer.drawTrackSignal = originalDrawTrackSignal
+renderer.drawTrain = originalDrawTrain
+renderer.drawOutputSelector = originalDrawOutputSelector
+
+local sharedEdgeOutputCount = 0
+local sharedEdgeInputCount = 0
+local upperInputCount = 0
+local lowerInputCount = 0
+
+for _, call in ipairs(drawOrder) do
+    if call == "output:shared_edge" then
+        sharedEdgeOutputCount = sharedEdgeOutputCount + 1
+    elseif call == "input:shared_edge" then
+        sharedEdgeInputCount = sharedEdgeInputCount + 1
+    elseif call == "input:upper_input" then
+        upperInputCount = upperInputCount + 1
+    elseif call == "input:lower_input" then
+        lowerInputCount = lowerInputCount + 1
+    end
+end
+
+assertEqual(sharedEdgeOutputCount, 1, "shared junction-to-junction edge should render once on the output pass")
+assertEqual(sharedEdgeInputCount, 0, "shared junction-to-junction edge should not be redrawn on the input pass")
+assertEqual(upperInputCount, 1, "non-shared upper input should still render once")
+assertEqual(lowerInputCount, 1, "non-shared lower input should still render once")
+
 print("track scene renderer layering tests passed")


### PR DESCRIPTION
## Requested Behavior
- Fix the editor so multiline routes do not disappear when a shared lane runs through a junction before another junction.
- Keep shared junction-to-junction lanes visible and stable in the editor preview.

## Summary
- Prevented shared edges from being drawn twice in the scene renderer.
- Kept output and input track rendering in separate passes so a shared lane is painted once with consistent styling.
- Added a regression test for the consecutive junction case.

## Testing
- `tests/track_scene_renderer_layering_test.lua` passed.
- Not run: editor shared-lane regression tests under the local Lua 5.1 runtime, which cannot load this codebase because it uses `goto`.