### PR TITLE
Add juicy intro and replay-driven menu presentation

### DIFF
--- a/src/game/app/game_map_presentation.lua
+++ b/src/game/app/game_map_presentation.lua
@@ -1,0 +1,65 @@
+local mapPresentation = require("src.game.app.map_presentation")
+
+return function(Game, shared)
+    setfenv(1, setmetatable({ Game = Game }, {
+        __index = function(_, key)
+            local sharedValue = shared[key]
+            if sharedValue ~= nil then
+                return sharedValue
+            end
+
+            return _G[key]
+        end,
+    }))
+
+function Game:beginMapPresentation(mapDescriptor)
+    if not self.world then
+        self.mapPresentation = nil
+        return nil
+    end
+
+    self.mapPresentation = mapPresentation.buildState(self.world, mapDescriptor or self.currentMapDescriptor, self.profile)
+    return self.mapPresentation
+end
+
+function Game:isMapPresentationActive()
+    return self.screen == "play"
+        and self.mapPresentation ~= nil
+        and mapPresentation.isBlocking(self.mapPresentation)
+end
+
+function Game:updateMapPresentation(dt)
+    if not self.mapPresentation then
+        return false
+    end
+
+    local finished = mapPresentation.update(self.mapPresentation, dt)
+    if finished then
+        self.mapPresentation = nil
+    end
+    return finished
+end
+
+function Game:skipMapPresentation()
+    if not self.mapPresentation then
+        return false
+    end
+
+    self.mapPresentation = mapPresentation.skip(self.mapPresentation)
+    self.playHoverInfo = nil
+    return true
+end
+
+function Game:getMapPresentationDrawOptions()
+    if self.screen ~= "play" or self.playPhase ~= "prepare" or not self.mapPresentation or not mapPresentation.isBlocking(self.mapPresentation) then
+        return nil
+    end
+
+    return {
+        presentation = self.mapPresentation,
+        drawTrains = false,
+        drawCollision = false,
+    }
+end
+
+end

--- a/src/game/app/game_menu_background.lua
+++ b/src/game/app/game_menu_background.lua
@@ -1,0 +1,254 @@
+local mapPresentation = require("src.game.app.map_presentation")
+
+return function(Game, shared)
+    setfenv(1, setmetatable({ Game = Game }, {
+        __index = function(_, key)
+            local sharedValue = shared[key]
+            if sharedValue ~= nil then
+                return sharedValue
+            end
+
+            return _G[key]
+        end,
+    }))
+
+local MENU_BACKGROUND_BUILTIN_REPLAY_DIR = "src/game/data/replays/campaign"
+local MENU_BACKGROUND_LOCAL_REPLAY_DIR = "cache/replays"
+local MENU_BACKGROUND_OUTRO_DURATION = 0.56
+local MENU_BACKGROUND_REPLAY_END_EPSILON = 0.0005
+
+local function clamp(value, minValue, maxValue)
+    if value < minValue then
+        return minValue
+    end
+    if value > maxValue then
+        return maxValue
+    end
+    return value
+end
+
+local function isTomlReplayFile(fileName)
+    return type(fileName) == "string" and fileName:match("%.toml$") ~= nil
+end
+
+local function listReplayPathsInDirectory(directoryPath, source)
+    local candidates = {}
+    if not love.filesystem.getInfo(directoryPath, "directory") then
+        return candidates
+    end
+
+    local fileNames = love.filesystem.getDirectoryItems(directoryPath)
+    table.sort(fileNames)
+    for _, fileName in ipairs(fileNames) do
+        if isTomlReplayFile(fileName) then
+            candidates[#candidates + 1] = {
+                path = directoryPath .. "/" .. fileName,
+                source = source,
+            }
+        end
+    end
+
+    return candidates
+end
+
+local function getRandomIndex(count)
+    if count <= 0 then
+        return nil
+    end
+
+    if love and love.math and love.math.random then
+        return love.math.random(count)
+    end
+
+    return math.random(count)
+end
+
+function Game:getMenuBackgroundReplayCandidates()
+    local candidates = {}
+
+    for _, candidate in ipairs(listReplayPathsInDirectory(MENU_BACKGROUND_LOCAL_REPLAY_DIR, "local")) do
+        candidates[#candidates + 1] = candidate
+    end
+
+    for _, candidate in ipairs(listReplayPathsInDirectory(MENU_BACKGROUND_BUILTIN_REPLAY_DIR, "builtin")) do
+        candidates[#candidates + 1] = candidate
+    end
+
+    return candidates
+end
+
+function Game:buildMenuBackgroundReplayState(candidate)
+    local resolvedCandidate = type(candidate) == "table" and candidate or nil
+    local replayPath = tostring(resolvedCandidate and resolvedCandidate.path or "")
+    if replayPath == "" then
+        return nil
+    end
+
+    local replayRecord = replayStorage.load(replayPath)
+    if type(replayRecord) ~= "table" then
+        return nil
+    end
+
+    local mapDescriptor = self:getMapDescriptorByUuid(
+        tostring(replayRecord.mapUuid or ""),
+        tostring(replayRecord.mapHash or "")
+    )
+    if not mapDescriptor then
+        return nil
+    end
+
+    local replayLevelSource = self:getReplayLevelSourceForDescriptor(mapDescriptor)
+    if type(replayLevelSource) ~= "table" then
+        return nil
+    end
+
+    local runtime = replayRuntime.new(
+        replayLevelSource,
+        replayRecord,
+        self.viewport.w,
+        self.viewport.h
+    )
+    local presentation = mapPresentation.buildState(runtime.playbackWorld, mapDescriptor, self.profile)
+    if not presentation then
+        return nil
+    end
+
+    return {
+        candidatePath = replayPath,
+        source = resolvedCandidate.source or "unknown",
+        replayRecord = replayRecord,
+        mapDescriptor = mapDescriptor,
+        replayLevelSource = replayLevelSource,
+        replayRuntime = runtime,
+        presentation = presentation,
+        phase = "intro",
+        outroElapsed = 0,
+    }
+end
+
+function Game:startMenuBackgroundReplayLoop()
+    local candidates = self:getMenuBackgroundReplayCandidates()
+    local skippedLastPath = false
+
+    while #candidates > 0 do
+        local candidateIndex = getRandomIndex(#candidates) or 1
+        local candidate = table.remove(candidates, candidateIndex)
+        if #candidates > 0
+            and not skippedLastPath
+            and candidate.path == self.menuBackgroundReplayLastPath then
+            skippedLastPath = true
+            candidates[#candidates + 1] = candidate
+        else
+            local replayState = self:buildMenuBackgroundReplayState(candidate)
+            if replayState then
+                self.menuBackgroundReplay = replayState
+                return replayState
+            end
+        end
+    end
+
+    self.menuBackgroundReplay = nil
+    return nil
+end
+
+function Game:resetMenuBackgroundReplayLoop()
+    self.menuBackgroundReplay = nil
+    return self:startMenuBackgroundReplayLoop()
+end
+
+function Game:updateMenuBackgroundReplay(dt)
+    if self.screen ~= "menu" then
+        return false
+    end
+
+    if not self.menuBackgroundReplay then
+        return self:startMenuBackgroundReplayLoop() ~= nil
+    end
+
+    local replayState = self.menuBackgroundReplay
+    if replayState.phase == "intro" then
+        if mapPresentation.update(replayState.presentation, dt) then
+            replayState.phase = "replay"
+            replayState.replayRuntime:seek(0)
+            replayState.replayRuntime:setPlaying(true)
+        end
+        return true
+    end
+
+    if replayState.phase == "replay" then
+        replayState.replayRuntime:update(dt)
+        if replayState.replayRuntime.isPlaying ~= true
+            and (replayState.replayRuntime.currentTime or 0) >= ((replayState.replayRuntime.duration or 0) - MENU_BACKGROUND_REPLAY_END_EPSILON) then
+            replayState.phase = "outro"
+            replayState.outroElapsed = 0
+        end
+        return true
+    end
+
+    if replayState.phase == "outro" then
+        replayState.outroElapsed = math.max(0, (replayState.outroElapsed or 0) + math.max(0, dt or 0))
+        if replayState.outroElapsed >= MENU_BACKGROUND_OUTRO_DURATION then
+            self.menuBackgroundReplayLastPath = replayState.candidatePath
+            self:startMenuBackgroundReplayLoop()
+        end
+        return true
+    end
+
+    return false
+end
+
+function Game:hasMenuBackgroundReplay()
+    return self.screen == "menu"
+        and self.menuBackgroundReplay ~= nil
+        and self.menuBackgroundReplay.replayRuntime ~= nil
+        and self.menuBackgroundReplay.replayRuntime.playbackWorld ~= nil
+end
+
+function Game:getMenuBackgroundReplayTitleState()
+    local replayState = self.menuBackgroundReplay
+    if not replayState or replayState.phase ~= "intro" then
+        return nil
+    end
+
+    local titleEndTime = replayState.presentation
+        and replayState.presentation.titleSequence
+        and replayState.presentation.titleSequence.endTime
+        or 0
+    if (replayState.presentation and replayState.presentation.elapsed or 0) >= titleEndTime then
+        return nil
+    end
+
+    return replayState.presentation
+end
+
+function Game:getMenuBackgroundReplayDrawOptions()
+    local replayState = self.menuBackgroundReplay
+    if not replayState then
+        return nil
+    end
+
+    if replayState.phase == "intro" then
+        return {
+            presentation = replayState.presentation,
+            drawTrains = false,
+            drawCollision = false,
+        }
+    end
+
+    if replayState.phase == "outro" then
+        return {
+            drawTrains = false,
+            drawCollision = false,
+            outro = {
+                progress = clamp((replayState.outroElapsed or 0) / MENU_BACKGROUND_OUTRO_DURATION, 0, 1),
+                presentation = replayState.presentation,
+            },
+        }
+    end
+
+    return {
+        drawCollision = false,
+    }
+end
+
+end

--- a/src/game/app/game_runtime.lua
+++ b/src/game/app/game_runtime.lua
@@ -498,6 +498,8 @@ function Game.new()
     self.profileModeSetupError = nil
     self.menuStatusMessage = nil
     self.menuTitleAnimationStartedAt = love.timer.getTime()
+    self.menuIntroSkipStartedAt = nil
+    self.menuIntroSkipFromElapsed = nil
     if getProfilePlayMode(self.profile) == PLAY_MODE_ONLINE and not self.onlineConfig.isConfigured then
         self.profile.playMode = PLAY_MODE_OFFLINE
         self.profileModeSelection = PLAY_MODE_OFFLINE

--- a/src/game/app/game_runtime.lua
+++ b/src/game/app/game_runtime.lua
@@ -514,6 +514,7 @@ function Game.new()
     self.networkRequestOverlayCopyStatus = nil
     self.playGuide = nil
     self.playGuideTransition = nil
+    self.mapPresentation = nil
     self.pendingReplayPreparationInteractions = {}
     self.replayRecorder = nil
     self.replayRecord = nil
@@ -688,6 +689,7 @@ local shared = {
 
 require("src.game.app.game_remote_services")(Game, shared)
 require("src.game.app.game_profile_and_results")(Game, shared)
+require("src.game.app.game_map_presentation")(Game, shared)
 require("src.game.app.game_screen_flow")(Game, shared)
 require("src.game.app.game_runtime_handlers")(Game, shared)
 

--- a/src/game/app/game_runtime.lua
+++ b/src/game/app/game_runtime.lua
@@ -500,6 +500,8 @@ function Game.new()
     self.menuTitleAnimationStartedAt = love.timer.getTime()
     self.menuIntroSkipStartedAt = nil
     self.menuIntroSkipFromElapsed = nil
+    self.menuBackgroundReplay = nil
+    self.menuBackgroundReplayLastPath = nil
     if getProfilePlayMode(self.profile) == PLAY_MODE_ONLINE and not self.onlineConfig.isConfigured then
         self.profile.playMode = PLAY_MODE_OFFLINE
         self.profileModeSelection = PLAY_MODE_OFFLINE
@@ -559,6 +561,9 @@ function Game.new()
 
     self:updateRenderTransform()
     self:refreshMaps()
+    if self.screen == "menu" and self.resetMenuBackgroundReplayLoop then
+        self:resetMenuBackgroundReplayLoop()
+    end
 
     return self
 end
@@ -694,6 +699,7 @@ local shared = {
 require("src.game.app.game_remote_services")(Game, shared)
 require("src.game.app.game_profile_and_results")(Game, shared)
 require("src.game.app.game_map_presentation")(Game, shared)
+require("src.game.app.game_menu_background")(Game, shared)
 require("src.game.app.game_screen_flow")(Game, shared)
 require("src.game.app.game_runtime_handlers")(Game, shared)
 

--- a/src/game/app/game_runtime.lua
+++ b/src/game/app/game_runtime.lua
@@ -496,6 +496,8 @@ function Game.new()
     self.profileModeSelection = getProfilePlayMode(profile) ~= "" and getProfilePlayMode(profile) or PLAY_MODE_OFFLINE
     self.profileModeHoverId = nil
     self.profileModeSetupError = nil
+    self.menuStatusMessage = nil
+    self.menuTitleAnimationStartedAt = love.timer.getTime()
     if getProfilePlayMode(self.profile) == PLAY_MODE_ONLINE and not self.onlineConfig.isConfigured then
         self.profile.playMode = PLAY_MODE_OFFLINE
         self.profileModeSelection = PLAY_MODE_OFFLINE

--- a/src/game/app/game_runtime_handlers.lua
+++ b/src/game/app/game_runtime_handlers.lua
@@ -100,6 +100,13 @@ function Game:update(dt)
         return
     end
 
+    if self.mapPresentation then
+        self:updateMapPresentation(dt)
+        if self:isMapPresentationActive() then
+            return
+        end
+    end
+
     if self.playPhase ~= "play" then
         return
     end
@@ -141,7 +148,7 @@ function Game:draw()
         self.replayRuntime.playbackWorld:draw()
         ui.drawReplay(self)
     elseif self.screen == "play" and self.world then
-        self.world:draw()
+        self.world:draw(self:getMapPresentationDrawOptions())
         ui.drawPlay(self)
     end
 
@@ -459,6 +466,16 @@ function Game:keypressed(key)
         return
     end
 
+    if self:isMapPresentationActive() then
+        if key == "space" or key == "return" then
+            self:skipMapPresentation()
+            return
+        end
+        if key ~= "m" and key ~= "e" and key ~= "r" then
+            return
+        end
+    end
+
     if key == "f2" then
         self.playOverlayCopyStatus = nil
         if self.playOverlayMode == "help" then
@@ -763,6 +780,11 @@ function Game:mousepressed(x, y, button)
         return
     end
 
+    if self:isMapPresentationActive() then
+        self:skipMapPresentation()
+        return
+    end
+
     if button == 1 and self.playOverlayMode == "debug" then
         local overlayHit = ui.getPlayOverlayHit and ui.getPlayOverlayHit(self, viewportX, viewportY) or nil
         if overlayHit and overlayHit.kind == "copy_debug_value" then
@@ -847,6 +869,10 @@ function Game:mousemoved(x, y, dx, dy)
 
     if self.screen == "editor" then
         self.editor:mousemoved(viewportX, viewportY, dx, dy)
+        return
+    end
+
+    if self.screen == "play" and self:isMapPresentationActive() then
         return
     end
 

--- a/src/game/app/game_runtime_handlers.lua
+++ b/src/game/app/game_runtime_handlers.lua
@@ -262,6 +262,13 @@ function Game:keypressed(key)
     end
 
     if self.screen == "menu" then
+        if self:isMenuIntroActive() then
+            if key == "space" then
+                self:skipMenuIntro()
+            end
+            return
+        end
+
         if key == "return" or key == "space" then
             self:openLevelSelect()
         elseif key == "e" then
@@ -594,16 +601,32 @@ function Game:mousepressed(x, y, button)
     end
 
     if self.screen == "menu" then
+        if self:isMenuIntroActive() then
+            self:skipMenuIntro()
+            return
+        end
+
         local action = ui.getMenuActionAt(self, viewportX, viewportY)
         if action == "play" then
+            self.menuStatusMessage = nil
             self:openLevelSelect()
         elseif action == "leaderboard" then
+            self.menuStatusMessage = nil
             self:openLeaderboard({ returnScreen = "menu" })
+        elseif action == "set_play_mode_online" then
+            local ok, message = self:setPlayMode(PLAY_MODE_ONLINE)
+            self.menuStatusMessage = ok and nil or message
+        elseif action == "set_play_mode_offline" then
+            local ok, message = self:setPlayMode(PLAY_MODE_OFFLINE)
+            self.menuStatusMessage = ok and nil or message
         elseif action == "toggle_play_mode" then
-            self:togglePlayMode()
+            local ok, message = self:togglePlayMode()
+            self.menuStatusMessage = ok and nil or message
         elseif action == "editor" then
+            self.menuStatusMessage = nil
             self:openEditorBlank()
         elseif action == "quit" then
+            self.menuStatusMessage = nil
             love.event.quit()
         end
         return

--- a/src/game/app/game_runtime_handlers.lua
+++ b/src/game/app/game_runtime_handlers.lua
@@ -69,6 +69,11 @@ function Game:update(dt)
     self:updateLeaderboardFetchState()
     self:updatePlayGuideTransition(dt)
 
+    if self.screen == "menu" then
+        self:updateMenuBackgroundReplay(dt)
+        return
+    end
+
     if self.screen == "level_select" then
         self:updateLevelSelectAnimation(dt)
         return
@@ -131,6 +136,9 @@ function Game:draw()
     love.graphics.scale(self.renderScale, self.renderScale)
 
     if self.screen == "menu" then
+        if self:hasMenuBackgroundReplay() then
+            self.menuBackgroundReplay.replayRuntime.playbackWorld:draw(self:getMenuBackgroundReplayDrawOptions())
+        end
         ui.drawMenu(self)
     elseif self.screen == "profile_setup" then
         ui.drawProfileSetup(self)

--- a/src/game/app/game_screen_flow.lua
+++ b/src/game/app/game_screen_flow.lua
@@ -746,6 +746,7 @@ function Game:openMenu()
     self.menuTitleAnimationStartedAt = love.timer.getTime()
     self.menuIntroSkipStartedAt = nil
     self.menuIntroSkipFromElapsed = nil
+    self:resetMenuBackgroundReplayLoop()
     self.levelSelectIssue = nil
     self:closeLevelSelectReplayOverlay()
     self.levelSelectHoverId = nil

--- a/src/game/app/game_screen_flow.lua
+++ b/src/game/app/game_screen_flow.lua
@@ -743,6 +743,7 @@ function Game:openMenu()
     end
 
     self.screen = "menu"
+    self.menuTitleAnimationStartedAt = love.timer.getTime()
     self.levelSelectIssue = nil
     self:closeLevelSelectReplayOverlay()
     self.levelSelectHoverId = nil
@@ -758,6 +759,31 @@ function Game:openMenu()
     self.replayDragActive = false
     self.replayDragTime = nil
     self:refreshMaps()
+end
+
+local MENU_TITLE_ENTER_DURATION = 0.55
+local MENU_BUTTON_REVEAL_DURATION = 0.52
+local MENU_BUTTON_STAGGER = 0.07
+local MENU_BUTTON_COUNT = 5
+
+function Game:getMenuIntroTotalDuration()
+    return MENU_TITLE_ENTER_DURATION
+        + MENU_BUTTON_REVEAL_DURATION
+        + (MENU_BUTTON_STAGGER * math.max(0, MENU_BUTTON_COUNT - 1))
+end
+
+function Game:getMenuIntroElapsed()
+    local startedAt = tonumber(self.menuTitleAnimationStartedAt or 0) or 0
+    local now = love.timer.getTime()
+    return math.max(0, now - startedAt)
+end
+
+function Game:isMenuIntroActive()
+    return self.screen == "menu" and self:getMenuIntroElapsed() < self:getMenuIntroTotalDuration()
+end
+
+function Game:skipMenuIntro()
+    self.menuTitleAnimationStartedAt = love.timer.getTime() - self:getMenuIntroTotalDuration()
 end
 
 function Game:openLevelSelect()

--- a/src/game/app/game_screen_flow.lua
+++ b/src/game/app/game_screen_flow.lua
@@ -744,6 +744,8 @@ function Game:openMenu()
 
     self.screen = "menu"
     self.menuTitleAnimationStartedAt = love.timer.getTime()
+    self.menuIntroSkipStartedAt = nil
+    self.menuIntroSkipFromElapsed = nil
     self.levelSelectIssue = nil
     self:closeLevelSelectReplayOverlay()
     self.levelSelectHoverId = nil
@@ -765,6 +767,23 @@ local MENU_TITLE_ENTER_DURATION = 0.55
 local MENU_BUTTON_REVEAL_DURATION = 0.52
 local MENU_BUTTON_STAGGER = 0.07
 local MENU_BUTTON_COUNT = 5
+local MENU_SKIP_FINISH_DURATION = 0.16
+
+local function clamp01(value)
+    if value < 0 then
+        return 0
+    end
+    if value > 1 then
+        return 1
+    end
+    return value
+end
+
+local function easeOutCubic(t)
+    local clamped = clamp01(t)
+    local inverse = 1 - clamped
+    return 1 - inverse * inverse * inverse
+end
 
 function Game:getMenuIntroTotalDuration()
     return MENU_TITLE_ENTER_DURATION
@@ -773,9 +792,17 @@ function Game:getMenuIntroTotalDuration()
 end
 
 function Game:getMenuIntroElapsed()
-    local startedAt = tonumber(self.menuTitleAnimationStartedAt or 0) or 0
+    local totalDuration = self:getMenuIntroTotalDuration()
     local now = love.timer.getTime()
-    return math.max(0, now - startedAt)
+    local skipStartedAt = tonumber(self.menuIntroSkipStartedAt or 0) or 0
+    if skipStartedAt > 0 then
+        local skipFromElapsed = tonumber(self.menuIntroSkipFromElapsed or 0) or 0
+        local skipProgress = clamp01((now - skipStartedAt) / MENU_SKIP_FINISH_DURATION)
+        return skipFromElapsed + ((totalDuration - skipFromElapsed) * easeOutCubic(skipProgress))
+    end
+
+    local startedAt = tonumber(self.menuTitleAnimationStartedAt or 0) or 0
+    return math.max(0, math.min(totalDuration, now - startedAt))
 end
 
 function Game:isMenuIntroActive()
@@ -783,7 +810,12 @@ function Game:isMenuIntroActive()
 end
 
 function Game:skipMenuIntro()
-    self.menuTitleAnimationStartedAt = love.timer.getTime() - self:getMenuIntroTotalDuration()
+    if self.menuIntroSkipStartedAt then
+        return
+    end
+
+    self.menuIntroSkipFromElapsed = self:getMenuIntroElapsed()
+    self.menuIntroSkipStartedAt = love.timer.getTime()
 end
 
 function Game:openLevelSelect()

--- a/src/game/app/game_screen_flow.lua
+++ b/src/game/app/game_screen_flow.lua
@@ -881,9 +881,11 @@ function Game:startMap(mapDescriptor, options)
     self.replayDragActive = false
     self.replayDragTime = nil
     self.pendingReplayPreparationInteractions = {}
+    self.mapPresentation = nil
     self.world = world.new(self.viewport.w, self.viewport.h, mapData.level)
     self.playGuide = self:buildPlayGuideState(mapData.level)
     self.playGuideTransition = nil
+    self:beginMapPresentation(mapDescriptor)
     self.screen = "play"
     return true
 end
@@ -946,7 +948,7 @@ function Game:isPreparingRun()
 end
 
 function Game:startPlayPhase()
-    if not self.world or self.playPhase ~= "prepare" or self.playGuide then
+    if not self.world or self.playPhase ~= "prepare" or self.playGuide or self.mapPresentation then
         return false
     end
 

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -157,85 +157,11 @@ local function getJunctionEntryAngle(edge)
     return angleBetweenPoints(points[#points], points[#points - 1])
 end
 
-local function popNextQueuedEdge(queue)
-    if #queue == 0 then
-        return nil
-    end
-
-    local bestIndex = 1
-    local bestTime = queue[1].startTime
-    for index = 2, #queue do
-        if queue[index].startTime < bestTime then
-            bestIndex = index
-            bestTime = queue[index].startTime
-        end
-    end
-
-    local entry = queue[bestIndex]
-    table.remove(queue, bestIndex)
-    return entry
-end
-
-local function queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, startTime)
-    if not edge or not edge.id then
-        return false
-    end
-
-    local duration = getTrackRevealDuration(world, edge)
-    local existingSchedule = edgeSchedulesById[edge.id]
-    if existingSchedule and existingSchedule.startTime <= startTime + 0.0001 then
-        return false
-    end
-
-    edgeSchedulesById[edge.id] = {
-        startTime = startTime,
-        endTime = startTime + duration,
-        duration = duration,
-    }
-    queue[#queue + 1] = {
-        edgeId = edge.id,
-        startTime = startTime,
-    }
-    return true
-end
-
-local function tryScheduleJunctionArrival(junctionId, incomingByTargetId, incomingArrivalStateByJunctionId, junctionSchedulesById, outgoingBySourceId, queue, edgeSchedulesById, world)
-    if not junctionId or junctionSchedulesById[junctionId] then
-        return false
-    end
-
-    local incomingEdges = incomingByTargetId[junctionId] or {}
-    local arrivalState = incomingArrivalStateByJunctionId[junctionId]
-    if not arrivalState or arrivalState.completedCount < #incomingEdges then
-        return false
-    end
-
-    local arrivalTime = arrivalState.latestEndTime or 0
-    local ringStartTime = arrivalTime
-    local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
-    local iconStartTime = ringEndTime
-    local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
-    junctionSchedulesById[junctionId] = {
-        arrivalTime = arrivalTime,
-        ringStartTime = ringStartTime,
-        ringEndTime = ringEndTime,
-        iconStartTime = iconStartTime,
-        iconEndTime = iconEndTime,
-        entryAngle = arrivalState.entryAngle or (-math.pi * 0.5),
-    }
-
-    for _, outgoingEdge in ipairs(outgoingBySourceId[junctionId] or {}) do
-        queueEdgeIfEarlier(queue, edgeSchedulesById, world, outgoingEdge, ringEndTime)
-    end
-
-    return true
-end
-
 local function buildPresentationSchedule(world)
     local edges = {}
     local edgeById = {}
-    local outgoingBySourceId = {}
     local incomingByTargetId = {}
+    local baseDurationByEdgeId = {}
 
     for edgeId, edge in pairs(type(world) == "table" and world.edges or {}) do
         if type(edge) == "table" then
@@ -243,108 +169,111 @@ local function buildPresentationSchedule(world)
             edge.id = resolvedId
             edges[#edges + 1] = edge
             edgeById[resolvedId] = edge
-            if edge.sourceType == "junction" and edge.sourceId then
-                outgoingBySourceId[edge.sourceId] = outgoingBySourceId[edge.sourceId] or {}
-                outgoingBySourceId[edge.sourceId][#outgoingBySourceId[edge.sourceId] + 1] = edge
-            end
             if edge.targetType == "junction" and edge.targetId then
                 incomingByTargetId[edge.targetId] = incomingByTargetId[edge.targetId] or {}
                 incomingByTargetId[edge.targetId][#incomingByTargetId[edge.targetId] + 1] = edge
             end
+            baseDurationByEdgeId[resolvedId] = getTrackRevealDuration(world, edge)
         end
     end
 
-    local queue = {}
     local edgeSchedulesById = {}
     local junctionSchedulesById = {}
-    local incomingArrivalStateByJunctionId = {}
     local graphCompleteTime = 0
+    local visitingJunctions = {}
+
+    local function buildFallbackJunctionSchedule()
+        local ringStartTime = 0
+        local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
+        local iconStartTime = ringEndTime
+        local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+        return {
+            arrivalTime = 0,
+            ringStartTime = ringStartTime,
+            ringEndTime = ringEndTime,
+            iconStartTime = iconStartTime,
+            iconEndTime = iconEndTime,
+            entryAngle = -math.pi * 0.5,
+        }
+    end
+
+    local computeJunctionSchedule
+
+    local function computeEdgeStartTime(edge)
+        if edge.sourceType == "junction" and edge.sourceId then
+            local sourceSchedule = computeJunctionSchedule(edge.sourceId)
+            return sourceSchedule and sourceSchedule.ringEndTime or 0
+        end
+
+        return 0
+    end
+
+    local function computeNaturalEdgeEndTime(edge)
+        return computeEdgeStartTime(edge) + (baseDurationByEdgeId[edge.id] or 0)
+    end
+
+    computeJunctionSchedule = function(junctionId)
+        if not junctionId then
+            return nil
+        end
+        if junctionSchedulesById[junctionId] then
+            return junctionSchedulesById[junctionId]
+        end
+        if visitingJunctions[junctionId] then
+            return buildFallbackJunctionSchedule()
+        end
+
+        visitingJunctions[junctionId] = true
+
+        local incomingEdges = incomingByTargetId[junctionId] or {}
+        local arrivalTime = 0
+        local entryEdge = nil
+
+        for _, edge in ipairs(incomingEdges) do
+            local naturalEndTime = computeNaturalEdgeEndTime(edge)
+            if (not entryEdge) or naturalEndTime > arrivalTime + 0.0001 then
+                arrivalTime = naturalEndTime
+                entryEdge = edge
+            end
+        end
+
+        local ringStartTime = arrivalTime
+        local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
+        local iconStartTime = ringEndTime
+        local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+        local schedule = {
+            arrivalTime = arrivalTime,
+            ringStartTime = ringStartTime,
+            ringEndTime = ringEndTime,
+            iconStartTime = iconStartTime,
+            iconEndTime = iconEndTime,
+            entryAngle = entryEdge and getJunctionEntryAngle(entryEdge) or (-math.pi * 0.5),
+        }
+
+        junctionSchedulesById[junctionId] = schedule
+        visitingJunctions[junctionId] = nil
+        return schedule
+    end
 
     for _, edge in ipairs(edges) do
-        if edge.sourceType == "start" then
-            queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, 0)
+        local startTime = computeEdgeStartTime(edge)
+        local endTime = startTime + (baseDurationByEdgeId[edge.id] or 0)
+        if edge.targetType == "junction" and edge.targetId then
+            local targetSchedule = computeJunctionSchedule(edge.targetId)
+            endTime = targetSchedule and targetSchedule.arrivalTime or endTime
         end
+
+        local duration = math.max(0, endTime - startTime)
+        edgeSchedulesById[edge.id] = {
+            startTime = startTime,
+            endTime = endTime,
+            duration = duration,
+        }
+        graphCompleteTime = maxValue(graphCompleteTime, endTime)
     end
 
-    if #queue == 0 then
-        for _, edge in ipairs(edges) do
-            queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, 0)
-        end
-    end
-
-    local function processQueuedEdge(queuedEdge)
-        local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
-        if not edgeSchedule or math.abs(edgeSchedule.startTime - queuedEdge.startTime) > 0.0001 then
-            return
-        end
-
-        local edge = edgeById[queuedEdge.edgeId]
-        graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
-
-        if edge and edge.targetType == "junction" and edge.targetId then
-            local arrivalState = incomingArrivalStateByJunctionId[edge.targetId] or {
-                completedEdgeIds = {},
-                completedCount = 0,
-                latestEndTime = 0,
-                entryAngle = nil,
-            }
-            incomingArrivalStateByJunctionId[edge.targetId] = arrivalState
-
-            if not arrivalState.completedEdgeIds[edge.id] then
-                arrivalState.completedEdgeIds[edge.id] = true
-                arrivalState.completedCount = arrivalState.completedCount + 1
-            end
-
-            if edgeSchedule.endTime >= (arrivalState.latestEndTime or 0) - 0.0001 then
-                arrivalState.latestEndTime = edgeSchedule.endTime
-                arrivalState.entryAngle = getJunctionEntryAngle(edge)
-            end
-
-            if tryScheduleJunctionArrival(
-                edge.targetId,
-                incomingByTargetId,
-                incomingArrivalStateByJunctionId,
-                junctionSchedulesById,
-                outgoingBySourceId,
-                queue,
-                edgeSchedulesById,
-                world
-            ) then
-                graphCompleteTime = maxValue(graphCompleteTime, junctionSchedulesById[edge.targetId].iconEndTime)
-            end
-        end
-    end
-
-    while true do
-        local queuedEdge = popNextQueuedEdge(queue)
-        if not queuedEdge then
-            break
-        end
-
-        processQueuedEdge(queuedEdge)
-    end
-
-    local scheduledFallbackEdge = false
-    for _, edge in ipairs(edges) do
-        if not edgeSchedulesById[edge.id] then
-            local fallbackStartTime = 0
-            local sourceJunctionSchedule = edge.sourceId and junctionSchedulesById[edge.sourceId] or nil
-            if sourceJunctionSchedule then
-                fallbackStartTime = sourceJunctionSchedule.ringEndTime
-            end
-            scheduledFallbackEdge = queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, fallbackStartTime) or scheduledFallbackEdge
-        end
-    end
-
-    if scheduledFallbackEdge then
-        while true do
-            local queuedEdge = popNextQueuedEdge(queue)
-            if not queuedEdge then
-                break
-            end
-
-            processQueuedEdge(queuedEdge)
-        end
+    for _, schedule in pairs(junctionSchedulesById) do
+        graphCompleteTime = maxValue(graphCompleteTime, schedule.iconEndTime)
     end
 
     if graphCompleteTime > 0.0001 then

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -17,6 +17,7 @@ local UI_REVEAL_DURATION = 0.52
 local UI_CARD_STAGGER = 0.07
 local UI_TEXT_FADE_DELAY = 0.1
 local UI_TEXT_FADE_DURATION = 0.32
+local CLUSTER_MEMBER_STAGGER = 0.08
 
 local function clamp(value, minValue, maxValue)
     if value < minValue then
@@ -37,6 +38,23 @@ local function maxValue(a, b)
         return a
     end
     return b
+end
+
+local function compareStrings(a, b)
+    return tostring(a or "") < tostring(b or "")
+end
+
+local function shallowCopyArray(values)
+    local copy = {}
+    for index, value in ipairs(values or {}) do
+        copy[index] = value
+    end
+    return copy
+end
+
+local function sortStrings(values)
+    table.sort(values, compareStrings)
+    return values
 end
 
 local function getDescriptorMapKind(descriptor)
@@ -157,144 +175,414 @@ local function getJunctionEntryAngle(edge)
     return angleBetweenPoints(points[#points], points[#points - 1])
 end
 
-local function buildPresentationSchedule(world)
-    local edges = {}
-    local edgeById = {}
-    local incomingByTargetId = {}
-    local baseDurationByEdgeId = {}
+local function buildJunctionSchedule(arrivalTime, entryEdge)
+    local resolvedArrival = math.max(0, arrivalTime or 0)
+    local ringStartTime = resolvedArrival
+    local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
+    local iconStartTime = ringEndTime
+    local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+
+    return {
+        arrivalTime = resolvedArrival,
+        ringStartTime = ringStartTime,
+        ringEndTime = ringEndTime,
+        iconStartTime = iconStartTime,
+        iconEndTime = iconEndTime,
+        entryAngle = entryEdge and getJunctionEntryAngle(entryEdge) or (-math.pi * 0.5),
+    }
+end
+
+local function buildGraphContext(world)
+    local context = {
+        edges = {},
+        edgeById = {},
+        incomingByTargetId = {},
+        outgoingBySourceId = {},
+        baseDurationByEdgeId = {},
+        junctionIds = {},
+    }
 
     for edgeId, edge in pairs(type(world) == "table" and world.edges or {}) do
         if type(edge) == "table" then
             local resolvedId = edge.id or edgeId
             edge.id = resolvedId
-            edges[#edges + 1] = edge
-            edgeById[resolvedId] = edge
-            if edge.targetType == "junction" and edge.targetId then
-                incomingByTargetId[edge.targetId] = incomingByTargetId[edge.targetId] or {}
-                incomingByTargetId[edge.targetId][#incomingByTargetId[edge.targetId] + 1] = edge
+            context.edges[#context.edges + 1] = edge
+            context.edgeById[resolvedId] = edge
+            context.baseDurationByEdgeId[resolvedId] = getTrackRevealDuration(world, edge)
+
+            if edge.sourceType == "junction" and edge.sourceId then
+                context.outgoingBySourceId[edge.sourceId] = context.outgoingBySourceId[edge.sourceId] or {}
+                context.outgoingBySourceId[edge.sourceId][#context.outgoingBySourceId[edge.sourceId] + 1] = edge
+                context.junctionIds[edge.sourceId] = true
             end
-            baseDurationByEdgeId[resolvedId] = getTrackRevealDuration(world, edge)
+            if edge.targetType == "junction" and edge.targetId then
+                context.incomingByTargetId[edge.targetId] = context.incomingByTargetId[edge.targetId] or {}
+                context.incomingByTargetId[edge.targetId][#context.incomingByTargetId[edge.targetId] + 1] = edge
+                context.junctionIds[edge.targetId] = true
+            end
         end
     end
 
+    table.sort(context.edges, function(a, b)
+        return compareStrings(a.id, b.id)
+    end)
+
+    for junctionId, edges in pairs(context.incomingByTargetId) do
+        table.sort(edges, function(a, b)
+            return compareStrings(a.id, b.id)
+        end)
+        context.incomingByTargetId[junctionId] = edges
+    end
+
+    for junctionId, edges in pairs(context.outgoingBySourceId) do
+        table.sort(edges, function(a, b)
+            return compareStrings(a.id, b.id)
+        end)
+        context.outgoingBySourceId[junctionId] = edges
+    end
+
+    return context
+end
+
+local function scaleSchedules(edgeSchedulesById, junctionSchedulesById, graphCompleteTime)
+    if graphCompleteTime <= 0.0001 then
+        return edgeSchedulesById, junctionSchedulesById, GRAPH_REVEAL_DURATION
+    end
+
+    local timeScale = GRAPH_REVEAL_DURATION / graphCompleteTime
+
+    for _, schedule in pairs(edgeSchedulesById or {}) do
+        schedule.startTime = schedule.startTime * timeScale
+        schedule.endTime = schedule.endTime * timeScale
+        schedule.duration = schedule.duration * timeScale
+    end
+
+    for _, schedule in pairs(junctionSchedulesById or {}) do
+        schedule.arrivalTime = schedule.arrivalTime * timeScale
+        schedule.ringStartTime = schedule.ringStartTime * timeScale
+        schedule.ringEndTime = schedule.ringEndTime * timeScale
+        schedule.iconStartTime = schedule.iconStartTime * timeScale
+        schedule.iconEndTime = schedule.iconEndTime * timeScale
+    end
+
+    return edgeSchedulesById, junctionSchedulesById, GRAPH_REVEAL_DURATION
+end
+
+local function buildSccInfo(context)
+    local sortedJunctionIds = {}
+    for junctionId in pairs(context.junctionIds or {}) do
+        sortedJunctionIds[#sortedJunctionIds + 1] = junctionId
+    end
+    sortStrings(sortedJunctionIds)
+
+    local adjacencyByJunctionId = {}
+    for _, junctionId in ipairs(sortedJunctionIds) do
+        adjacencyByJunctionId[junctionId] = {}
+    end
+
+    for _, edge in ipairs(context.edges) do
+        if edge.sourceType == "junction" and edge.targetType == "junction" and edge.sourceId and edge.targetId then
+            adjacencyByJunctionId[edge.sourceId] = adjacencyByJunctionId[edge.sourceId] or {}
+            adjacencyByJunctionId[edge.sourceId][#adjacencyByJunctionId[edge.sourceId] + 1] = edge.targetId
+        end
+    end
+
+    for junctionId, targets in pairs(adjacencyByJunctionId) do
+        table.sort(targets, compareStrings)
+        adjacencyByJunctionId[junctionId] = targets
+    end
+
+    local indexByJunctionId = {}
+    local lowlinkByJunctionId = {}
+    local onStackByJunctionId = {}
+    local stack = {}
+    local nextIndex = 1
+    local componentByJunctionId = {}
+    local componentsById = {}
+    local componentId = 0
+
+    local function visit(junctionId)
+        indexByJunctionId[junctionId] = nextIndex
+        lowlinkByJunctionId[junctionId] = nextIndex
+        nextIndex = nextIndex + 1
+        stack[#stack + 1] = junctionId
+        onStackByJunctionId[junctionId] = true
+
+        for _, targetId in ipairs(adjacencyByJunctionId[junctionId] or {}) do
+            if not indexByJunctionId[targetId] then
+                visit(targetId)
+                lowlinkByJunctionId[junctionId] = math.min(lowlinkByJunctionId[junctionId], lowlinkByJunctionId[targetId])
+            elseif onStackByJunctionId[targetId] then
+                lowlinkByJunctionId[junctionId] = math.min(lowlinkByJunctionId[junctionId], indexByJunctionId[targetId])
+            end
+        end
+
+        if lowlinkByJunctionId[junctionId] == indexByJunctionId[junctionId] then
+            componentId = componentId + 1
+            local members = {}
+            while true do
+                local memberId = stack[#stack]
+                stack[#stack] = nil
+                onStackByJunctionId[memberId] = nil
+                componentByJunctionId[memberId] = componentId
+                members[#members + 1] = memberId
+                if memberId == junctionId then
+                    break
+                end
+            end
+            sortStrings(members)
+            componentsById[componentId] = {
+                id = componentId,
+                junctionIds = members,
+            }
+        end
+    end
+
+    for _, junctionId in ipairs(sortedJunctionIds) do
+        if not indexByJunctionId[junctionId] then
+            visit(junctionId)
+        end
+    end
+
+    local componentSizeById = {}
+    for id, component in pairs(componentsById) do
+        componentSizeById[id] = #(component.junctionIds or {})
+    end
+
+    return {
+        componentByJunctionId = componentByJunctionId,
+        componentsById = componentsById,
+        componentSizeById = componentSizeById,
+    }
+end
+
+local function buildClusteredCycleSchedule(context)
     local edgeSchedulesById = {}
     local junctionSchedulesById = {}
     local graphCompleteTime = 0
-    local visitingJunctions = {}
+    local sccInfo = buildSccInfo(context)
+    local componentInfoById = {}
 
-    local function buildFallbackJunctionSchedule()
-        local ringStartTime = 0
-        local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
-        local iconStartTime = ringEndTime
-        local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
-        return {
-            arrivalTime = 0,
-            ringStartTime = ringStartTime,
-            ringEndTime = ringEndTime,
-            iconStartTime = iconStartTime,
-            iconEndTime = iconEndTime,
-            entryAngle = -math.pi * 0.5,
+    for componentId, component in pairs(sccInfo.componentsById or {}) do
+        componentInfoById[componentId] = {
+            id = componentId,
+            junctionIds = shallowCopyArray(component.junctionIds or {}),
+            internalEdges = {},
+            externalIncomingEdges = {},
+            externalOutgoingEdges = {},
         }
     end
 
-    local computeJunctionSchedule
+    for _, edge in ipairs(context.edges) do
+        local sourceComponentId = edge.sourceType == "junction" and sccInfo.componentByJunctionId[edge.sourceId] or nil
+        local targetComponentId = edge.targetType == "junction" and sccInfo.componentByJunctionId[edge.targetId] or nil
 
-    local function computeEdgeStartTime(edge)
-        if edge.sourceType == "junction" and edge.sourceId then
-            local sourceSchedule = computeJunctionSchedule(edge.sourceId)
-            return sourceSchedule and sourceSchedule.ringEndTime or 0
+        if sourceComponentId and targetComponentId and sourceComponentId == targetComponentId then
+            componentInfoById[sourceComponentId].internalEdges[#componentInfoById[sourceComponentId].internalEdges + 1] = edge
+        elseif targetComponentId then
+            componentInfoById[targetComponentId].externalIncomingEdges[#componentInfoById[targetComponentId].externalIncomingEdges + 1] = edge
         end
 
+        if sourceComponentId and (not targetComponentId or targetComponentId ~= sourceComponentId) then
+            componentInfoById[sourceComponentId].externalOutgoingEdges[#componentInfoById[sourceComponentId].externalOutgoingEdges + 1] = edge
+        end
+    end
+
+    for _, componentInfo in pairs(componentInfoById) do
+        table.sort(componentInfo.internalEdges, function(a, b)
+            return compareStrings(a.id, b.id)
+        end)
+        table.sort(componentInfo.externalIncomingEdges, function(a, b)
+            return compareStrings(a.id, b.id)
+        end)
+        table.sort(componentInfo.externalOutgoingEdges, function(a, b)
+            return compareStrings(a.id, b.id)
+        end)
+        table.sort(componentInfo.junctionIds, compareStrings)
+    end
+
+    local componentScheduleById = {}
+    local visitingComponents = {}
+
+    local computeComponentSchedule
+
+    local function getExternalEdgeStartTime(edge)
+        if edge.sourceType == "junction" and edge.sourceId then
+            local sourceComponentId = sccInfo.componentByJunctionId[edge.sourceId]
+            local sourceComponentSchedule = sourceComponentId and computeComponentSchedule(sourceComponentId) or nil
+            return sourceComponentSchedule and sourceComponentSchedule.completeTime or 0
+        end
         return 0
     end
 
-    local function computeNaturalEdgeEndTime(edge)
-        return computeEdgeStartTime(edge) + (baseDurationByEdgeId[edge.id] or 0)
-    end
-
-    computeJunctionSchedule = function(junctionId)
-        if not junctionId then
-            return nil
+    computeComponentSchedule = function(componentId)
+        if componentScheduleById[componentId] then
+            return componentScheduleById[componentId]
         end
-        if junctionSchedulesById[junctionId] then
-            return junctionSchedulesById[junctionId]
-        end
-        if visitingJunctions[junctionId] then
-            return buildFallbackJunctionSchedule()
+        if visitingComponents[componentId] then
+            return {
+                arrivalTime = 0,
+                completeTime = JUNCTION_ICON_DURATION,
+                junctionSchedulesById = {},
+            }
         end
 
-        visitingJunctions[junctionId] = true
-
-        local incomingEdges = incomingByTargetId[junctionId] or {}
+        visitingComponents[componentId] = true
+        local componentInfo = componentInfoById[componentId]
         local arrivalTime = 0
-        local entryEdge = nil
+        local entryEdgesByJunctionId = {}
 
-        for _, edge in ipairs(incomingEdges) do
-            local naturalEndTime = computeNaturalEdgeEndTime(edge)
-            if (not entryEdge) or naturalEndTime > arrivalTime + 0.0001 then
-                arrivalTime = naturalEndTime
-                entryEdge = edge
+        for _, edge in ipairs(componentInfo.externalIncomingEdges or {}) do
+            local endTime = getExternalEdgeStartTime(edge) + (context.baseDurationByEdgeId[edge.id] or 0)
+            arrivalTime = maxValue(arrivalTime, endTime)
+            if edge.targetId then
+                entryEdgesByJunctionId[edge.targetId] = entryEdgesByJunctionId[edge.targetId] or {}
+                entryEdgesByJunctionId[edge.targetId][#entryEdgesByJunctionId[edge.targetId] + 1] = edge
             end
         end
 
-        local ringStartTime = arrivalTime
-        local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
-        local iconStartTime = ringEndTime
-        local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+        local localSchedulesByJunctionId = {}
+        local internalArrivalByJunctionId = {}
+        local queue = {}
+
+        local function scheduleLocalJunction(junctionId, junctionArrivalTime, entryEdge)
+            local existing = localSchedulesByJunctionId[junctionId]
+            if existing and existing.arrivalTime <= junctionArrivalTime + 0.0001 then
+                return false
+            end
+
+            local schedule = buildJunctionSchedule(junctionArrivalTime, entryEdge)
+            localSchedulesByJunctionId[junctionId] = schedule
+            queue[#queue + 1] = {
+                junctionId = junctionId,
+                ringEndTime = schedule.ringEndTime,
+            }
+            return true
+        end
+
+        local seeded = false
+        for _, junctionId in ipairs(componentInfo.junctionIds or {}) do
+            local entryEdges = entryEdgesByJunctionId[junctionId]
+            if entryEdges and #entryEdges > 0 then
+                scheduleLocalJunction(junctionId, arrivalTime, entryEdges[1])
+                seeded = true
+            end
+        end
+
+        if not seeded and componentInfo.junctionIds[1] then
+            scheduleLocalJunction(componentInfo.junctionIds[1], arrivalTime, nil)
+        end
+
+        while #queue > 0 do
+            local bestIndex = 1
+            local bestRingEnd = queue[1].ringEndTime
+            for index = 2, #queue do
+                if queue[index].ringEndTime < bestRingEnd - 0.0001 then
+                    bestIndex = index
+                    bestRingEnd = queue[index].ringEndTime
+                end
+            end
+            local queued = queue[bestIndex]
+            table.remove(queue, bestIndex)
+
+            local sourceJunctionId = queued.junctionId
+            for _, edge in ipairs(context.outgoingBySourceId[sourceJunctionId] or {}) do
+                local targetComponentId = edge.targetType == "junction" and sccInfo.componentByJunctionId[edge.targetId] or nil
+                if targetComponentId == componentId then
+                    local edgeEndTime = queued.ringEndTime + (context.baseDurationByEdgeId[edge.id] or 0)
+                    local currentArrivalTime = internalArrivalByJunctionId[edge.targetId]
+                    if currentArrivalTime == nil or edgeEndTime < currentArrivalTime - 0.0001 then
+                        internalArrivalByJunctionId[edge.targetId] = edgeEndTime
+                        scheduleLocalJunction(edge.targetId, edgeEndTime, edge)
+                    end
+                end
+            end
+        end
+
+        local completeTime = arrivalTime
+        for _, junctionId in ipairs(componentInfo.junctionIds or {}) do
+            local schedule = localSchedulesByJunctionId[junctionId]
+            if not schedule then
+                schedule = buildJunctionSchedule(arrivalTime, nil)
+                localSchedulesByJunctionId[junctionId] = schedule
+            end
+
+            if (sccInfo.componentSizeById[componentId] or 0) > 1 then
+                local memberIndex = 0
+                for index, memberId in ipairs(componentInfo.junctionIds or {}) do
+                    if memberId == junctionId then
+                        memberIndex = index - 1
+                        break
+                    end
+                end
+                schedule.arrivalTime = schedule.arrivalTime + (memberIndex * CLUSTER_MEMBER_STAGGER)
+                schedule.ringStartTime = schedule.arrivalTime
+                schedule.ringEndTime = schedule.ringStartTime + JUNCTION_RING_DURATION
+                schedule.iconStartTime = schedule.ringEndTime
+                schedule.iconEndTime = schedule.iconStartTime + JUNCTION_ICON_DURATION
+            end
+
+            completeTime = maxValue(completeTime, schedule.iconEndTime)
+        end
+
         local schedule = {
             arrivalTime = arrivalTime,
-            ringStartTime = ringStartTime,
-            ringEndTime = ringEndTime,
-            iconStartTime = iconStartTime,
-            iconEndTime = iconEndTime,
-            entryAngle = entryEdge and getJunctionEntryAngle(entryEdge) or (-math.pi * 0.5),
+            completeTime = completeTime,
+            junctionSchedulesById = localSchedulesByJunctionId,
         }
-
-        junctionSchedulesById[junctionId] = schedule
-        visitingJunctions[junctionId] = nil
+        componentScheduleById[componentId] = schedule
+        visitingComponents[componentId] = nil
         return schedule
     end
 
-    for _, edge in ipairs(edges) do
-        local startTime = computeEdgeStartTime(edge)
-        local endTime = startTime + (baseDurationByEdgeId[edge.id] or 0)
-        if edge.targetType == "junction" and edge.targetId then
-            local targetSchedule = computeJunctionSchedule(edge.targetId)
-            endTime = targetSchedule and targetSchedule.arrivalTime or endTime
+    for componentId in pairs(componentInfoById) do
+        local componentSchedule = computeComponentSchedule(componentId)
+        for junctionId, schedule in pairs(componentSchedule.junctionSchedulesById or {}) do
+            junctionSchedulesById[junctionId] = schedule
+            graphCompleteTime = maxValue(graphCompleteTime, schedule.iconEndTime)
+        end
+        graphCompleteTime = maxValue(graphCompleteTime, componentSchedule.completeTime or 0)
+    end
+
+    for _, edge in ipairs(context.edges) do
+        local sourceComponentId = edge.sourceType == "junction" and sccInfo.componentByJunctionId[edge.sourceId] or nil
+        local targetComponentId = edge.targetType == "junction" and sccInfo.componentByJunctionId[edge.targetId] or nil
+        local startTime = 0
+        local endTime = 0
+
+        if sourceComponentId and targetComponentId and sourceComponentId == targetComponentId then
+            local sourceSchedule = junctionSchedulesById[edge.sourceId]
+            local targetSchedule = junctionSchedulesById[edge.targetId]
+            startTime = sourceSchedule and sourceSchedule.ringEndTime or 0
+            endTime = targetSchedule and targetSchedule.arrivalTime or (startTime + (context.baseDurationByEdgeId[edge.id] or 0))
+        elseif targetComponentId then
+            startTime = getExternalEdgeStartTime(edge)
+            local targetComponentSchedule = computeComponentSchedule(targetComponentId)
+            endTime = targetComponentSchedule and targetComponentSchedule.arrivalTime or (startTime + (context.baseDurationByEdgeId[edge.id] or 0))
+        elseif sourceComponentId then
+            local sourceComponentSchedule = computeComponentSchedule(sourceComponentId)
+            startTime = sourceComponentSchedule and sourceComponentSchedule.completeTime or 0
+            endTime = startTime + (context.baseDurationByEdgeId[edge.id] or 0)
+        else
+            startTime = 0
+            endTime = startTime + (context.baseDurationByEdgeId[edge.id] or 0)
         end
 
-        local duration = math.max(0, endTime - startTime)
         edgeSchedulesById[edge.id] = {
             startTime = startTime,
             endTime = endTime,
-            duration = duration,
+            duration = math.max(0, endTime - startTime),
         }
         graphCompleteTime = maxValue(graphCompleteTime, endTime)
     end
 
-    for _, schedule in pairs(junctionSchedulesById) do
-        graphCompleteTime = maxValue(graphCompleteTime, schedule.iconEndTime)
-    end
+    return edgeSchedulesById, junctionSchedulesById, graphCompleteTime
+end
 
-    if graphCompleteTime > 0.0001 then
-        local timeScale = GRAPH_REVEAL_DURATION / graphCompleteTime
-
-        for _, schedule in pairs(edgeSchedulesById) do
-            schedule.startTime = schedule.startTime * timeScale
-            schedule.endTime = schedule.endTime * timeScale
-            schedule.duration = schedule.duration * timeScale
-        end
-
-        for _, schedule in pairs(junctionSchedulesById) do
-            schedule.arrivalTime = schedule.arrivalTime * timeScale
-            schedule.ringStartTime = schedule.ringStartTime * timeScale
-            schedule.ringEndTime = schedule.ringEndTime * timeScale
-            schedule.iconStartTime = schedule.iconStartTime * timeScale
-            schedule.iconEndTime = schedule.iconEndTime * timeScale
-        end
-    end
-
-    return edgeSchedulesById, junctionSchedulesById, GRAPH_REVEAL_DURATION
+local function buildPresentationSchedule(world)
+    local context = buildGraphContext(world)
+    local edgeSchedulesById, junctionSchedulesById, graphCompleteTime = buildClusteredCycleSchedule(context)
+    return scaleSchedules(edgeSchedulesById, junctionSchedulesById, graphCompleteTime)
 end
 
 function mapPresentation.buildState(world, descriptor, profile)

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -10,6 +10,8 @@ local TRACK_REVEAL_PIXELS_PER_SECOND = 560
 local TRACK_REVEAL_MIN_DURATION = 0.16
 local JUNCTION_RING_DURATION = 0.18
 local JUNCTION_ICON_DURATION = 0.32
+local TRACK_STATE_BLEND_DURATION = 0.42
+local SIGNAL_POP_DURATION = 0.42
 local UI_REVEAL_DELAY = 0.08
 local UI_REVEAL_DURATION = 0.52
 local UI_CARD_STAGGER = 0.07
@@ -333,7 +335,14 @@ function mapPresentation.buildState(world, descriptor, profile)
     end
 
     local uiRevealStartTime = graphCompleteTime + UI_REVEAL_DELAY
-    local finishTime = math.max(titleEndTime, uiRevealStartTime + UI_REVEAL_DURATION + maxCardDelay)
+    local trackStateBlendEndTime = graphCompleteTime + TRACK_STATE_BLEND_DURATION
+    local signalPopEndTime = graphCompleteTime + SIGNAL_POP_DURATION
+    local finishTime = math.max(
+        titleEndTime,
+        uiRevealStartTime + UI_REVEAL_DURATION + maxCardDelay,
+        trackStateBlendEndTime,
+        signalPopEndTime
+    )
     local allEdgeIds = {}
     for edgeId in pairs(edgeSchedulesById) do
         allEdgeIds[edgeId] = true
@@ -361,6 +370,16 @@ function mapPresentation.buildState(world, descriptor, profile)
             maxCardDelay = maxCardDelay,
         },
         graphCompleteTime = graphCompleteTime,
+        trackStateBlend = {
+            startTime = graphCompleteTime,
+            duration = TRACK_STATE_BLEND_DURATION,
+            endTime = trackStateBlendEndTime,
+        },
+        signalPop = {
+            startTime = graphCompleteTime,
+            duration = SIGNAL_POP_DURATION,
+            endTime = signalPopEndTime,
+        },
         edgeScheduleById = edgeSchedulesById,
         junctionScheduleById = junctionSchedulesById,
         allEdgeIds = allEdgeIds,

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -10,6 +10,8 @@ local TRACK_REVEAL_PIXELS_PER_SECOND = 560
 local TRACK_REVEAL_MIN_DURATION = 0.16
 local JUNCTION_RING_DURATION = 0.18
 local JUNCTION_ICON_DURATION = 0.32
+local JUNCTION_SELECTOR_DELAY = 0.08
+local JUNCTION_SELECTOR_DURATION = 0.30
 local TRACK_STATE_BLEND_DURATION = 0.42
 local SIGNAL_POP_DURATION = 0.42
 local UI_REVEAL_DELAY = 0.08
@@ -181,6 +183,8 @@ local function buildJunctionSchedule(arrivalTime, entryEdge)
     local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
     local iconStartTime = ringEndTime
     local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+    local selectorStartTime = iconEndTime + JUNCTION_SELECTOR_DELAY
+    local selectorEndTime = selectorStartTime + JUNCTION_SELECTOR_DURATION
 
     return {
         arrivalTime = resolvedArrival,
@@ -188,6 +192,8 @@ local function buildJunctionSchedule(arrivalTime, entryEdge)
         ringEndTime = ringEndTime,
         iconStartTime = iconStartTime,
         iconEndTime = iconEndTime,
+        selectorStartTime = selectorStartTime,
+        selectorEndTime = selectorEndTime,
         entryAngle = entryEdge and getJunctionEntryAngle(entryEdge) or (-math.pi * 0.5),
     }
 end
@@ -263,6 +269,8 @@ local function scaleSchedules(edgeSchedulesById, junctionSchedulesById, graphCom
         schedule.ringEndTime = schedule.ringEndTime * timeScale
         schedule.iconStartTime = schedule.iconStartTime * timeScale
         schedule.iconEndTime = schedule.iconEndTime * timeScale
+        schedule.selectorStartTime = schedule.selectorStartTime * timeScale
+        schedule.selectorEndTime = schedule.selectorEndTime * timeScale
     end
 
     return edgeSchedulesById, junctionSchedulesById, GRAPH_REVEAL_DURATION
@@ -522,7 +530,7 @@ local function buildClusteredCycleSchedule(context)
                 schedule.iconEndTime = schedule.iconStartTime + JUNCTION_ICON_DURATION
             end
 
-            completeTime = maxValue(completeTime, schedule.iconEndTime)
+            completeTime = maxValue(completeTime, schedule.selectorEndTime)
         end
 
         local schedule = {
@@ -539,7 +547,7 @@ local function buildClusteredCycleSchedule(context)
         local componentSchedule = computeComponentSchedule(componentId)
         for junctionId, schedule in pairs(componentSchedule.junctionSchedulesById or {}) do
             junctionSchedulesById[junctionId] = schedule
-            graphCompleteTime = maxValue(graphCompleteTime, schedule.iconEndTime)
+            graphCompleteTime = maxValue(graphCompleteTime, schedule.selectorEndTime)
         end
         graphCompleteTime = maxValue(graphCompleteTime, componentSchedule.completeTime or 0)
     end

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -199,10 +199,43 @@ local function queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, startTi
     return true
 end
 
+local function tryScheduleJunctionArrival(junctionId, incomingByTargetId, incomingArrivalStateByJunctionId, junctionSchedulesById, outgoingBySourceId, queue, edgeSchedulesById, world)
+    if not junctionId or junctionSchedulesById[junctionId] then
+        return false
+    end
+
+    local incomingEdges = incomingByTargetId[junctionId] or {}
+    local arrivalState = incomingArrivalStateByJunctionId[junctionId]
+    if not arrivalState or arrivalState.completedCount < #incomingEdges then
+        return false
+    end
+
+    local arrivalTime = arrivalState.latestEndTime or 0
+    local ringStartTime = arrivalTime
+    local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
+    local iconStartTime = ringEndTime
+    local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+    junctionSchedulesById[junctionId] = {
+        arrivalTime = arrivalTime,
+        ringStartTime = ringStartTime,
+        ringEndTime = ringEndTime,
+        iconStartTime = iconStartTime,
+        iconEndTime = iconEndTime,
+        entryAngle = arrivalState.entryAngle or (-math.pi * 0.5),
+    }
+
+    for _, outgoingEdge in ipairs(outgoingBySourceId[junctionId] or {}) do
+        queueEdgeIfEarlier(queue, edgeSchedulesById, world, outgoingEdge, ringEndTime)
+    end
+
+    return true
+end
+
 local function buildPresentationSchedule(world)
     local edges = {}
     local edgeById = {}
     local outgoingBySourceId = {}
+    local incomingByTargetId = {}
 
     for edgeId, edge in pairs(type(world) == "table" and world.edges or {}) do
         if type(edge) == "table" then
@@ -214,12 +247,17 @@ local function buildPresentationSchedule(world)
                 outgoingBySourceId[edge.sourceId] = outgoingBySourceId[edge.sourceId] or {}
                 outgoingBySourceId[edge.sourceId][#outgoingBySourceId[edge.sourceId] + 1] = edge
             end
+            if edge.targetType == "junction" and edge.targetId then
+                incomingByTargetId[edge.targetId] = incomingByTargetId[edge.targetId] or {}
+                incomingByTargetId[edge.targetId][#incomingByTargetId[edge.targetId] + 1] = edge
+            end
         end
     end
 
     local queue = {}
     local edgeSchedulesById = {}
     local junctionSchedulesById = {}
+    local incomingArrivalStateByJunctionId = {}
     local graphCompleteTime = 0
 
     for _, edge in ipairs(edges) do
@@ -234,41 +272,56 @@ local function buildPresentationSchedule(world)
         end
     end
 
+    local function processQueuedEdge(queuedEdge)
+        local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
+        if not edgeSchedule or math.abs(edgeSchedule.startTime - queuedEdge.startTime) > 0.0001 then
+            return
+        end
+
+        local edge = edgeById[queuedEdge.edgeId]
+        graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
+
+        if edge and edge.targetType == "junction" and edge.targetId then
+            local arrivalState = incomingArrivalStateByJunctionId[edge.targetId] or {
+                completedEdgeIds = {},
+                completedCount = 0,
+                latestEndTime = 0,
+                entryAngle = nil,
+            }
+            incomingArrivalStateByJunctionId[edge.targetId] = arrivalState
+
+            if not arrivalState.completedEdgeIds[edge.id] then
+                arrivalState.completedEdgeIds[edge.id] = true
+                arrivalState.completedCount = arrivalState.completedCount + 1
+            end
+
+            if edgeSchedule.endTime >= (arrivalState.latestEndTime or 0) - 0.0001 then
+                arrivalState.latestEndTime = edgeSchedule.endTime
+                arrivalState.entryAngle = getJunctionEntryAngle(edge)
+            end
+
+            if tryScheduleJunctionArrival(
+                edge.targetId,
+                incomingByTargetId,
+                incomingArrivalStateByJunctionId,
+                junctionSchedulesById,
+                outgoingBySourceId,
+                queue,
+                edgeSchedulesById,
+                world
+            ) then
+                graphCompleteTime = maxValue(graphCompleteTime, junctionSchedulesById[edge.targetId].iconEndTime)
+            end
+        end
+    end
+
     while true do
         local queuedEdge = popNextQueuedEdge(queue)
         if not queuedEdge then
             break
         end
 
-        local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
-        if edgeSchedule and math.abs(edgeSchedule.startTime - queuedEdge.startTime) <= 0.0001 then
-            local edge = edgeById[queuedEdge.edgeId]
-            graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
-
-            if edge and edge.targetType == "junction" and edge.targetId then
-                local arrivalTime = edgeSchedule.endTime
-                local existingJunctionSchedule = junctionSchedulesById[edge.targetId]
-                if not existingJunctionSchedule or arrivalTime < existingJunctionSchedule.arrivalTime - 0.0001 then
-                    local ringStartTime = arrivalTime
-                    local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
-                    local iconStartTime = ringEndTime
-                    local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
-                    junctionSchedulesById[edge.targetId] = {
-                        arrivalTime = arrivalTime,
-                        ringStartTime = ringStartTime,
-                        ringEndTime = ringEndTime,
-                        iconStartTime = iconStartTime,
-                        iconEndTime = iconEndTime,
-                        entryAngle = getJunctionEntryAngle(edge),
-                    }
-                    graphCompleteTime = maxValue(graphCompleteTime, iconEndTime)
-
-                    for _, outgoingEdge in ipairs(outgoingBySourceId[edge.targetId] or {}) do
-                        queueEdgeIfEarlier(queue, edgeSchedulesById, world, outgoingEdge, iconEndTime)
-                    end
-                end
-            end
-        end
+        processQueuedEdge(queuedEdge)
     end
 
     local scheduledFallbackEdge = false
@@ -277,7 +330,7 @@ local function buildPresentationSchedule(world)
             local fallbackStartTime = 0
             local sourceJunctionSchedule = edge.sourceId and junctionSchedulesById[edge.sourceId] or nil
             if sourceJunctionSchedule then
-                fallbackStartTime = sourceJunctionSchedule.iconEndTime
+                fallbackStartTime = sourceJunctionSchedule.ringEndTime
             end
             scheduledFallbackEdge = queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, fallbackStartTime) or scheduledFallbackEdge
         end
@@ -290,10 +343,7 @@ local function buildPresentationSchedule(world)
                 break
             end
 
-            local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
-            if edgeSchedule then
-                graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
-            end
+            processQueuedEdge(queuedEdge)
         end
     end
 

--- a/src/game/app/map_presentation.lua
+++ b/src/game/app/map_presentation.lua
@@ -1,0 +1,403 @@
+local mapPresentation = {}
+
+local GRAPH_REVEAL_DURATION = 3.5
+local TITLE_ENTER_DURATION = 0.55
+local TITLE_HOLD_DURATION = 2.0
+local TITLE_EXIT_DURATION = 0.55
+local TITLE_LINE_DELAY = 0.18
+local TITLE_TRAVEL_DISTANCE = 420
+local TRACK_REVEAL_PIXELS_PER_SECOND = 560
+local TRACK_REVEAL_MIN_DURATION = 0.16
+local JUNCTION_RING_DURATION = 0.18
+local JUNCTION_ICON_DURATION = 0.32
+local UI_REVEAL_DELAY = 0.08
+local UI_REVEAL_DURATION = 0.52
+local UI_CARD_STAGGER = 0.07
+local UI_TEXT_FADE_DELAY = 0.1
+local UI_TEXT_FADE_DURATION = 0.32
+
+local function clamp(value, minValue, maxValue)
+    if value < minValue then
+        return minValue
+    end
+    if value > maxValue then
+        return maxValue
+    end
+    return value
+end
+
+local function trim(value)
+    return tostring(value or ""):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function maxValue(a, b)
+    if a > b then
+        return a
+    end
+    return b
+end
+
+local function getDescriptorMapKind(descriptor)
+    local resolvedDescriptor = type(descriptor) == "table" and descriptor or {}
+    if resolvedDescriptor.source == "user" and resolvedDescriptor.isRemoteImport then
+        return "downloaded"
+    end
+    if resolvedDescriptor.mapKind then
+        return resolvedDescriptor.mapKind
+    end
+    if resolvedDescriptor.source == "user" or resolvedDescriptor.source == "remote" then
+        return "user"
+    end
+    return "campaign"
+end
+
+local function getCreatorDisplayName(descriptor, profile)
+    local resolvedDescriptor = type(descriptor) == "table" and descriptor or {}
+    local candidates = {
+        resolvedDescriptor.creatorDisplayName,
+        resolvedDescriptor.creator_display_name,
+        resolvedDescriptor.remoteSource and resolvedDescriptor.remoteSource.creatorDisplayName or nil,
+        resolvedDescriptor.remoteSourceEntry and resolvedDescriptor.remoteSourceEntry.creator_display_name or nil,
+        profile and profile.playerDisplayName or nil,
+    }
+
+    for _, candidate in ipairs(candidates) do
+        local name = trim(candidate)
+        if name ~= "" then
+            return name
+        end
+    end
+
+    return ""
+end
+
+local function getMapTitle(world, descriptor)
+    local level = type(world) == "table" and type(world.getLevel) == "function" and world:getLevel() or nil
+    local candidates = {
+        level and level.title or nil,
+        descriptor and descriptor.displayName or nil,
+        descriptor and descriptor.name or nil,
+    }
+
+    for _, candidate in ipairs(candidates) do
+        local title = trim(candidate)
+        if title ~= "" then
+            return title
+        end
+    end
+
+    return "Untitled Map"
+end
+
+function mapPresentation.resolveSubtitle(descriptor, profile)
+    local mapKind = getDescriptorMapKind(descriptor)
+    if mapKind == "tutorial" then
+        return "Guidebook Map"
+    end
+    if mapKind == "campaign" then
+        return "Campaign Map"
+    end
+
+    local creatorDisplayName = getCreatorDisplayName(descriptor, profile)
+    if creatorDisplayName ~= "" then
+        return "by " .. creatorDisplayName
+    end
+
+    if mapKind == "downloaded" then
+        return "Downloaded Map"
+    end
+
+    return "User Map"
+end
+
+local function getRenderedEdgeLength(world, edge)
+    if type(world) == "table" and type(world.getRenderedTrackWindow) == "function" then
+        local startDistance, endDistance = world:getRenderedTrackWindow(edge)
+        return math.max(0, (endDistance or 0) - (startDistance or 0))
+    end
+
+    return math.max(0, edge and edge.path and edge.path.length or 0)
+end
+
+local function getTrackRevealDuration(world, edge)
+    local visibleLength = getRenderedEdgeLength(world, edge)
+    return math.max(TRACK_REVEAL_MIN_DURATION, visibleLength / TRACK_REVEAL_PIXELS_PER_SECOND)
+end
+
+local function angleBetweenPoints(a, b)
+    local dx = (b and b.x or 0) - (a and a.x or 0)
+    local dy = (b and b.y or 0) - (a and a.y or 0)
+
+    if math.atan2 then
+        return math.atan2(dy, dx)
+    end
+
+    if math.abs(dx) <= 0.0001 then
+        return dy >= 0 and math.pi * 0.5 or -math.pi * 0.5
+    end
+
+    local angle = math.atan(dy / dx)
+    if dx < 0 then
+        angle = angle + math.pi
+    end
+    if angle > math.pi then
+        angle = angle - math.pi * 2
+    end
+    return angle
+end
+
+local function getJunctionEntryAngle(edge)
+    local points = edge and edge.path and edge.path.points or nil
+    if not points or #points < 2 then
+        return -math.pi * 0.5
+    end
+
+    return angleBetweenPoints(points[#points], points[#points - 1])
+end
+
+local function popNextQueuedEdge(queue)
+    if #queue == 0 then
+        return nil
+    end
+
+    local bestIndex = 1
+    local bestTime = queue[1].startTime
+    for index = 2, #queue do
+        if queue[index].startTime < bestTime then
+            bestIndex = index
+            bestTime = queue[index].startTime
+        end
+    end
+
+    local entry = queue[bestIndex]
+    table.remove(queue, bestIndex)
+    return entry
+end
+
+local function queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, startTime)
+    if not edge or not edge.id then
+        return false
+    end
+
+    local duration = getTrackRevealDuration(world, edge)
+    local existingSchedule = edgeSchedulesById[edge.id]
+    if existingSchedule and existingSchedule.startTime <= startTime + 0.0001 then
+        return false
+    end
+
+    edgeSchedulesById[edge.id] = {
+        startTime = startTime,
+        endTime = startTime + duration,
+        duration = duration,
+    }
+    queue[#queue + 1] = {
+        edgeId = edge.id,
+        startTime = startTime,
+    }
+    return true
+end
+
+local function buildPresentationSchedule(world)
+    local edges = {}
+    local edgeById = {}
+    local outgoingBySourceId = {}
+
+    for edgeId, edge in pairs(type(world) == "table" and world.edges or {}) do
+        if type(edge) == "table" then
+            local resolvedId = edge.id or edgeId
+            edge.id = resolvedId
+            edges[#edges + 1] = edge
+            edgeById[resolvedId] = edge
+            if edge.sourceType == "junction" and edge.sourceId then
+                outgoingBySourceId[edge.sourceId] = outgoingBySourceId[edge.sourceId] or {}
+                outgoingBySourceId[edge.sourceId][#outgoingBySourceId[edge.sourceId] + 1] = edge
+            end
+        end
+    end
+
+    local queue = {}
+    local edgeSchedulesById = {}
+    local junctionSchedulesById = {}
+    local graphCompleteTime = 0
+
+    for _, edge in ipairs(edges) do
+        if edge.sourceType == "start" then
+            queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, 0)
+        end
+    end
+
+    if #queue == 0 then
+        for _, edge in ipairs(edges) do
+            queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, 0)
+        end
+    end
+
+    while true do
+        local queuedEdge = popNextQueuedEdge(queue)
+        if not queuedEdge then
+            break
+        end
+
+        local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
+        if edgeSchedule and math.abs(edgeSchedule.startTime - queuedEdge.startTime) <= 0.0001 then
+            local edge = edgeById[queuedEdge.edgeId]
+            graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
+
+            if edge and edge.targetType == "junction" and edge.targetId then
+                local arrivalTime = edgeSchedule.endTime
+                local existingJunctionSchedule = junctionSchedulesById[edge.targetId]
+                if not existingJunctionSchedule or arrivalTime < existingJunctionSchedule.arrivalTime - 0.0001 then
+                    local ringStartTime = arrivalTime
+                    local ringEndTime = ringStartTime + JUNCTION_RING_DURATION
+                    local iconStartTime = ringEndTime
+                    local iconEndTime = iconStartTime + JUNCTION_ICON_DURATION
+                    junctionSchedulesById[edge.targetId] = {
+                        arrivalTime = arrivalTime,
+                        ringStartTime = ringStartTime,
+                        ringEndTime = ringEndTime,
+                        iconStartTime = iconStartTime,
+                        iconEndTime = iconEndTime,
+                        entryAngle = getJunctionEntryAngle(edge),
+                    }
+                    graphCompleteTime = maxValue(graphCompleteTime, iconEndTime)
+
+                    for _, outgoingEdge in ipairs(outgoingBySourceId[edge.targetId] or {}) do
+                        queueEdgeIfEarlier(queue, edgeSchedulesById, world, outgoingEdge, iconEndTime)
+                    end
+                end
+            end
+        end
+    end
+
+    local scheduledFallbackEdge = false
+    for _, edge in ipairs(edges) do
+        if not edgeSchedulesById[edge.id] then
+            local fallbackStartTime = 0
+            local sourceJunctionSchedule = edge.sourceId and junctionSchedulesById[edge.sourceId] or nil
+            if sourceJunctionSchedule then
+                fallbackStartTime = sourceJunctionSchedule.iconEndTime
+            end
+            scheduledFallbackEdge = queueEdgeIfEarlier(queue, edgeSchedulesById, world, edge, fallbackStartTime) or scheduledFallbackEdge
+        end
+    end
+
+    if scheduledFallbackEdge then
+        while true do
+            local queuedEdge = popNextQueuedEdge(queue)
+            if not queuedEdge then
+                break
+            end
+
+            local edgeSchedule = edgeSchedulesById[queuedEdge.edgeId]
+            if edgeSchedule then
+                graphCompleteTime = maxValue(graphCompleteTime, edgeSchedule.endTime)
+            end
+        end
+    end
+
+    if graphCompleteTime > 0.0001 then
+        local timeScale = GRAPH_REVEAL_DURATION / graphCompleteTime
+
+        for _, schedule in pairs(edgeSchedulesById) do
+            schedule.startTime = schedule.startTime * timeScale
+            schedule.endTime = schedule.endTime * timeScale
+            schedule.duration = schedule.duration * timeScale
+        end
+
+        for _, schedule in pairs(junctionSchedulesById) do
+            schedule.arrivalTime = schedule.arrivalTime * timeScale
+            schedule.ringStartTime = schedule.ringStartTime * timeScale
+            schedule.ringEndTime = schedule.ringEndTime * timeScale
+            schedule.iconStartTime = schedule.iconStartTime * timeScale
+            schedule.iconEndTime = schedule.iconEndTime * timeScale
+        end
+    end
+
+    return edgeSchedulesById, junctionSchedulesById, GRAPH_REVEAL_DURATION
+end
+
+function mapPresentation.buildState(world, descriptor, profile)
+    if type(world) ~= "table" then
+        return nil
+    end
+
+    local edgeSchedulesById, junctionSchedulesById, graphCompleteTime = buildPresentationSchedule(world)
+    local title = getMapTitle(world, descriptor)
+    local subtitle = mapPresentation.resolveSubtitle(descriptor, profile)
+    local inputGroupCount = type(world.getInputEdgeGroups) == "function" and #(world:getInputEdgeGroups() or {}) or 0
+    local outputGroupCount = type(world.getOutputBadgeGroups) == "function" and #(world:getOutputBadgeGroups() or {}) or 0
+    local maxCardDelay = math.max(inputGroupCount - 1, outputGroupCount - 1, 0) * UI_CARD_STAGGER
+    local titleEndTime = TITLE_ENTER_DURATION + TITLE_HOLD_DURATION + TITLE_EXIT_DURATION
+    if subtitle ~= "" then
+        titleEndTime = titleEndTime + TITLE_LINE_DELAY
+    end
+
+    local uiRevealStartTime = graphCompleteTime + UI_REVEAL_DELAY
+    local finishTime = math.max(titleEndTime, uiRevealStartTime + UI_REVEAL_DURATION + maxCardDelay)
+    local allEdgeIds = {}
+    for edgeId in pairs(edgeSchedulesById) do
+        allEdgeIds[edgeId] = true
+    end
+
+    return {
+        elapsed = 0,
+        finishTime = finishTime,
+        title = title,
+        subtitle = subtitle,
+        titleSequence = {
+            enterDuration = TITLE_ENTER_DURATION,
+            holdDuration = TITLE_HOLD_DURATION,
+            exitDuration = TITLE_EXIT_DURATION,
+            lineDelay = TITLE_LINE_DELAY,
+            travelDistance = TITLE_TRAVEL_DISTANCE,
+            endTime = titleEndTime,
+        },
+        uiReveal = {
+            startTime = uiRevealStartTime,
+            duration = UI_REVEAL_DURATION,
+            cardStagger = UI_CARD_STAGGER,
+            textFadeDelay = UI_TEXT_FADE_DELAY,
+            textFadeDuration = UI_TEXT_FADE_DURATION,
+            maxCardDelay = maxCardDelay,
+        },
+        graphCompleteTime = graphCompleteTime,
+        edgeScheduleById = edgeSchedulesById,
+        junctionScheduleById = junctionSchedulesById,
+        allEdgeIds = allEdgeIds,
+        titleOnly = false,
+    }
+end
+
+function mapPresentation.isBlocking(state)
+    return type(state) == "table" and state.titleOnly ~= true
+end
+
+function mapPresentation.skip(state)
+    if type(state) ~= "table" then
+        return nil
+    end
+
+    local titleEndTime = state.titleSequence and state.titleSequence.endTime or 0
+    if (state.elapsed or 0) >= titleEndTime - 0.0001 then
+        return nil
+    end
+
+    state.titleOnly = true
+    return state
+end
+
+function mapPresentation.update(state, dt)
+    if type(state) ~= "table" then
+        return true
+    end
+
+    local maxElapsed = state.finishTime or 0
+    if state.titleOnly == true then
+        maxElapsed = state.titleSequence and state.titleSequence.endTime or maxElapsed
+    end
+
+    state.elapsed = clamp((state.elapsed or 0) + math.max(0, dt or 0), 0, maxElapsed)
+    return state.elapsed >= maxElapsed - 0.0001
+end
+
+return mapPresentation

--- a/src/game/data/replays/campaign/ambient_simple_beginning.toml
+++ b/src/game/data/replays/campaign/ambient_simple_beginning.toml
@@ -1,0 +1,7 @@
+version = 1
+replayId = "campaign-ambient-simple-beginning"
+mapUuid = "3206710d-793f-474e-957a-fdb721926f52"
+mapTitle = "A Simple Beginning"
+createdAt = "2026-04-23T00:00:00Z"
+duration = 9
+endReason = "ambient"

--- a/src/game/data/replays/campaign/ambient_two_crossings.toml
+++ b/src/game/data/replays/campaign/ambient_two_crossings.toml
@@ -1,0 +1,7 @@
+version = 1
+replayId = "campaign-ambient-two-crossings"
+mapUuid = "16b6e4e1-cafc-4f02-8285-11dc7e2f5d75"
+mapTitle = "Two Crossings"
+createdAt = "2026-04-23T00:00:00Z"
+duration = 10
+endReason = "ambient"

--- a/src/game/gameplay/railway_world_rendering.lua
+++ b/src/game/gameplay/railway_world_rendering.lua
@@ -556,10 +556,12 @@ function world:drawCollisionMarker()
     return trackSceneRenderer.drawCollisionMarker(self)
 end
 
-function world:draw()
-    return trackSceneRenderer.drawScene(self, {
-        backgroundColor = { 0.08, 0.1, 0.12, 1 },
-    })
+function world:draw(drawOptions)
+    local options = drawOptions or {}
+    if options.backgroundColor == nil then
+        options.backgroundColor = { 0.08, 0.1, 0.12, 1 }
+    end
+    return trackSceneRenderer.drawScene(self, options)
 end
 
 

--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -120,6 +120,116 @@ local function buildCubicCurvePoints(startPoint, controlPointA, controlPointB, e
     return points
 end
 
+local function appendPoint(points, x, y)
+    local lastPoint = points[#points]
+    if lastPoint and math.abs((lastPoint.x or 0) - x) <= 0.001 and math.abs((lastPoint.y or 0) - y) <= 0.001 then
+        return
+    end
+
+    points[#points + 1] = {
+        x = x,
+        y = y,
+    }
+end
+
+local function buildPathSlice(scene, path, startDistance, endDistance)
+    local points = {}
+    local clampedStart = clamp(startDistance or 0, 0, path.length)
+    local clampedEnd = clamp(endDistance or path.length, 0, path.length)
+
+    if clampedEnd <= clampedStart then
+        local x, y = scene:pointOnPath(path, clampedStart)
+        appendPoint(points, x, y)
+        return points
+    end
+
+    local startX, startY = scene:pointOnPath(path, clampedStart)
+    local endX, endY = scene:pointOnPath(path, clampedEnd)
+    appendPoint(points, startX, startY)
+
+    for _, segment in ipairs(path.segments or {}) do
+        local segmentEndDistance = (segment.startDistance or 0) + (segment.length or 0)
+        if segmentEndDistance > clampedStart and segmentEndDistance < clampedEnd then
+            appendPoint(points, segment.b.x, segment.b.y)
+        end
+    end
+
+    appendPoint(points, endX, endY)
+    return points
+end
+
+local function getRenderedTrackPoints(scene, track, revealProgress)
+    local resolvedRevealProgress = revealProgress == nil and 1 or clamp(revealProgress, 0, 1)
+    if resolvedRevealProgress <= 0 then
+        return {}
+    end
+    if resolvedRevealProgress >= 0.999 then
+        return scene:getRenderedTrackPoints(track)
+    end
+
+    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
+    local visibleLength = math.max(0, (endDistance or 0) - (startDistance or 0))
+    return buildPathSlice(scene, track.path, startDistance, startDistance + visibleLength * resolvedRevealProgress)
+end
+
+local function easeOutBack(t)
+    local s = 1.70158
+    local value = t - 1
+    return 1 + value * value * ((s + 1) * value + s)
+end
+
+local function getPresentationTrackRevealProgress(presentation, edgeId)
+    local schedule = presentation and presentation.edgeScheduleById and presentation.edgeScheduleById[edgeId] or nil
+    if not schedule then
+        return 1
+    end
+
+    local duration = math.max(0.0001, (schedule.endTime or 0) - (schedule.startTime or 0))
+    return clamp(((presentation.elapsed or 0) - (schedule.startTime or 0)) / duration, 0, 1)
+end
+
+local function getPresentationJunctionState(presentation, junctionId)
+    local schedule = presentation and presentation.junctionScheduleById and presentation.junctionScheduleById[junctionId] or nil
+    if not schedule then
+        return nil
+    end
+
+    local elapsed = presentation.elapsed or 0
+    if elapsed < (schedule.arrivalTime or 0) then
+        return nil
+    end
+
+    local ringDuration = math.max(0.0001, (schedule.ringEndTime or 0) - (schedule.ringStartTime or 0))
+    local iconDuration = math.max(0.0001, (schedule.iconEndTime or 0) - (schedule.iconStartTime or 0))
+    local ringProgress = clamp((elapsed - (schedule.ringStartTime or 0)) / ringDuration, 0, 1)
+    local iconProgress = clamp((elapsed - (schedule.iconStartTime or 0)) / iconDuration, 0, 1)
+
+    return {
+        ringProgress = ringProgress,
+        iconProgress = iconProgress,
+        iconScaleMultiplier = 0.18 + 0.82 * easeOutBack(iconProgress),
+        entryAngle = schedule.entryAngle or (-math.pi * 0.5),
+    }
+end
+
+local function drawPresentationJunctionRing(graphics, scene, junction, presentationState)
+    local activeInput = junction.inputs[junction.activeInputIndex]
+    local activeOutputColor = scene:getOutputDisplayColor(junction, junction.activeOutputIndex, true)
+    local activeInputColor = activeInput and activeInput.color or activeOutputColor
+    local x = junction.mergePoint.x
+    local y = junction.mergePoint.y
+    local radius = junction.crossingRadius
+    local startAngle = presentationState.entryAngle or (-math.pi * 0.5)
+    local endAngle = startAngle + math.pi * 2 * clamp(presentationState.ringProgress or 0, 0, 1)
+
+    graphics.setColor(0.05, 0.06, 0.08, 0.42)
+    graphics.circle("fill", x, y, radius - 3)
+    graphics.setColor(activeInputColor[1], activeInputColor[2], activeInputColor[3], 0.92)
+    graphics.setLineWidth(3)
+    graphics.arc("line", x, y, radius, startAngle, endAngle)
+    graphics.setLineWidth(1)
+end
+
 local function getTimerRatio(armed, remaining, duration)
     if duration <= 0 then
         return armed and 1 or 0
@@ -553,12 +663,13 @@ function renderer.drawStripedTrack(_, points, width, stripeColors, alpha)
     end
 end
 
-function renderer.drawInputTrack(scene, track, isActive)
+function renderer.drawInputTrack(scene, track, isActive, drawState)
     local graphics = love.graphics
     local trackColor = isActive and track.color or track.darkColor
     local trackAlpha = isActive and 0.96 or 0.72
     local stripeColors = buildTrackStripeColors(track.colors, isActive)
-    local renderedPoints = scene:getRenderedTrackPoints(track)
+    local revealProgress = drawState and drawState.revealProgress or nil
+    local renderedPoints = getRenderedTrackPoints(scene, track, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -577,10 +688,12 @@ function renderer.drawInputTrack(scene, track, isActive)
         renderer.drawTrackLine(scene, points, scene.trackWidth, trackColor, trackAlpha)
     end
 
-    renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+    if not drawState or drawState.showMarkers ~= false then
+        renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+    end
 end
 
-function renderer.drawStandaloneTrack(scene, track, isActive)
+function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
     local graphics = love.graphics
     local trackColor = isActive and track.color or track.darkColor
     local trackAlpha = isActive and 0.96 or 0.72
@@ -590,7 +703,8 @@ function renderer.drawStandaloneTrack(scene, track, isActive)
         stripeColors = buildTrackStripeColors(track.colors, isActive)
     end
 
-    local renderedPoints = scene:getRenderedTrackPoints(track)
+    local revealProgress = drawState and drawState.revealProgress or nil
+    local renderedPoints = getRenderedTrackPoints(scene, track, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -609,15 +723,18 @@ function renderer.drawStandaloneTrack(scene, track, isActive)
         renderer.drawTrackLine(scene, points, scene.trackWidth, trackColor, trackAlpha)
     end
 
-    renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+    if not drawState or drawState.showMarkers ~= false then
+        renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+    end
 end
 
-function renderer.drawOutputTrack(scene, junction, outputIndex, isActive)
+function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawState)
     local graphics = love.graphics
     local outputTrack = junction.outputs[outputIndex]
     local color = scene:getOutputDisplayColor(junction, outputIndex, isActive)
     local stripeColors = outputTrack and not outputTrack.adoptInputColor and buildTrackStripeColors(outputTrack.colors, isActive) or nil
-    local renderedPoints = scene:getRenderedTrackPoints(outputTrack)
+    local revealProgress = drawState and drawState.revealProgress or nil
+    local renderedPoints = getRenderedTrackPoints(scene, outputTrack, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -636,14 +753,17 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive)
         renderer.drawTrackLine(scene, points, scene.sharedWidth, color, isActive and 0.98 or 0.7)
     end
 
-    renderer.drawTrackRoadTypeMarkers(scene, outputTrack, isActive)
+    if not drawState or drawState.showMarkers ~= false then
+        renderer.drawTrackRoadTypeMarkers(scene, outputTrack, isActive)
+    end
 end
 
-function renderer.drawControlOverlay(scene, junction)
+function renderer.drawControlOverlay(scene, junction, options)
     local graphics = love.graphics
     local control = junction.control
     local inputColor, inputStripeColors = getJunctionInputStyle(junction)
-    local iconScale = getControlIconScale(control)
+    local resolvedOptions = options or {}
+    local iconScale = getControlIconScale(control) * (resolvedOptions.iconScaleMultiplier or 1)
 
     if control.type == "direct" then
         local centerX, centerY, innerRadius = drawJunctionCircle(graphics, junction, inputColor, inputStripeColors)
@@ -811,14 +931,33 @@ function renderer.drawActiveRouteIndicator(scene, junction, activeInput, activeO
     graphics.line(curvePoints)
 end
 
-function renderer.drawCrossing(scene, junction)
+function renderer.drawCrossing(scene, junction, options)
     local graphics = love.graphics
+    local resolvedOptions = options or {}
+    local presentationState = resolvedOptions.presentation
     local activeInput = junction.inputs[junction.activeInputIndex]
     local activeOutputColor = scene:getOutputDisplayColor(junction, junction.activeOutputIndex, true)
     local activeInputColor = activeInput and activeInput.color or activeOutputColor
     local x = junction.mergePoint.x
     local y = junction.mergePoint.y
     local inputStripeColors = activeInput and buildTrackStripeColors(activeInput.colors, true) or nil
+
+    if presentationState then
+        if (presentationState.ringProgress or 0) < 0.999 then
+            drawPresentationJunctionRing(graphics, scene, junction, presentationState)
+            return
+        end
+
+        if (presentationState.iconProgress or 0) <= 0.001 then
+            drawJunctionCircle(graphics, junction, activeInputColor, inputStripeColors)
+            return
+        end
+
+        renderer.drawControlOverlay(scene, junction, {
+            iconScaleMultiplier = presentationState.iconScaleMultiplier or 1,
+        })
+        return
+    end
 
     graphics.setColor(0.05, 0.06, 0.08, 1)
     graphics.circle("fill", x, y, junction.crossingRadius)
@@ -913,6 +1052,7 @@ end
 function renderer.drawScene(scene, options)
     local graphics = love.graphics
     local drawOptions = options or {}
+    local presentation = drawOptions.presentation
     local highlightedEdgeIds = drawOptions.highlightedEdgeIds or scene:getHighlightedEdgeIds()
     local drawnEdgeIds = {}
 
@@ -926,7 +1066,17 @@ function renderer.drawScene(scene, options)
         for outputIndex = 1, #junction.outputs do
             local outputTrack = junction.outputs[outputIndex]
             if outputTrack and not drawnEdgeIds[outputTrack.id] then
-                renderer.drawOutputTrack(scene, junction, outputIndex, highlightedEdgeIds[outputTrack.id] == true)
+                local drawState = presentation and {
+                    revealProgress = getPresentationTrackRevealProgress(presentation, outputTrack.id),
+                    showMarkers = false,
+                } or nil
+                renderer.drawOutputTrack(
+                    scene,
+                    junction,
+                    outputIndex,
+                    presentation and true or highlightedEdgeIds[outputTrack.id] == true,
+                    drawState
+                )
                 drawnEdgeIds[outputTrack.id] = true
             end
         end
@@ -936,7 +1086,16 @@ function renderer.drawScene(scene, options)
         for inputIndex = 1, #junction.inputs do
             local inputTrack = junction.inputs[inputIndex]
             if inputTrack and not drawnEdgeIds[inputTrack.id] then
-                renderer.drawInputTrack(scene, inputTrack, highlightedEdgeIds[inputTrack.id] == true)
+                local drawState = presentation and {
+                    revealProgress = getPresentationTrackRevealProgress(presentation, inputTrack.id),
+                    showMarkers = false,
+                } or nil
+                renderer.drawInputTrack(
+                    scene,
+                    inputTrack,
+                    presentation and true or highlightedEdgeIds[inputTrack.id] == true,
+                    drawState
+                )
                 drawnEdgeIds[inputTrack.id] = true
             end
         end
@@ -944,17 +1103,32 @@ function renderer.drawScene(scene, options)
 
     for _, track in pairs(scene.edges or {}) do
         if track and not drawnEdgeIds[track.id] then
-            renderer.drawStandaloneTrack(scene, track, highlightedEdgeIds[track.id] == true)
+            local drawState = presentation and {
+                revealProgress = getPresentationTrackRevealProgress(presentation, track.id),
+                showMarkers = false,
+            } or nil
+            renderer.drawStandaloneTrack(
+                scene,
+                track,
+                presentation and true or highlightedEdgeIds[track.id] == true,
+                drawState
+            )
+            drawnEdgeIds[track.id] = true
         end
     end
 
     for _, junction in ipairs(scene.junctionOrder or {}) do
-        renderer.drawCrossing(scene, junction)
+        local presentationState = presentation and getPresentationJunctionState(presentation, junction.id) or nil
+        if not presentation or presentationState then
+            renderer.drawCrossing(scene, junction, presentationState and { presentation = presentationState } or nil)
+        end
     end
 
-    for _, junction in ipairs(scene.junctionOrder or {}) do
-        for inputIndex = 1, #junction.inputs do
-            renderer.drawTrackSignal(scene, junction, inputIndex)
+    if not presentation then
+        for _, junction in ipairs(scene.junctionOrder or {}) do
+            for inputIndex = 1, #junction.inputs do
+                renderer.drawTrackSignal(scene, junction, inputIndex)
+            end
         end
     end
 
@@ -964,8 +1138,10 @@ function renderer.drawScene(scene, options)
         end
     end
 
-    for _, junction in ipairs(scene.junctionOrder or {}) do
-        renderer.drawOutputSelector(scene, junction)
+    if not presentation then
+        for _, junction in ipairs(scene.junctionOrder or {}) do
+            renderer.drawOutputSelector(scene, junction)
+        end
     end
 
     if drawOptions.drawCollision ~= false then

--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -307,13 +307,17 @@ local function getPresentationJunctionState(presentation, junctionId)
 
     local ringDuration = math.max(0.0001, (schedule.ringEndTime or 0) - (schedule.ringStartTime or 0))
     local iconDuration = math.max(0.0001, (schedule.iconEndTime or 0) - (schedule.iconStartTime or 0))
+    local selectorDuration = math.max(0.0001, (schedule.selectorEndTime or 0) - (schedule.selectorStartTime or 0))
     local ringProgress = clamp((elapsed - (schedule.ringStartTime or 0)) / ringDuration, 0, 1)
     local iconProgress = clamp((elapsed - (schedule.iconStartTime or 0)) / iconDuration, 0, 1)
+    local selectorProgress = clamp((elapsed - (schedule.selectorStartTime or 0)) / selectorDuration, 0, 1)
 
     return {
         ringProgress = ringProgress,
         iconProgress = iconProgress,
         iconScaleMultiplier = 0.18 + 0.82 * easeOutBack(iconProgress),
+        selectorProgress = selectorProgress,
+        selectorScaleMultiplier = 0.06 + 0.94 * easeOutSpring(selectorProgress),
         entryAngle = schedule.entryAngle or (-math.pi * 0.5),
     }
 end
@@ -1399,6 +1403,15 @@ function renderer.drawScene(scene, options)
                         alphaMultiplier = signalState.alpha,
                     })
                 end
+            end
+        end
+
+        for _, junction in ipairs(scene.junctionOrder or {}) do
+            local presentationState = getPresentationJunctionState(presentation, junction.id)
+            if presentationState and (presentationState.selectorProgress or 0) > 0.001 then
+                renderer.drawOutputSelector(scene, junction, {
+                    scaleMultiplier = presentationState.selectorScaleMultiplier or 1,
+                })
             end
         end
     elseif outro then

--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -18,6 +18,8 @@ local CROSSBAR_FLASH_DURATION = 0.28
 local SPRING_RELEASE_DURATION = 0.42
 local ROAD_PATTERN_OUTLINE = { 0.04, 0.05, 0.07, 0.98 }
 local ROAD_PATTERN_FILL = { 0.97, 0.98, 1.0, 0.94 }
+local TRACK_DECORATOR_REVEAL_DELAY = 0.08
+local TRACK_DECORATOR_POP_DURATION = 0.50
 local TRACK_STRIPE_LENGTH = 14
 local OUTPUT_SELECTOR_RADIUS = 15
 local TRACK_LINE_JOIN = "bevel"
@@ -172,42 +174,56 @@ local function buildPathSlice(scene, path, startDistance, endDistance)
     return points
 end
 
-local function getRenderedTrackPoints(scene, track, revealProgress)
+local function getTrackRenderWindow(scene, track, drawState)
+    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
+    local revealProgress = drawState and drawState.revealProgress or nil
+    local outroProgress = drawState and drawState.outroProgress or nil
+
+    if outroProgress ~= nil then
+        local clampedOutroProgress = clamp(outroProgress, 0, 1)
+        if clampedOutroProgress >= 0.999 then
+            return nil, nil
+        end
+
+        local midpoint = (startDistance + endDistance) * 0.5
+        local animatedStartDistance = lerp(startDistance, midpoint, clampedOutroProgress)
+        local animatedEndDistance = lerp(endDistance, midpoint, clampedOutroProgress)
+        if animatedEndDistance - animatedStartDistance <= 0.001 then
+            return nil, nil
+        end
+
+        return animatedStartDistance, animatedEndDistance
+    end
+
     local resolvedRevealProgress = revealProgress == nil and 1 or clamp(revealProgress, 0, 1)
     if resolvedRevealProgress <= 0 then
-        return {}
+        return nil, nil
     end
     if resolvedRevealProgress >= 0.999 then
-        return scene:getRenderedTrackPoints(track)
+        return startDistance, endDistance
     end
 
-    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
     local visibleLength = math.max(0, (endDistance or 0) - (startDistance or 0))
-    return buildPathSlice(scene, track.path, startDistance, startDistance + visibleLength * resolvedRevealProgress)
-end
-
-local function getUndrawingTrackPoints(scene, track, outroProgress)
-    local clampedOutroProgress = clamp(outroProgress or 0, 0, 1)
-    if clampedOutroProgress >= 0.999 then
-        return {}
-    end
-
-    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
-    local midpoint = (startDistance + endDistance) * 0.5
-    local animatedStartDistance = lerp(startDistance, midpoint, clampedOutroProgress)
-    local animatedEndDistance = lerp(endDistance, midpoint, clampedOutroProgress)
-
-    if animatedEndDistance - animatedStartDistance <= 0.001 then
-        return {}
-    end
-
-    return buildPathSlice(scene, track.path, animatedStartDistance, animatedEndDistance)
+    return startDistance, startDistance + visibleLength * resolvedRevealProgress
 end
 
 local function easeOutBack(t)
     local s = 1.70158
     local value = t - 1
     return 1 + value * value * ((s + 1) * value + s)
+end
+
+local function easeOutSpring(t)
+    local clamped = clamp(t or 0, 0, 1)
+    if clamped <= 0.001 then
+        return 0
+    end
+    if clamped >= 0.999 then
+        return 1
+    end
+
+    local c4 = (2 * math.pi) / 3
+    return math.pow(2, -10 * clamped) * math.sin((clamped * 10 - 0.75) * c4) + 1
 end
 
 local function getPresentationTimedProgress(presentation, transition)
@@ -258,6 +274,24 @@ local function getPresentationTrackRevealProgress(presentation, edgeId)
 
     local duration = math.max(0.0001, (schedule.endTime or 0) - (schedule.startTime or 0))
     return clamp(((presentation.elapsed or 0) - (schedule.startTime or 0)) / duration, 0, 1)
+end
+
+local function getPresentationTrackDecoratorState(presentation, edgeId)
+    local schedule = presentation and presentation.edgeScheduleById and presentation.edgeScheduleById[edgeId] or nil
+    if not schedule then
+        return nil
+    end
+
+    local duration = math.max(0.0001, (schedule.endTime or 0) - (schedule.startTime or 0))
+    local startTime = (schedule.startTime or 0) + math.min(TRACK_DECORATOR_REVEAL_DELAY, duration * 0.35)
+
+    return {
+        elapsed = presentation.elapsed or 0,
+        startTime = startTime,
+        duration = duration,
+        frontProgress = clamp(((presentation.elapsed or 0) - startTime) / duration, 0, 1),
+        popDuration = TRACK_DECORATOR_POP_DURATION,
+    }
 end
 
 local function getPresentationJunctionState(presentation, junctionId)
@@ -645,16 +679,34 @@ function renderer.drawTrackPatternSegment(_, startX, startY, endX, endY, alpha, 
     graphics.line(startX, startY, endX, endY)
 end
 
-function renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
-    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
+local function scalePointFromCenter(centerX, centerY, pointX, pointY, scale)
+    return centerX + (pointX - centerX) * scale, centerY + (pointY - centerY) * scale
+end
+
+function renderer.drawTrackRoadTypeMarkers(scene, track, isActive, drawState)
+    local startDistance = drawState and drawState.renderStartDistance or nil
+    local endDistance = drawState and drawState.renderEndDistance or nil
+    if startDistance == nil or endDistance == nil then
+        startDistance, endDistance = scene:getRenderedTrackWindow(track)
+    end
+    if endDistance <= startDistance then
+        return
+    end
+
     local activityMix = type(isActive) == "number" and clamp(isActive, 0, 1) or (isActive and 1 or 0)
     local alpha = lerp(0.78, 0.95, activityMix)
+    local fullStartDistance, fullEndDistance = scene:getRenderedTrackWindow(track)
+    local fullVisibleLength = math.max(0.0001, (fullEndDistance or 0) - (fullStartDistance or 0))
+    local decoratorPresentation = drawState and drawState.decoratorPresentation or nil
+    local decoratorEndDistance = decoratorPresentation
+        and (fullStartDistance + fullVisibleLength * decoratorPresentation.frontProgress)
+        or endDistance
 
     for _, section in ipairs(track.styleSections or {}) do
         local roadTypeConfig = roadTypes.getConfig(section.roadType)
         if roadTypeConfig.pattern ~= "plain" then
             local sectionStartDistance = math.max(startDistance, section.startDistance)
-            local sectionEndDistance = math.min(endDistance, section.endDistance)
+            local sectionEndDistance = math.min(endDistance, section.endDistance, decoratorEndDistance)
             local markerDistance = sectionStartDistance + roadTypeConfig.markerSpacing * 0.5
             local markerSize = roadTypeConfig.markerSize
             local outlineWidth = roadTypeConfig.markerWidth + 2
@@ -666,6 +718,24 @@ function renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
                 local directionY = math.sin(angle)
                 local normalX = -directionY
                 local normalY = directionX
+                local markerAlpha = alpha
+                local markerScale = 1
+
+                if decoratorPresentation then
+                    local markerFraction = clamp((markerDistance - fullStartDistance) / fullVisibleLength, 0, 1)
+                    local markerStartTime = decoratorPresentation.startTime + decoratorPresentation.duration * markerFraction
+                    local popupProgress = clamp(
+                        (decoratorPresentation.elapsed - markerStartTime) / math.max(0.0001, decoratorPresentation.popDuration),
+                        0,
+                        1
+                    )
+                    if popupProgress <= 0.001 then
+                        markerDistance = markerDistance + roadTypeConfig.markerSpacing
+                        goto continue_marker
+                    end
+
+                    markerScale = 0.06 + 0.94 * easeOutSpring(popupProgress)
+                end
 
                 if roadTypeConfig.pattern == "chevron" then
                     local tipX = markerX + directionX * markerSize
@@ -674,17 +744,23 @@ function renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
                     local leftY = markerY - normalY * markerSize * 0.7
                     local rightX = markerX + normalX * markerSize * 0.7
                     local rightY = markerY + normalY * markerSize * 0.7
-                    renderer.drawTrackPatternSegment(scene, leftX, leftY, tipX, tipY, alpha, outlineWidth, fillWidth)
-                    renderer.drawTrackPatternSegment(scene, rightX, rightY, tipX, tipY, alpha, outlineWidth, fillWidth)
+                    tipX, tipY = scalePointFromCenter(markerX, markerY, tipX, tipY, markerScale)
+                    leftX, leftY = scalePointFromCenter(markerX, markerY, leftX, leftY, markerScale)
+                    rightX, rightY = scalePointFromCenter(markerX, markerY, rightX, rightY, markerScale)
+                    renderer.drawTrackPatternSegment(scene, leftX, leftY, tipX, tipY, markerAlpha, outlineWidth, fillWidth)
+                    renderer.drawTrackPatternSegment(scene, rightX, rightY, tipX, tipY, markerAlpha, outlineWidth, fillWidth)
                 elseif roadTypeConfig.pattern == "crossbar" then
                     local startX = markerX - normalX * markerSize
                     local startY = markerY - normalY * markerSize
                     local endX = markerX + normalX * markerSize
                     local endY = markerY + normalY * markerSize
-                    renderer.drawTrackPatternSegment(scene, startX, startY, endX, endY, alpha, outlineWidth, fillWidth)
+                    startX, startY = scalePointFromCenter(markerX, markerY, startX, startY, markerScale)
+                    endX, endY = scalePointFromCenter(markerX, markerY, endX, endY, markerScale)
+                    renderer.drawTrackPatternSegment(scene, startX, startY, endX, endY, markerAlpha, outlineWidth, fillWidth)
                 end
 
                 markerDistance = markerDistance + roadTypeConfig.markerSpacing
+                ::continue_marker::
             end
         end
     end
@@ -745,10 +821,13 @@ function renderer.drawInputTrack(scene, track, isActive, drawState)
     local trackColor = mixColor(track.darkColor, track.color, activityMix)
     local trackAlpha = lerp(0.72, 0.96, activityMix)
     local stripeColors = buildTrackStripeColors(track.colors, activityMix)
-    local revealProgress = drawState and drawState.revealProgress or nil
-    local outroProgress = drawState and drawState.outroProgress or nil
-    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, track, outroProgress)
-        or getRenderedTrackPoints(scene, track, revealProgress)
+    local renderStartDistance, renderEndDistance = getTrackRenderWindow(scene, track, drawState)
+    local renderedPoints = nil
+    if renderStartDistance == nil or renderEndDistance == nil then
+        renderedPoints = {}
+    else
+        renderedPoints = buildPathSlice(scene, track.path, renderStartDistance, renderEndDistance)
+    end
     if #renderedPoints < 2 then
         return
     end
@@ -768,7 +847,11 @@ function renderer.drawInputTrack(scene, track, isActive, drawState)
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix)
+        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix, {
+            renderStartDistance = renderStartDistance,
+            renderEndDistance = renderEndDistance,
+            decoratorPresentation = drawState and drawState.decoratorPresentation or nil,
+        })
     end
 end
 
@@ -786,10 +869,13 @@ function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
         stripeColors = buildTrackStripeColors(track.colors, activityMix)
     end
 
-    local revealProgress = drawState and drawState.revealProgress or nil
-    local outroProgress = drawState and drawState.outroProgress or nil
-    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, track, outroProgress)
-        or getRenderedTrackPoints(scene, track, revealProgress)
+    local renderStartDistance, renderEndDistance = getTrackRenderWindow(scene, track, drawState)
+    local renderedPoints = nil
+    if renderStartDistance == nil or renderEndDistance == nil then
+        renderedPoints = {}
+    else
+        renderedPoints = buildPathSlice(scene, track.path, renderStartDistance, renderEndDistance)
+    end
     if #renderedPoints < 2 then
         return
     end
@@ -809,7 +895,11 @@ function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix)
+        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix, {
+            renderStartDistance = renderStartDistance,
+            renderEndDistance = renderEndDistance,
+            decoratorPresentation = drawState and drawState.decoratorPresentation or nil,
+        })
     end
 end
 
@@ -824,10 +914,13 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawSt
     local inactiveColor = scene:getOutputDisplayColor(junction, outputIndex, false)
     local color = mixColor(inactiveColor, activeColor, activityMix)
     local stripeColors = outputTrack and not outputTrack.adoptInputColor and buildTrackStripeColors(outputTrack.colors, activityMix) or nil
-    local revealProgress = drawState and drawState.revealProgress or nil
-    local outroProgress = drawState and drawState.outroProgress or nil
-    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, outputTrack, outroProgress)
-        or getRenderedTrackPoints(scene, outputTrack, revealProgress)
+    local renderStartDistance, renderEndDistance = getTrackRenderWindow(scene, outputTrack, drawState)
+    local renderedPoints = nil
+    if renderStartDistance == nil or renderEndDistance == nil then
+        renderedPoints = {}
+    else
+        renderedPoints = buildPathSlice(scene, outputTrack.path, renderStartDistance, renderEndDistance)
+    end
     if #renderedPoints < 2 then
         return
     end
@@ -847,7 +940,11 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawSt
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, outputTrack, activityMix)
+        renderer.drawTrackRoadTypeMarkers(scene, outputTrack, activityMix, {
+            renderStartDistance = renderStartDistance,
+            renderEndDistance = renderEndDistance,
+            decoratorPresentation = drawState and drawState.decoratorPresentation or nil,
+        })
     end
 end
 
@@ -1193,8 +1290,8 @@ function renderer.drawScene(scene, options)
                 if presentation then
                     drawState = {
                         revealProgress = getPresentationTrackRevealProgress(presentation, outputTrack.id),
-                        showMarkers = false,
                         activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                        decoratorPresentation = getPresentationTrackDecoratorState(presentation, outputTrack.id),
                     }
                 elseif outro then
                     drawState = {
@@ -1223,8 +1320,8 @@ function renderer.drawScene(scene, options)
                 if presentation then
                     drawState = {
                         revealProgress = getPresentationTrackRevealProgress(presentation, inputTrack.id),
-                        showMarkers = false,
                         activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                        decoratorPresentation = getPresentationTrackDecoratorState(presentation, inputTrack.id),
                     }
                 elseif outro then
                     drawState = {
@@ -1250,8 +1347,8 @@ function renderer.drawScene(scene, options)
             if presentation then
                 drawState = {
                     revealProgress = getPresentationTrackRevealProgress(presentation, track.id),
-                    showMarkers = false,
                     activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                    decoratorPresentation = getPresentationTrackDecoratorState(presentation, track.id),
                 }
             elseif outro then
                 drawState = {

--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -186,6 +186,24 @@ local function getRenderedTrackPoints(scene, track, revealProgress)
     return buildPathSlice(scene, track.path, startDistance, startDistance + visibleLength * resolvedRevealProgress)
 end
 
+local function getUndrawingTrackPoints(scene, track, outroProgress)
+    local clampedOutroProgress = clamp(outroProgress or 0, 0, 1)
+    if clampedOutroProgress >= 0.999 then
+        return {}
+    end
+
+    local startDistance, endDistance = scene:getRenderedTrackWindow(track)
+    local midpoint = (startDistance + endDistance) * 0.5
+    local animatedStartDistance = lerp(startDistance, midpoint, clampedOutroProgress)
+    local animatedEndDistance = lerp(endDistance, midpoint, clampedOutroProgress)
+
+    if animatedEndDistance - animatedStartDistance <= 0.001 then
+        return {}
+    end
+
+    return buildPathSlice(scene, track.path, animatedStartDistance, animatedEndDistance)
+end
+
 local function easeOutBack(t)
     local s = 1.70158
     local value = t - 1
@@ -728,7 +746,9 @@ function renderer.drawInputTrack(scene, track, isActive, drawState)
     local trackAlpha = lerp(0.72, 0.96, activityMix)
     local stripeColors = buildTrackStripeColors(track.colors, activityMix)
     local revealProgress = drawState and drawState.revealProgress or nil
-    local renderedPoints = getRenderedTrackPoints(scene, track, revealProgress)
+    local outroProgress = drawState and drawState.outroProgress or nil
+    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, track, outroProgress)
+        or getRenderedTrackPoints(scene, track, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -767,7 +787,9 @@ function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
     end
 
     local revealProgress = drawState and drawState.revealProgress or nil
-    local renderedPoints = getRenderedTrackPoints(scene, track, revealProgress)
+    local outroProgress = drawState and drawState.outroProgress or nil
+    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, track, outroProgress)
+        or getRenderedTrackPoints(scene, track, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -803,7 +825,9 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawSt
     local color = mixColor(inactiveColor, activeColor, activityMix)
     local stripeColors = outputTrack and not outputTrack.adoptInputColor and buildTrackStripeColors(outputTrack.colors, activityMix) or nil
     local revealProgress = drawState and drawState.revealProgress or nil
-    local renderedPoints = getRenderedTrackPoints(scene, outputTrack, revealProgress)
+    local outroProgress = drawState and drawState.outroProgress or nil
+    local renderedPoints = outroProgress and getUndrawingTrackPoints(scene, outputTrack, outroProgress)
+        or getRenderedTrackPoints(scene, outputTrack, revealProgress)
     if #renderedPoints < 2 then
         return
     end
@@ -1004,6 +1028,7 @@ function renderer.drawCrossing(scene, junction, options)
     local graphics = love.graphics
     local resolvedOptions = options or {}
     local presentationState = resolvedOptions.presentation
+    local outroState = resolvedOptions.outro
     local activeInput = junction.inputs[junction.activeInputIndex]
     local activeOutputColor = scene:getOutputDisplayColor(junction, junction.activeOutputIndex, true)
     local activeInputColor = activeInput and activeInput.color or activeOutputColor
@@ -1028,6 +1053,25 @@ function renderer.drawCrossing(scene, junction, options)
         return
     end
 
+    if outroState then
+        local progress = clamp(outroState.progress or 0, 0, 1)
+        local iconDurationRatio = 0.64
+
+        if progress < iconDurationRatio then
+            local reverseIconProgress = 1 - (progress / iconDurationRatio)
+            renderer.drawControlOverlay(scene, junction, {
+                iconScaleMultiplier = 0.18 + 0.82 * easeOutBack(reverseIconProgress),
+            })
+            return
+        end
+
+        drawPresentationJunctionRing(graphics, scene, junction, {
+            ringProgress = 1 - ((progress - iconDurationRatio) / (1 - iconDurationRatio)),
+            entryAngle = outroState.entryAngle or (-math.pi * 0.5),
+        })
+        return
+    end
+
     graphics.setColor(0.05, 0.06, 0.08, 1)
     graphics.circle("fill", x, y, junction.crossingRadius)
 
@@ -1041,17 +1085,19 @@ function renderer.drawCrossing(scene, junction, options)
     renderer.drawControlOverlay(scene, junction)
 end
 
-function renderer.drawOutputSelector(scene, junction)
+function renderer.drawOutputSelector(scene, junction, options)
     local graphics = love.graphics
+    local resolvedOptions = options or {}
     local activeOutputColor = scene:getOutputDisplayColor(junction, junction.activeOutputIndex, true)
     local selectorX, selectorY, selectorRadius = renderer.getOutputSelectorLayout(junction)
     if selectorX then
-        local selectorScale = getSelectorIconScale(junction)
+        local selectorScale = getSelectorIconScale(junction) * (resolvedOptions.scaleMultiplier or 1)
+        local alphaMultiplier = resolvedOptions.alphaMultiplier or 1
         withIconScale(graphics, selectorX, selectorY, selectorScale, function()
-            graphics.setColor(activeOutputColor[1], activeOutputColor[2], activeOutputColor[3], 1)
+            graphics.setColor(activeOutputColor[1], activeOutputColor[2], activeOutputColor[3], alphaMultiplier)
             graphics.circle("fill", selectorX, selectorY, selectorRadius)
             graphics.setLineWidth(3)
-            graphics.setColor(0.05, 0.06, 0.08, 1)
+            graphics.setColor(0.05, 0.06, 0.08, alphaMultiplier)
             graphics.circle("line", selectorX, selectorY, selectorRadius)
         end)
     end
@@ -1128,6 +1174,7 @@ function renderer.drawScene(scene, options)
     local graphics = love.graphics
     local drawOptions = options or {}
     local presentation = drawOptions.presentation
+    local outro = drawOptions.outro
     local highlightedEdgeIds = drawOptions.highlightedEdgeIds or scene:getHighlightedEdgeIds()
     local drawnEdgeIds = {}
 
@@ -1142,11 +1189,19 @@ function renderer.drawScene(scene, options)
             local outputTrack = junction.outputs[outputIndex]
             if outputTrack and not drawnEdgeIds[outputTrack.id] then
                 local actualActive = highlightedEdgeIds[outputTrack.id] == true
-                local drawState = presentation and {
-                    revealProgress = getPresentationTrackRevealProgress(presentation, outputTrack.id),
-                    showMarkers = false,
-                    activityMix = getPresentationTrackActivityMix(presentation, actualActive),
-                } or nil
+                local drawState = nil
+                if presentation then
+                    drawState = {
+                        revealProgress = getPresentationTrackRevealProgress(presentation, outputTrack.id),
+                        showMarkers = false,
+                        activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                    }
+                elseif outro then
+                    drawState = {
+                        outroProgress = clamp(outro.progress or 0, 0, 1),
+                        showMarkers = false,
+                    }
+                end
                 renderer.drawOutputTrack(
                     scene,
                     junction,
@@ -1164,11 +1219,19 @@ function renderer.drawScene(scene, options)
             local inputTrack = junction.inputs[inputIndex]
             if inputTrack and not drawnEdgeIds[inputTrack.id] then
                 local actualActive = highlightedEdgeIds[inputTrack.id] == true
-                local drawState = presentation and {
-                    revealProgress = getPresentationTrackRevealProgress(presentation, inputTrack.id),
-                    showMarkers = false,
-                    activityMix = getPresentationTrackActivityMix(presentation, actualActive),
-                } or nil
+                local drawState = nil
+                if presentation then
+                    drawState = {
+                        revealProgress = getPresentationTrackRevealProgress(presentation, inputTrack.id),
+                        showMarkers = false,
+                        activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                    }
+                elseif outro then
+                    drawState = {
+                        outroProgress = clamp(outro.progress or 0, 0, 1),
+                        showMarkers = false,
+                    }
+                end
                 renderer.drawInputTrack(
                     scene,
                     inputTrack,
@@ -1183,11 +1246,19 @@ function renderer.drawScene(scene, options)
     for _, track in pairs(scene.edges or {}) do
         if track and not drawnEdgeIds[track.id] then
             local actualActive = highlightedEdgeIds[track.id] == true
-            local drawState = presentation and {
-                revealProgress = getPresentationTrackRevealProgress(presentation, track.id),
-                showMarkers = false,
-                activityMix = getPresentationTrackActivityMix(presentation, actualActive),
-            } or nil
+            local drawState = nil
+            if presentation then
+                drawState = {
+                    revealProgress = getPresentationTrackRevealProgress(presentation, track.id),
+                    showMarkers = false,
+                    activityMix = getPresentationTrackActivityMix(presentation, actualActive),
+                }
+            elseif outro then
+                drawState = {
+                    outroProgress = clamp(outro.progress or 0, 0, 1),
+                    showMarkers = false,
+                }
+            end
             renderer.drawStandaloneTrack(
                 scene,
                 track,
@@ -1200,8 +1271,24 @@ function renderer.drawScene(scene, options)
 
     for _, junction in ipairs(scene.junctionOrder or {}) do
         local presentationState = presentation and getPresentationJunctionState(presentation, junction.id) or nil
-        if not presentation or presentationState then
-            renderer.drawCrossing(scene, junction, presentationState and { presentation = presentationState } or nil)
+        if presentation then
+            if presentationState then
+                renderer.drawCrossing(scene, junction, { presentation = presentationState })
+            end
+        elseif outro then
+            local entryAngle = outro.presentation
+                and outro.presentation.junctionScheduleById
+                and outro.presentation.junctionScheduleById[junction.id]
+                and outro.presentation.junctionScheduleById[junction.id].entryAngle
+                or (-math.pi * 0.5)
+            renderer.drawCrossing(scene, junction, {
+                outro = {
+                    progress = clamp(outro.progress or 0, 0, 1),
+                    entryAngle = entryAngle,
+                },
+            })
+        else
+            renderer.drawCrossing(scene, junction)
         end
     end
 
@@ -1210,8 +1297,22 @@ function renderer.drawScene(scene, options)
         if signalState then
             for _, junction in ipairs(scene.junctionOrder or {}) do
                 for inputIndex = 1, #junction.inputs do
-                    renderer.drawTrackSignal(scene, junction, inputIndex, signalState)
+                    renderer.drawTrackSignal(scene, junction, inputIndex, {
+                        scaleMultiplier = signalState.scaleMultiplier,
+                        alphaMultiplier = signalState.alpha,
+                    })
                 end
+            end
+        end
+    elseif outro then
+        local reverseProgress = 1 - clamp(outro.progress or 0, 0, 1)
+        local signalScaleMultiplier = 0.18 + 0.82 * easeOutBack(reverseProgress)
+        for _, junction in ipairs(scene.junctionOrder or {}) do
+            for inputIndex = 1, #junction.inputs do
+                renderer.drawTrackSignal(scene, junction, inputIndex, {
+                    scaleMultiplier = signalScaleMultiplier,
+                    alphaMultiplier = reverseProgress,
+                })
             end
         end
     else
@@ -1228,9 +1329,18 @@ function renderer.drawScene(scene, options)
         end
     end
 
-    if not presentation then
+    if not presentation and not outro then
         for _, junction in ipairs(scene.junctionOrder or {}) do
             renderer.drawOutputSelector(scene, junction)
+        end
+    elseif outro then
+        local reverseProgress = 1 - clamp(outro.progress or 0, 0, 1)
+        local selectorScaleMultiplier = 0.18 + 0.82 * easeOutBack(reverseProgress)
+        for _, junction in ipairs(scene.junctionOrder or {}) do
+            renderer.drawOutputSelector(scene, junction, {
+                scaleMultiplier = selectorScaleMultiplier,
+                alphaMultiplier = reverseProgress,
+            })
         end
     end
 

--- a/src/game/rendering/track_scene_renderer.lua
+++ b/src/game/rendering/track_scene_renderer.lua
@@ -32,6 +32,18 @@ local function clamp(value, minValue, maxValue)
     return value
 end
 
+local function lerp(a, b, t)
+    return a + (b - a) * clamp(t or 0, 0, 1)
+end
+
+local function mixColor(fromColor, toColor, t)
+    return {
+        lerp((fromColor and fromColor[1]) or 0, (toColor and toColor[1]) or 0, t),
+        lerp((fromColor and fromColor[2]) or 0, (toColor and toColor[2]) or 0, t),
+        lerp((fromColor and fromColor[3]) or 0, (toColor and toColor[3]) or 0, t),
+    }
+end
+
 local function copyColor(color)
     if not color then
         return { 0.8, 0.8, 0.8 }
@@ -69,7 +81,9 @@ local function buildTrackStripeColors(colorIds, isActive)
         return nil
     end
 
-    local brightness = isActive and 1 or 0.58
+    local brightness = type(isActive) == "number"
+        and lerp(0.58, 1, isActive)
+        or (isActive and 1 or 0.58)
     local colors = {}
     for _, colorId in ipairs(colorIds or {}) do
         local color = getColorById(colorId)
@@ -176,6 +190,46 @@ local function easeOutBack(t)
     local s = 1.70158
     local value = t - 1
     return 1 + value * value * ((s + 1) * value + s)
+end
+
+local function getPresentationTimedProgress(presentation, transition)
+    local schedule = presentation and presentation[transition] or nil
+    if not schedule then
+        return nil
+    end
+
+    local duration = math.max(0.0001, tonumber(schedule.duration or ((schedule.endTime or 0) - (schedule.startTime or 0))) or 0.0001)
+    return clamp(((presentation.elapsed or 0) - (schedule.startTime or 0)) / duration, 0, 1)
+end
+
+local function getPresentationTrackActivityMix(presentation, finalIsActive)
+    if not presentation then
+        return finalIsActive and 1 or 0
+    end
+
+    if finalIsActive then
+        return 1
+    end
+
+    local transitionProgress = getPresentationTimedProgress(presentation, "trackStateBlend") or 0
+    return 1 - transitionProgress
+end
+
+local function getPresentationSignalState(presentation)
+    if not presentation then
+        return nil
+    end
+
+    local progress = getPresentationTimedProgress(presentation, "signalPop")
+    if not progress or progress <= 0.001 then
+        return nil
+    end
+
+    return {
+        progress = progress,
+        alpha = progress,
+        scaleMultiplier = 0.18 + 0.82 * easeOutBack(progress),
+    }
 end
 
 local function getPresentationTrackRevealProgress(presentation, edgeId)
@@ -575,7 +629,8 @@ end
 
 function renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
     local startDistance, endDistance = scene:getRenderedTrackWindow(track)
-    local alpha = isActive and 0.95 or 0.78
+    local activityMix = type(isActive) == "number" and clamp(isActive, 0, 1) or (isActive and 1 or 0)
+    local alpha = lerp(0.78, 0.95, activityMix)
 
     for _, section in ipairs(track.styleSections or {}) do
         local roadTypeConfig = roadTypes.getConfig(section.roadType)
@@ -665,9 +720,13 @@ end
 
 function renderer.drawInputTrack(scene, track, isActive, drawState)
     local graphics = love.graphics
-    local trackColor = isActive and track.color or track.darkColor
-    local trackAlpha = isActive and 0.96 or 0.72
-    local stripeColors = buildTrackStripeColors(track.colors, isActive)
+    local activityMix = drawState and drawState.activityMix
+    if activityMix == nil then
+        activityMix = isActive and 1 or 0
+    end
+    local trackColor = mixColor(track.darkColor, track.color, activityMix)
+    local trackAlpha = lerp(0.72, 0.96, activityMix)
+    local stripeColors = buildTrackStripeColors(track.colors, activityMix)
     local revealProgress = drawState and drawState.revealProgress or nil
     local renderedPoints = getRenderedTrackPoints(scene, track, revealProgress)
     if #renderedPoints < 2 then
@@ -689,18 +748,22 @@ function renderer.drawInputTrack(scene, track, isActive, drawState)
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix)
     end
 end
 
 function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
     local graphics = love.graphics
-    local trackColor = isActive and track.color or track.darkColor
-    local trackAlpha = isActive and 0.96 or 0.72
+    local activityMix = drawState and drawState.activityMix
+    if activityMix == nil then
+        activityMix = isActive and 1 or 0
+    end
+    local trackColor = mixColor(track.darkColor, track.color, activityMix)
+    local trackAlpha = lerp(0.72, 0.96, activityMix)
     local stripeColors = nil
 
     if not track.adoptInputColor then
-        stripeColors = buildTrackStripeColors(track.colors, isActive)
+        stripeColors = buildTrackStripeColors(track.colors, activityMix)
     end
 
     local revealProgress = drawState and drawState.revealProgress or nil
@@ -724,15 +787,21 @@ function renderer.drawStandaloneTrack(scene, track, isActive, drawState)
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, track, isActive)
+        renderer.drawTrackRoadTypeMarkers(scene, track, activityMix)
     end
 end
 
 function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawState)
     local graphics = love.graphics
     local outputTrack = junction.outputs[outputIndex]
-    local color = scene:getOutputDisplayColor(junction, outputIndex, isActive)
-    local stripeColors = outputTrack and not outputTrack.adoptInputColor and buildTrackStripeColors(outputTrack.colors, isActive) or nil
+    local activityMix = drawState and drawState.activityMix
+    if activityMix == nil then
+        activityMix = isActive and 1 or 0
+    end
+    local activeColor = scene:getOutputDisplayColor(junction, outputIndex, true)
+    local inactiveColor = scene:getOutputDisplayColor(junction, outputIndex, false)
+    local color = mixColor(inactiveColor, activeColor, activityMix)
+    local stripeColors = outputTrack and not outputTrack.adoptInputColor and buildTrackStripeColors(outputTrack.colors, activityMix) or nil
     local revealProgress = drawState and drawState.revealProgress or nil
     local renderedPoints = getRenderedTrackPoints(scene, outputTrack, revealProgress)
     if #renderedPoints < 2 then
@@ -748,13 +817,13 @@ function renderer.drawOutputTrack(scene, junction, outputIndex, isActive, drawSt
     graphics.line(points)
 
     if stripeColors then
-        renderer.drawStripedTrack(scene, points, scene.sharedWidth, stripeColors, isActive and 0.98 or 0.7)
+        renderer.drawStripedTrack(scene, points, scene.sharedWidth, stripeColors, lerp(0.7, 0.98, activityMix))
     else
-        renderer.drawTrackLine(scene, points, scene.sharedWidth, color, isActive and 0.98 or 0.7)
+        renderer.drawTrackLine(scene, points, scene.sharedWidth, color, lerp(0.7, 0.98, activityMix))
     end
 
     if not drawState or drawState.showMarkers ~= false then
-        renderer.drawTrackRoadTypeMarkers(scene, outputTrack, isActive)
+        renderer.drawTrackRoadTypeMarkers(scene, outputTrack, activityMix)
     end
 end
 
@@ -988,18 +1057,24 @@ function renderer.drawOutputSelector(scene, junction)
     end
 end
 
-function renderer.drawTrackSignal(_, junction, inputIndex)
+function renderer.drawTrackSignal(_, junction, inputIndex, options)
     local graphics = love.graphics
+    local resolvedOptions = options or {}
     local track = junction.inputs[inputIndex]
     local signalPoint = track.signalPoint
+    if not signalPoint then
+        return
+    end
     local pulse = 0.5 + 0.5 * math.sin(love.timer.getTime() * 6 + inputIndex)
-    local signalRadius = 12 + pulse * 3
+    local scaleMultiplier = resolvedOptions.scaleMultiplier or 1
+    local alphaMultiplier = resolvedOptions.alphaMultiplier or 1
+    local signalRadius = (12 + pulse * 3) * scaleMultiplier
 
     graphics.setLineWidth(6)
     if inputIndex == junction.activeInputIndex then
-        graphics.setColor(0.42, 0.92, 0.54, 1)
+        graphics.setColor(0.42, 0.92, 0.54, alphaMultiplier)
     else
-        graphics.setColor(0.92, 0.26, 0.2, 1)
+        graphics.setColor(0.92, 0.26, 0.2, alphaMultiplier)
     end
     graphics.circle("fill", signalPoint.x, signalPoint.y, signalRadius)
 end
@@ -1066,15 +1141,17 @@ function renderer.drawScene(scene, options)
         for outputIndex = 1, #junction.outputs do
             local outputTrack = junction.outputs[outputIndex]
             if outputTrack and not drawnEdgeIds[outputTrack.id] then
+                local actualActive = highlightedEdgeIds[outputTrack.id] == true
                 local drawState = presentation and {
                     revealProgress = getPresentationTrackRevealProgress(presentation, outputTrack.id),
                     showMarkers = false,
+                    activityMix = getPresentationTrackActivityMix(presentation, actualActive),
                 } or nil
                 renderer.drawOutputTrack(
                     scene,
                     junction,
                     outputIndex,
-                    presentation and true or highlightedEdgeIds[outputTrack.id] == true,
+                    actualActive,
                     drawState
                 )
                 drawnEdgeIds[outputTrack.id] = true
@@ -1086,14 +1163,16 @@ function renderer.drawScene(scene, options)
         for inputIndex = 1, #junction.inputs do
             local inputTrack = junction.inputs[inputIndex]
             if inputTrack and not drawnEdgeIds[inputTrack.id] then
+                local actualActive = highlightedEdgeIds[inputTrack.id] == true
                 local drawState = presentation and {
                     revealProgress = getPresentationTrackRevealProgress(presentation, inputTrack.id),
                     showMarkers = false,
+                    activityMix = getPresentationTrackActivityMix(presentation, actualActive),
                 } or nil
                 renderer.drawInputTrack(
                     scene,
                     inputTrack,
-                    presentation and true or highlightedEdgeIds[inputTrack.id] == true,
+                    actualActive,
                     drawState
                 )
                 drawnEdgeIds[inputTrack.id] = true
@@ -1103,14 +1182,16 @@ function renderer.drawScene(scene, options)
 
     for _, track in pairs(scene.edges or {}) do
         if track and not drawnEdgeIds[track.id] then
+            local actualActive = highlightedEdgeIds[track.id] == true
             local drawState = presentation and {
                 revealProgress = getPresentationTrackRevealProgress(presentation, track.id),
                 showMarkers = false,
+                activityMix = getPresentationTrackActivityMix(presentation, actualActive),
             } or nil
             renderer.drawStandaloneTrack(
                 scene,
                 track,
-                presentation and true or highlightedEdgeIds[track.id] == true,
+                actualActive,
                 drawState
             )
             drawnEdgeIds[track.id] = true
@@ -1124,7 +1205,16 @@ function renderer.drawScene(scene, options)
         end
     end
 
-    if not presentation then
+    if presentation then
+        local signalState = getPresentationSignalState(presentation)
+        if signalState then
+            for _, junction in ipairs(scene.junctionOrder or {}) do
+                for inputIndex = 1, #junction.inputs do
+                    renderer.drawTrackSignal(scene, junction, inputIndex, signalState)
+                end
+            end
+        end
+    else
         for _, junction in ipairs(scene.junctionOrder or {}) do
             for inputIndex = 1, #junction.inputs do
                 renderer.drawTrackSignal(scene, junction, inputIndex)

--- a/src/game/ui/game_screens.lua
+++ b/src/game/ui/game_screens.lua
@@ -268,10 +268,15 @@ local NETWORK_REQUEST_OVERLAY = {
 }
 
 local MENU_LAYOUT = {
-    buttonWidth = 320,
-    buttonHeight = 56,
-    buttonGap = 16,
-    firstButtonY = 248,
+    cornerInset = 24,
+    verticalGap = 14,
+    leaderboardW = 170,
+    leaderboardH = 42,
+    editorW = 148,
+    editorH = 42,
+    playModeW = 132,
+    playModeH = 38,
+    quitSize = 38,
 }
 
 local PROFILE_MODE_SETUP_LAYOUT = {

--- a/src/game/ui/screen_drawers.lua
+++ b/src/game/ui/screen_drawers.lua
@@ -20,6 +20,7 @@ function ui.drawMenu(game)
     local modeToggleProgress = 0
     local menuTitle = "Out of Signal"
     local menuElapsed = game.getMenuIntroElapsed and game:getMenuIntroElapsed() or 0
+    local backgroundTitleState = game.getMenuBackgroundReplayTitleState and game:getMenuBackgroundReplayTitleState() or nil
     local titleEnterDuration = 0.55
     local buttonRevealDuration = 0.52
     local buttonStagger = 0.07
@@ -39,6 +40,11 @@ function ui.drawMenu(game)
         local s = 1.70158
         local value = clamped - 1
         return 1 + value * value * ((s + 1) * value + s)
+    end
+
+    local function easeInCubic(t)
+        local clamped = clamp01(t)
+        return clamped * clamped * clamped
     end
 
     local function withTranslatedDraw(offsetX, offsetY, drawFn)
@@ -90,12 +96,76 @@ function ui.drawMenu(game)
         return clamp01((menuElapsed - revealStart) / buttonRevealDuration)
     end
 
-    graphics.setColor(0.05, 0.07, 0.1, 1)
-    graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    if not (game.hasMenuBackgroundReplay and game:hasMenuBackgroundReplay()) then
+        graphics.setColor(0.05, 0.07, 0.1, 1)
+        graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
 
-    graphics.setColor(0, 0, 0, 0.22)
-    graphics.circle("fill", 200, 140, 180)
-    graphics.circle("fill", 1080, 560, 220)
+        graphics.setColor(0, 0, 0, 0.22)
+        graphics.circle("fill", 200, 140, 180)
+        graphics.circle("fill", 1080, 560, 220)
+    else
+        graphics.setColor(0.02, 0.03, 0.04, 0.42)
+        graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
+    end
+
+    if backgroundTitleState then
+        local sequence = backgroundTitleState.titleSequence or {}
+        local centerX = (game.viewport and game.viewport.w or 1280) * 0.5
+        local centerY = (game.viewport and game.viewport.h or 720) / 6
+        local titleFont = game.fonts.title
+        local subtitleFont = game.fonts.body
+        local subtitleGap = 8
+        local titleHeight = titleFont:getHeight()
+        local hasSubtitle = backgroundTitleState.subtitle ~= nil and backgroundTitleState.subtitle ~= ""
+        local subtitleHeight = hasSubtitle and subtitleFont:getHeight() or 0
+        local totalHeight = titleHeight + (hasSubtitle and (subtitleGap + subtitleHeight) or 0)
+        local titleCenterY = centerY - totalHeight * 0.5 + titleHeight * 0.5
+        local subtitleCenterY = titleCenterY + titleHeight * 0.5 + subtitleGap + subtitleHeight * 0.5
+
+        local function drawMovingLine(text, font, lineCenterY, delay, alphaScale)
+            if not text or text == "" then
+                return
+            end
+
+            local localElapsed = (backgroundTitleState.elapsed or 0) - (delay or 0)
+            if localElapsed <= 0 then
+                return
+            end
+
+            local enterDuration = sequence.enterDuration or 0.55
+            local holdDuration = sequence.holdDuration or 2.0
+            local exitDuration = sequence.exitDuration or 0.55
+            local travelDistance = sequence.travelDistance or 420
+            local alpha = 0
+            local centerOffsetX = 0
+
+            if localElapsed < enterDuration then
+                local progress = easeOutCubic(localElapsed / enterDuration)
+                centerOffsetX = (1 - progress) * travelDistance
+                alpha = progress
+            elseif localElapsed < enterDuration + holdDuration then
+                alpha = 1
+            elseif localElapsed < enterDuration + holdDuration + exitDuration then
+                local progress = easeInCubic((localElapsed - enterDuration - holdDuration) / exitDuration)
+                centerOffsetX = -travelDistance * progress
+                alpha = 1 - progress
+            else
+                return
+            end
+
+            alpha = alpha * (alphaScale or 1)
+            love.graphics.setFont(font)
+            local drawX = math.floor(centerX - font:getWidth(text) * 0.5 + centerOffsetX + 0.5)
+            local drawY = math.floor(lineCenterY - font:getHeight() * 0.5 + 0.5)
+            graphics.setColor(0.02, 0.03, 0.05, alpha * 0.55)
+            graphics.print(text, drawX + 4, drawY + 4)
+            graphics.setColor(0.97, 0.98, 1, alpha)
+            graphics.print(text, drawX, drawY)
+        end
+
+        drawMovingLine(backgroundTitleState.title or "Untitled Map", titleFont, titleCenterY, 0, 1)
+        drawMovingLine(backgroundTitleState.subtitle or "", subtitleFont, subtitleCenterY, sequence.lineDelay or 0.18, 0.94)
+    end
 
     do
         local enterDuration = 0.55

--- a/src/game/ui/screen_drawers.lua
+++ b/src/game/ui/screen_drawers.lua
@@ -672,6 +672,244 @@ function ui.drawPlay(game)
     local allowHoverTooltip = (not game.playGuideTransition) and (not activeGuideStep or activeGuideStep.allowHoverTooltip == true)
     local headerHintLines = ui.getPlayHeaderHintLines(game)
     local headerHintX = 24
+    local presentationState = game.mapPresentation
+    local introState = game.playPhase == "prepare" and presentationState and presentationState.titleOnly ~= true and presentationState or nil
+    local titleOverlayState = presentationState
+        and (presentationState.elapsed or 0) < (((presentationState.titleSequence or {}).endTime) or 0)
+        and presentationState
+        or nil
+
+    local function clamp01(value)
+        return clamp(value or 0, 0, 1)
+    end
+
+    local function easeInCubic(t)
+        local clamped = clamp01(t)
+        return clamped * clamped * clamped
+    end
+
+    local function easeOutCubic(t)
+        local clamped = clamp01(t)
+        local inverse = 1 - clamped
+        return 1 - inverse * inverse * inverse
+    end
+
+    local function easeOutBack(t)
+        local clamped = clamp01(t)
+        local s = 1.70158
+        local value = clamped - 1
+        return 1 + value * value * ((s + 1) * value + s)
+    end
+
+    local function getTimedProgress(startTime, duration)
+        return clamp01(((introState and introState.elapsed or 0) - (startTime or 0)) / math.max(0.0001, duration or 0))
+    end
+
+    local function withTranslatedDraw(offsetX, offsetY, drawFn)
+        graphics.push()
+        graphics.translate(offsetX or 0, offsetY or 0)
+        drawFn()
+        graphics.pop()
+    end
+
+    local function getBorderSlideOffset(rect, progress)
+        local eased = easeOutBack(progress)
+        local viewport = game.viewport or { w = 1280, h = 720 }
+        local leftDistance = rect.x
+        local rightDistance = viewport.w - (rect.x + rect.w)
+        local topDistance = rect.y
+        local bottomDistance = viewport.h - (rect.y + rect.h)
+        local bestDistance = leftDistance
+        local border = "left"
+
+        if rightDistance < bestDistance then
+            bestDistance = rightDistance
+            border = "right"
+        end
+        if topDistance < bestDistance then
+            bestDistance = topDistance
+            border = "top"
+        end
+        if bottomDistance < bestDistance then
+            border = "bottom"
+        end
+
+        local startOffsetX = 0
+        local startOffsetY = 0
+        if border == "left" then
+            startOffsetX = -rect.x - rect.w - 28
+        elseif border == "right" then
+            startOffsetX = viewport.w - rect.x + 28
+        elseif border == "top" then
+            startOffsetY = -rect.y - rect.h - 28
+        else
+            startOffsetY = viewport.h - rect.y + 28
+        end
+
+        return startOffsetX * (1 - eased), startOffsetY * (1 - eased)
+    end
+
+    local function drawIntroTitle()
+        if not titleOverlayState then
+            return
+        end
+
+        local sequence = titleOverlayState.titleSequence or {}
+        local centerX = (game.viewport and game.viewport.w or 1280) * 0.5
+        local centerY = (game.viewport and game.viewport.h or 720) / 6
+        local titleFont = game.fonts.title
+        local subtitleFont = game.fonts.body
+        local subtitleGap = 8
+        local titleHeight = titleFont:getHeight()
+        local subtitleHeight = titleOverlayState.subtitle ~= "" and subtitleFont:getHeight() or 0
+        local totalHeight = titleHeight + (titleOverlayState.subtitle ~= "" and (subtitleGap + subtitleHeight) or 0)
+        local titleCenterY = centerY - totalHeight * 0.5 + titleHeight * 0.5
+        local subtitleCenterY = titleCenterY + titleHeight * 0.5 + subtitleGap + subtitleHeight * 0.5
+
+        local function drawMovingLine(text, font, lineCenterY, delay, alphaScale)
+            if not text or text == "" then
+                return
+            end
+
+            local localElapsed = (titleOverlayState.elapsed or 0) - (delay or 0)
+            if localElapsed <= 0 then
+                return
+            end
+
+            local enterDuration = sequence.enterDuration or 0.55
+            local holdDuration = sequence.holdDuration or 2.0
+            local exitDuration = sequence.exitDuration or 0.55
+            local travelDistance = sequence.travelDistance or 420
+            local alpha = 0
+            local centerOffsetX = 0
+
+            if localElapsed < enterDuration then
+                local progress = easeOutCubic(localElapsed / enterDuration)
+                centerOffsetX = (1 - progress) * travelDistance
+                alpha = progress
+            elseif localElapsed < enterDuration + holdDuration then
+                centerOffsetX = 0
+                alpha = 1
+            elseif localElapsed < enterDuration + holdDuration + exitDuration then
+                local progress = easeInCubic((localElapsed - enterDuration - holdDuration) / exitDuration)
+                centerOffsetX = -travelDistance * progress
+                alpha = 1 - progress
+            else
+                return
+            end
+
+            alpha = alpha * (alphaScale or 1)
+            love.graphics.setFont(font)
+            local drawX = math.floor(centerX - font:getWidth(text) * 0.5 + centerOffsetX + 0.5)
+            local drawY = math.floor(lineCenterY - font:getHeight() * 0.5 + 0.5)
+            graphics.setColor(0.02, 0.03, 0.05, alpha * 0.55)
+            graphics.print(text, drawX + 4, drawY + 4)
+            graphics.setColor(0.97, 0.98, 1, alpha)
+            graphics.print(text, drawX, drawY)
+        end
+
+        drawMovingLine(titleOverlayState.title or "Untitled Map", titleFont, titleCenterY, 0, 1)
+        drawMovingLine(titleOverlayState.subtitle or "", subtitleFont, subtitleCenterY, sequence.lineDelay or 0.18, 0.94)
+    end
+
+    if introState then
+        local uiReveal = introState.uiReveal or {}
+        local topProgress = getTimedProgress(uiReveal.startTime or 0, uiReveal.duration or 0.52)
+        if topProgress > 0 then
+            local topOffsetY = -140 * (1 - easeOutBack(topProgress))
+            local backRect = getPlayBackRect(game)
+            local startRect = getPlayStartRect()
+            drawButton(
+                {
+                    x = backRect.x,
+                    y = backRect.y + topOffsetY,
+                    w = backRect.w,
+                    h = backRect.h,
+                },
+                getRunBackLabel(game),
+                { 0.09, 0.11, 0.15, 0.98 },
+                { 0.3, 0.36, 0.42, 1 },
+                game.fonts.small
+            )
+            drawButton(
+                {
+                    x = startRect.x,
+                    y = startRect.y + topOffsetY,
+                    w = startRect.w,
+                    h = startRect.h,
+                },
+                "Start Run",
+                { 0.12, 0.17, 0.2, 0.98 },
+                { 0.48, 0.92, 0.62, 1 },
+                game.fonts.body
+            )
+            love.graphics.setFont(game.fonts.small)
+            graphics.setColor(0.84, 0.88, 0.92, 1)
+            graphics.printf(
+                "Preparation Phase: set your routes, then start the clock.",
+                0,
+                34 + topOffsetY,
+                game.viewport.w,
+                "center"
+            )
+        end
+
+        for index, badge in ipairs(outputGroups) do
+            local progress = getTimedProgress(
+                (uiReveal.startTime or 0) + ((index - 1) * (uiReveal.cardStagger or 0)),
+                uiReveal.duration or 0.52
+            )
+            if progress > 0 then
+                local rect = getOutputBadgeRect(game, badge.edge, badge)
+                local offsetX, offsetY = getBorderSlideOffset(rect, progress)
+                withTranslatedDraw(offsetX, offsetY, function()
+                    drawOutputBadge(game, badge)
+                end)
+            end
+        end
+
+        for index, group in ipairs(inputGroups) do
+            local progress = getTimedProgress(
+                (uiReveal.startTime or 0) + ((index - 1) * (uiReveal.cardStagger or 0)),
+                uiReveal.duration or 0.52
+            )
+            if progress > 0 then
+                local rect = getInputPrepCardRect(game, group.edge, #(group.trains or {}), inputGroups)
+                local offsetX, offsetY = getBorderSlideOffset(rect, progress)
+                withTranslatedDraw(offsetX, offsetY, function()
+                    drawInputPrepCard(game, group)
+                end)
+            end
+        end
+
+        local textAlpha = getTimedProgress(
+            (uiReveal.startTime or 0) + (uiReveal.textFadeDelay or 0.1),
+            uiReveal.textFadeDuration or 0.32
+        )
+        if textAlpha > 0 then
+            love.graphics.setFont(game.fonts.small)
+            local lineHeight = game.fonts.small:getHeight() + 6
+            local hintBlockHeight = #headerHintLines * lineHeight
+            local headerHintY = math.floor((game.viewport.h - hintBlockHeight) * 0.5 + 0.5)
+            graphics.setColor(0.72, 0.78, 0.84, 0.96 * textAlpha)
+            for index, hintLine in ipairs(headerHintLines) do
+                graphics.print(hintLine, headerHintX, headerHintY + ((index - 1) * lineHeight))
+            end
+
+            if not activeGuideStep then
+                local blinkAlpha = 0.3
+                if love and love.timer and love.timer.getTime then
+                    blinkAlpha = (math.sin(love.timer.getTime() * 4.8) > 0) and 1 or 0.3
+                end
+                graphics.setColor(1, 1, 1, blinkAlpha * textAlpha)
+                graphics.printf("Press Spacebar to Start", 0, game.viewport.h - 86, game.viewport.w, "center")
+            end
+        end
+
+        drawIntroTitle()
+
+        return
+    end
 
     for _, badge in ipairs(outputGroups) do
         drawOutputBadge(game, badge)
@@ -724,6 +962,7 @@ function ui.drawPlay(game)
     if game.playPhase == "prepare" and not game.playOverlayMode and game.playHoverInfo and allowHoverTooltip then
         drawPlayTooltip(game, game.playHoverInfo)
     end
+    drawIntroTitle()
 end
 
 function ui.drawResults(game)

--- a/src/game/ui/screen_drawers.lua
+++ b/src/game/ui/screen_drawers.lua
@@ -16,6 +16,79 @@ return function(ui, shared)
 function ui.drawMenu(game)
     local graphics = love.graphics
     local buttons = getMenuButtons(game)
+    local modeToggleRect = nil
+    local modeToggleProgress = 0
+    local menuTitle = "Out of Signal"
+    local menuElapsed = game.getMenuIntroElapsed and game:getMenuIntroElapsed() or 0
+    local titleEnterDuration = 0.55
+    local buttonRevealDuration = 0.52
+    local buttonStagger = 0.07
+
+    local function clamp01(value)
+        return clamp(value or 0, 0, 1)
+    end
+
+    local function easeOutCubic(t)
+        local clamped = clamp01(t)
+        local inverse = 1 - clamped
+        return 1 - inverse * inverse * inverse
+    end
+
+    local function easeOutBack(t)
+        local clamped = clamp01(t)
+        local s = 1.70158
+        local value = clamped - 1
+        return 1 + value * value * ((s + 1) * value + s)
+    end
+
+    local function withTranslatedDraw(offsetX, offsetY, drawFn)
+        graphics.push()
+        graphics.translate(offsetX or 0, offsetY or 0)
+        drawFn()
+        graphics.pop()
+    end
+
+    local function getBorderSlideOffset(rect, progress)
+        local eased = easeOutBack(progress)
+        local viewport = game.viewport or { w = 1280, h = 720 }
+        local leftDistance = rect.x
+        local rightDistance = viewport.w - (rect.x + rect.w)
+        local topDistance = rect.y
+        local bottomDistance = viewport.h - (rect.y + rect.h)
+        local bestDistance = leftDistance
+        local border = "left"
+
+        if rightDistance < bestDistance then
+            bestDistance = rightDistance
+            border = "right"
+        end
+        if topDistance < bestDistance then
+            bestDistance = topDistance
+            border = "top"
+        end
+        if bottomDistance < bestDistance then
+            border = "bottom"
+        end
+
+        local startOffsetX = 0
+        local startOffsetY = 0
+        if border == "left" then
+            startOffsetX = -rect.x - rect.w - 28
+        elseif border == "right" then
+            startOffsetX = viewport.w - rect.x + 28
+        elseif border == "top" then
+            startOffsetY = -rect.y - rect.h - 28
+        else
+            startOffsetY = viewport.h - rect.y + 28
+        end
+
+        return startOffsetX * (1 - eased), startOffsetY * (1 - eased)
+    end
+
+    local function getButtonProgress(index)
+        local revealStart = titleEnterDuration + ((index - 1) * buttonStagger)
+        return clamp01((menuElapsed - revealStart) / buttonRevealDuration)
+    end
 
     graphics.setColor(0.05, 0.07, 0.1, 1)
     graphics.rectangle("fill", 0, 0, game.viewport.w, game.viewport.h)
@@ -24,24 +97,129 @@ function ui.drawMenu(game)
     graphics.circle("fill", 200, 140, 180)
     graphics.circle("fill", 1080, 560, 220)
 
-    love.graphics.setFont(game.fonts.title)
-    graphics.setColor(0.97, 0.98, 1, 1)
-    graphics.printf("Out of Signal", 0, 128, game.viewport.w, "center")
+    do
+        local enterDuration = 0.55
+        local travelDistance = 420
+        local titleScale = 2
+        local progress = clamp01(menuElapsed / enterDuration)
+        local eased = easeOutCubic(progress)
+        local alpha = eased
+        local centerOffsetX = (1 - eased) * travelDistance
+        local centerX = (game.viewport and game.viewport.w or 1280) * 0.5
+        local centerY = (game.viewport and game.viewport.h or 720) * 0.5
+        local font = game.fonts.title
+        local scaledWidth = font:getWidth(menuTitle) * titleScale
+        local scaledHeight = font:getHeight() * titleScale
+        local drawX = math.floor(centerX - scaledWidth * 0.5 + centerOffsetX + 0.5)
+        local drawY = math.floor(centerY - scaledHeight * 0.5 + 0.5)
 
-    love.graphics.setFont(game.fonts.body)
-    graphics.setColor(0.84, 0.88, 0.92, 1)
-    graphics.printf(
-        game:isOfflineMode()
-            and "Route trains through lever-controlled merges and keep your personal scores on this device."
-            or "Route trains through lever-controlled merges, upload cleared scores, and compare runs online.",
-        game.viewport.w * 0.5 - 280,
-        188,
-        560,
-        "center"
-    )
+        love.graphics.setFont(font)
+        graphics.push()
+        graphics.translate(drawX, drawY)
+        graphics.scale(titleScale, titleScale)
+        graphics.setColor(0.02, 0.03, 0.05, alpha * 0.55)
+        graphics.print(menuTitle, 2, 2)
+        graphics.setColor(0.97, 0.98, 1, alpha)
+        graphics.print(menuTitle, 0, 0)
+        graphics.pop()
+    end
 
-    for _, rect in ipairs(buttons) do
-        drawButton(rect, rect.label, { 0.09, 0.11, 0.15, 0.98 }, { 0.48, 0.92, 0.62, 1 }, game.fonts.body)
+    for index, rect in ipairs(buttons) do
+        local progress = getButtonProgress(index)
+        if progress > 0 then
+            local offsetX, offsetY = getBorderSlideOffset(rect, progress)
+            withTranslatedDraw(offsetX, offsetY, function()
+                if rect.id == "toggle_play_mode" and rect.segments then
+                    modeToggleRect = rect
+                    modeToggleProgress = progress
+                    if not game.onlineConfig or not game.onlineConfig.isConfigured then
+                        local unavailableProgress = clamp01(
+                            (menuElapsed - (titleEnterDuration + ((index - 1) * buttonStagger) + buttonRevealDuration)) / 0.18
+                        )
+                        if unavailableProgress > 0 then
+                            local unavailableLabel = "Online unavailable"
+                            local easedUnavailable = easeOutCubic(unavailableProgress)
+                            love.graphics.setFont(game.fonts.small)
+                            local labelWidth = game.fonts.small:getWidth(unavailableLabel)
+                            local finalLabelX = rect.x + rect.w + 14
+                            local startLabelX = rect.x + rect.w - labelWidth - 18
+                            local labelX = startLabelX + ((finalLabelX - startLabelX) * easedUnavailable)
+                            local labelY = rect.y + math.floor((rect.h - game.fonts.small:getHeight()) * 0.5 + 0.5)
+                            graphics.setColor(0.7, 0.76, 0.82, 0.94 * easedUnavailable)
+                            graphics.print(unavailableLabel, labelX, labelY)
+                        end
+                    end
+
+                    uiControls.drawSegmentedToggle(
+                        rect,
+                        rect.segments,
+                        game:isOnlineMode() and "online" or "offline",
+                        nil,
+                        game.fonts.small,
+                        {
+                            cornerRadius = 14,
+                            backgroundColor = { 0.08, 0.1, 0.14, 0.98 },
+                            activeFillColor = { 0.78, 0.88, 0.98, 0.94 },
+                            hoverColor = { 0.3, 0.4, 0.5, 0.22 },
+                            outlineColor = { 0.26, 0.38, 0.5, 1 },
+                            innerOutlineColor = { 0.44, 0.62, 0.78, 0.34 },
+                            selectedTextColor = { 0.08, 0.11, 0.15, 1 },
+                            textColor = { 0.9, 0.93, 0.97, 1 },
+                        }
+                    )
+
+                    if not game.onlineConfig or not game.onlineConfig.isConfigured then
+                        local onlineSegment = uiControls.segmentRect(rect, 2, #rect.segments)
+                        graphics.setColor(0.08, 0.1, 0.14, 0.42 * progress)
+                        graphics.rectangle(
+                            "fill",
+                            onlineSegment.x + 2,
+                            onlineSegment.y + 2,
+                            onlineSegment.w - 4,
+                            onlineSegment.h - 4,
+                            12,
+                            12
+                        )
+                    end
+                elseif rect.id == "quit" then
+                    drawButton(
+                        rect,
+                        rect.label,
+                        { 0.2, 0.07, 0.08, 0.98 * progress },
+                        { 0.99, 0.4, 0.44, progress },
+                        game.fonts.small,
+                        nil,
+                        progress
+                    )
+                else
+                    local font = rect.h <= 42 and game.fonts.small or game.fonts.body
+                    local strokeColor = rect.id == "editor"
+                        and { 0.99, 0.78, 0.32, progress }
+                        or { 0.48, 0.92, 0.62, progress }
+                    drawButton(
+                        rect,
+                        rect.label,
+                        { 0.09, 0.11, 0.15, 0.98 * progress },
+                        strokeColor,
+                        font,
+                        nil,
+                        progress
+                    )
+                end
+            end)
+        end
+    end
+
+    if modeToggleRect and game.menuStatusMessage and game.menuStatusMessage ~= "" then
+        love.graphics.setFont(game.fonts.small)
+        graphics.setColor(0.99, 0.78, 0.32, modeToggleProgress)
+        graphics.printf(
+            game.menuStatusMessage,
+            modeToggleRect.x,
+            modeToggleRect.y - game.fonts.small:getHeight() - 28,
+            math.max(modeToggleRect.w, 220),
+            "left"
+        )
     end
 end
 

--- a/src/game/ui/screen_level_select_draw.lua
+++ b/src/game/ui/screen_level_select_draw.lua
@@ -855,9 +855,6 @@ function getMenuButtons(game)
 
     return {
         playButton,
-        leaderboardRect,
-        editorRect,
-        quitRect,
         {
             id = "toggle_play_mode",
             x = playModeRect.x,
@@ -870,6 +867,9 @@ function getMenuButtons(game)
                 { id = "online", label = "On" },
             },
         },
+        leaderboardRect,
+        editorRect,
+        quitRect,
     }
 end
 

--- a/src/game/ui/screen_level_select_draw.lua
+++ b/src/game/ui/screen_level_select_draw.lua
@@ -811,48 +811,64 @@ function drawMarketplaceSearchField(game)
 end
 
 function getMenuButtons(game)
-    local centerX = math.floor((game.viewport.w - MENU_LAYOUT.buttonWidth) * 0.5 + 0.5)
-    local buttonY = MENU_LAYOUT.firstButtonY
+    local bottomBarRect = getLevelSelectBottomBarRect(game)
+    local buttonY = bottomBarRect.y + math.floor((bottomBarRect.h - LEVEL_SELECT_ACTION_LAYOUT.buttonH) * 0.5 + 0.5)
+    local cornerInset = MENU_LAYOUT.cornerInset
+    local playButton = {
+        id = "play",
+        x = math.floor(game.viewport.w * 0.5 - LEVEL_SELECT_ACTION_LAYOUT.startW * 0.5 + 0.5),
+        y = buttonY,
+        w = LEVEL_SELECT_ACTION_LAYOUT.startW,
+        h = LEVEL_SELECT_ACTION_LAYOUT.buttonH,
+        label = "Level Select",
+    }
+    local playModeRect = {
+        x = cornerInset,
+        y = game.viewport.h - cornerInset - MENU_LAYOUT.playModeH,
+        w = MENU_LAYOUT.playModeW,
+        h = MENU_LAYOUT.playModeH,
+    }
+    local leaderboardRect = {
+        id = "leaderboard",
+        x = cornerInset,
+        y = playModeRect.y - MENU_LAYOUT.verticalGap - MENU_LAYOUT.leaderboardH,
+        w = MENU_LAYOUT.leaderboardW,
+        h = MENU_LAYOUT.leaderboardH,
+        label = "Leaderboard",
+    }
+    local editorRect = {
+        id = "editor",
+        x = game.viewport.w - cornerInset - MENU_LAYOUT.editorW,
+        y = buttonY,
+        w = MENU_LAYOUT.editorW,
+        h = MENU_LAYOUT.editorH,
+        label = "Editor",
+    }
+    local quitRect = {
+        id = "quit",
+        x = game.viewport.w - cornerInset - MENU_LAYOUT.quitSize,
+        y = cornerInset,
+        w = MENU_LAYOUT.quitSize,
+        h = MENU_LAYOUT.quitSize,
+        label = "X",
+    }
+
     return {
-        {
-            id = "play",
-            x = centerX,
-            y = buttonY,
-            w = MENU_LAYOUT.buttonWidth,
-            h = MENU_LAYOUT.buttonHeight,
-            label = "Level Select",
-        },
-        {
-            id = "leaderboard",
-            x = centerX,
-            y = buttonY + MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap,
-            w = MENU_LAYOUT.buttonWidth,
-            h = MENU_LAYOUT.buttonHeight,
-            label = game:getLeaderboardButtonLabel(),
-        },
-        {
-            id = "editor",
-            x = centerX,
-            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 2),
-            w = MENU_LAYOUT.buttonWidth,
-            h = MENU_LAYOUT.buttonHeight,
-            label = "Map Editor",
-        },
+        playButton,
+        leaderboardRect,
+        editorRect,
+        quitRect,
         {
             id = "toggle_play_mode",
-            x = centerX,
-            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 3),
-            w = MENU_LAYOUT.buttonWidth,
-            h = MENU_LAYOUT.buttonHeight,
+            x = playModeRect.x,
+            y = playModeRect.y,
+            w = playModeRect.w,
+            h = playModeRect.h,
             label = game:getPlayModeButtonLabel(),
-        },
-        {
-            id = "quit",
-            x = centerX,
-            y = buttonY + ((MENU_LAYOUT.buttonHeight + MENU_LAYOUT.buttonGap) * 4),
-            w = MENU_LAYOUT.buttonWidth,
-            h = MENU_LAYOUT.buttonHeight,
-            label = "Quit",
+            segments = {
+                { id = "offline", label = "Off" },
+                { id = "online", label = "On" },
+            },
         },
     }
 end
@@ -922,7 +938,13 @@ function ui.getMenuActionAt(game, x, y)
     local buttons = getMenuButtons(game)
 
     for _, rect in ipairs(buttons) do
-        if pointInRect(x, y, rect) then
+        if rect.id == "toggle_play_mode" and rect.segments then
+            for index, segment in ipairs(rect.segments) do
+                if pointInRect(x, y, uiControls.segmentRect(rect, index, #rect.segments)) then
+                    return segment.id == "online" and "set_play_mode_online" or "set_play_mode_offline"
+                end
+            end
+        elseif pointInRect(x, y, rect) then
             return rect.id
         end
     end

--- a/tests/map_presentation_test.lua
+++ b/tests/map_presentation_test.lua
@@ -1,0 +1,145 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local mapPresentation = require("src.game.app.map_presentation")
+
+local function assertEqual(actual, expected, message)
+    if actual ~= expected then
+        error(string.format("%s (expected %s, got %s)", message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assertNear(actual, expected, epsilon, message)
+    if math.abs((actual or 0) - (expected or 0)) > (epsilon or 0.0001) then
+        error(string.format("%s (expected %.4f, got %.4f)", message, expected, actual), 2)
+    end
+end
+
+assertEqual(
+    mapPresentation.resolveSubtitle({ mapKind = "campaign" }, { playerDisplayName = "Signal" }),
+    "Campaign Map",
+    "campaign maps show their map type"
+)
+
+assertEqual(
+    mapPresentation.resolveSubtitle({ mapKind = "tutorial" }, { playerDisplayName = "Signal" }),
+    "Guidebook Map",
+    "tutorial maps show the guidebook label"
+)
+
+assertEqual(
+    mapPresentation.resolveSubtitle({ mapKind = "user" }, { playerDisplayName = "Signal" }),
+    "by Signal",
+    "local user maps use the current player name"
+)
+
+assertEqual(
+    mapPresentation.resolveSubtitle({
+        mapKind = "user",
+        remoteSource = { creatorDisplayName = "Test Player" },
+    }, { playerDisplayName = "Signal" }),
+    "by Test Player",
+    "downloaded or imported user maps prefer the recorded creator name"
+)
+
+local fakeWorld = {
+    edges = {
+        start_a = {
+            id = "start_a",
+            sourceType = "start",
+            targetType = "junction",
+            targetId = "junction_1",
+            path = {
+                length = 100,
+                points = {
+                    { x = 0, y = 0 },
+                    { x = 100, y = 0 },
+                },
+            },
+        },
+        exit_a = {
+            id = "exit_a",
+            sourceType = "junction",
+            sourceId = "junction_1",
+            targetType = "exit",
+            path = {
+                length = 80,
+                points = {
+                    { x = 100, y = 0 },
+                    { x = 180, y = 0 },
+                },
+            },
+        },
+        exit_b = {
+            id = "exit_b",
+            sourceType = "junction",
+            sourceId = "junction_1",
+            targetType = "exit",
+            path = {
+                length = 90,
+                points = {
+                    { x = 100, y = 0 },
+                    { x = 100, y = 90 },
+                },
+            },
+        },
+    },
+    getRenderedTrackWindow = function(_, edge)
+        return 0, edge.path.length
+    end,
+    getLevel = function()
+        return { title = "Fork In The Line" }
+    end,
+    getInputEdgeGroups = function()
+        return {
+            { edge = { id = "start_a" } },
+        }
+    end,
+    getOutputBadgeGroups = function()
+        return {
+            { edge = { id = "exit_a" } },
+            { edge = { id = "exit_b" } },
+        }
+    end,
+}
+
+local state = mapPresentation.buildState(fakeWorld, { mapKind = "campaign" }, { playerDisplayName = "Signal" })
+local junctionSchedule = state.junctionScheduleById.junction_1
+assertEqual(state.title, "Fork In The Line", "map presentation uses the level title when present")
+assertNear(
+    state.graphCompleteTime,
+    3.5,
+    0.0001,
+    "graph reveal duration is normalized to the fixed map presentation length"
+)
+assertNear(
+    state.edgeScheduleById.exit_a.startTime,
+    junctionSchedule.iconEndTime,
+    0.0001,
+    "the first outgoing edge waits until the junction icon reveal finishes"
+)
+assertNear(
+    state.edgeScheduleById.exit_b.startTime,
+    junctionSchedule.iconEndTime,
+    0.0001,
+    "parallel outgoing edges start together after the junction reveal"
+)
+assertNear(
+    state.uiReveal.startTime,
+    state.graphCompleteTime + 0.08,
+    0.0001,
+    "ui reveal begins shortly after the track presentation finishes"
+)
+
+local skipState = mapPresentation.buildState(fakeWorld, { mapKind = "campaign" }, { playerDisplayName = "Signal" })
+skipState.elapsed = 1.1
+mapPresentation.skip(skipState)
+assertEqual(skipState.titleOnly, true, "skipping the intro keeps the title overlay alive")
+assertEqual(mapPresentation.isBlocking(skipState), false, "title-only mode no longer blocks gameplay")
+
+local finishedEarly = mapPresentation.update(skipState, 1.0)
+assertEqual(finishedEarly, false, "title-only mode remains active until the title animation completes")
+
+local finishedLate = mapPresentation.update(skipState, 5.0)
+assertEqual(finishedLate, true, "title-only mode finishes once the title animation ends")
+
+print("map presentation tests passed")

--- a/tests/map_presentation_test.lua
+++ b/tests/map_presentation_test.lua
@@ -129,6 +129,23 @@ assertNear(
     0.0001,
     "ui reveal begins shortly after the track presentation finishes"
 )
+assertNear(
+    state.trackStateBlend.startTime,
+    state.graphCompleteTime,
+    0.0001,
+    "track state blending starts when the graph reveal finishes"
+)
+assertNear(
+    state.signalPop.startTime,
+    state.graphCompleteTime,
+    0.0001,
+    "signal pop-in starts when the graph reveal finishes"
+)
+assertEqual(
+    state.finishTime >= state.signalPop.endTime,
+    true,
+    "presentation remains alive until the signal pop finishes"
+)
 
 local skipState = mapPresentation.buildState(fakeWorld, { mapKind = "campaign" }, { playerDisplayName = "Signal" })
 skipState.elapsed = 1.1

--- a/tests/map_presentation_test.lua
+++ b/tests/map_presentation_test.lua
@@ -113,15 +113,15 @@ assertNear(
 )
 assertNear(
     state.edgeScheduleById.exit_a.startTime,
-    junctionSchedule.iconEndTime,
+    junctionSchedule.ringEndTime,
     0.0001,
-    "the first outgoing edge waits until the junction icon reveal finishes"
+    "the first outgoing edge waits until the junction ring reveal finishes"
 )
 assertNear(
     state.edgeScheduleById.exit_b.startTime,
-    junctionSchedule.iconEndTime,
+    junctionSchedule.ringEndTime,
     0.0001,
-    "parallel outgoing edges start together after the junction reveal"
+    "parallel outgoing edges start together once the junction ring finishes"
 )
 assertNear(
     state.uiReveal.startTime,
@@ -158,5 +158,99 @@ assertEqual(finishedEarly, false, "title-only mode remains active until the titl
 
 local finishedLate = mapPresentation.update(skipState, 5.0)
 assertEqual(finishedLate, true, "title-only mode finishes once the title animation ends")
+
+local mergeWaitWorld = {
+    edges = {
+        a_to_merge = {
+            id = "a_to_merge",
+            sourceType = "start",
+            targetType = "junction",
+            targetId = "merge_junction",
+            path = {
+                length = 120,
+                points = {
+                    { x = 0, y = 0 },
+                    { x = 120, y = 0 },
+                },
+            },
+        },
+        merge_to_second = {
+            id = "merge_to_second",
+            sourceType = "junction",
+            sourceId = "merge_junction",
+            targetType = "junction",
+            targetId = "second_junction",
+            path = {
+                length = 90,
+                points = {
+                    { x = 120, y = 0 },
+                    { x = 210, y = 0 },
+                },
+            },
+        },
+        b_to_second = {
+            id = "b_to_second",
+            sourceType = "start",
+            targetType = "junction",
+            targetId = "second_junction",
+            path = {
+                length = 220,
+                points = {
+                    { x = 0, y = 80 },
+                    { x = 220, y = 80 },
+                },
+            },
+        },
+        second_to_exit = {
+            id = "second_to_exit",
+            sourceType = "junction",
+            sourceId = "second_junction",
+            targetType = "exit",
+            path = {
+                length = 70,
+                points = {
+                    { x = 220, y = 40 },
+                    { x = 290, y = 40 },
+                },
+            },
+        },
+    },
+    getRenderedTrackWindow = function(_, edge)
+        return 0, edge.path.length
+    end,
+    getLevel = function()
+        return { title = "Merge Wait" }
+    end,
+    getInputEdgeGroups = function()
+        return {
+            { edge = { id = "a_to_merge" } },
+            { edge = { id = "b_to_second" } },
+        }
+    end,
+    getOutputBadgeGroups = function()
+        return {
+            { edge = { id = "second_to_exit" } },
+        }
+    end,
+}
+
+local mergeWaitState = mapPresentation.buildState(mergeWaitWorld, { mapKind = "campaign" }, { playerDisplayName = "Signal" })
+local secondJunctionSchedule = mergeWaitState.junctionScheduleById.second_junction
+assertEqual(secondJunctionSchedule ~= nil, true, "downstream junction gets a reveal schedule")
+assertNear(
+    secondJunctionSchedule.arrivalTime,
+    math.max(
+        mergeWaitState.edgeScheduleById.merge_to_second.endTime,
+        mergeWaitState.edgeScheduleById.b_to_second.endTime
+    ),
+    0.0001,
+    "a junction waits for all incoming edges to finish before its reveal begins"
+)
+assertNear(
+    mergeWaitState.edgeScheduleById.second_to_exit.startTime,
+    secondJunctionSchedule.ringEndTime,
+    0.0001,
+    "outgoing edges wait for the fully resolved downstream junction ring"
+)
 
 print("map presentation tests passed")

--- a/tests/map_presentation_test.lua
+++ b/tests/map_presentation_test.lua
@@ -194,10 +194,10 @@ local mergeWaitWorld = {
             targetType = "junction",
             targetId = "second_junction",
             path = {
-                length = 220,
+                length = 70,
                 points = {
                     { x = 0, y = 80 },
-                    { x = 220, y = 80 },
+                    { x = 70, y = 80 },
                 },
             },
         },
@@ -245,6 +245,18 @@ assertNear(
     ),
     0.0001,
     "a junction waits for all incoming edges to finish before its reveal begins"
+)
+assertNear(
+    mergeWaitState.edgeScheduleById.merge_to_second.endTime,
+    secondJunctionSchedule.arrivalTime,
+    0.0001,
+    "the longer path into the junction preserves the target arrival time"
+)
+assertNear(
+    mergeWaitState.edgeScheduleById.b_to_second.endTime,
+    secondJunctionSchedule.arrivalTime,
+    0.0001,
+    "the shorter direct path is stretched so it finishes with the longer incoming path"
 )
 assertNear(
     mergeWaitState.edgeScheduleById.second_to_exit.startTime,


### PR DESCRIPTION
## Requested Behavior
- Redesign map and menu presentation to feel gradual, juicy, and skippable.
- Show map titles and player subtitles in the intro, animate them across the screen, and keep them layered above other UI.
- Draw maps progressively from their starting points, reveal junctions and their controls with springy motion, and let the intro be skipped without hard teleporting.
- Delay and animate road decorators, junction selectors, and other outgoing controls so they pop in with a spring after their related junction reveal.
- Keep the menu background alive with replay-backed map presentations, cycling through valid replays and falling back to bundled campaign replays when needed.
- Make the intro scheduler robust for maps with junction cycles so the presentation stays visually coherent on difficult layouts.

## Summary
- Added a replay-driven menu background that plays full map intros in the background instead of the static menu backdrop.
- Expanded the map presentation system with staged track, junction, decorator, and selector reveals plus smoother skip handling.
- Added support files for bundled campaign replay sources and updated rendering/UI wiring across play, menu, and level select screens.
- Added regression coverage for presentation timing and cycle handling.

## Testing
- Added and updated unit coverage for map presentation scheduling and UI hint formatting.
- Ran focused Love-based tests for presentation, renderer layout, and UI formatting.
- Performed smoke-load validation of the touched runtime and rendering modules.