### PR TITLE
Show online map revisions in the UI

### DIFF
--- a/src/game/app/game_profile_and_results.lua
+++ b/src/game/app/game_profile_and_results.lua
@@ -11,6 +11,8 @@ return function(Game, shared)
         end,
     }))
 
+local mapRevision = require("src.game.util.map_revision")
+
 function Game:isProfileComplete()
     return trim(self.profile and self.profile.playerDisplayName or "") ~= ""
 end
@@ -419,8 +421,29 @@ function Game:showUploadStartedMessage(origin)
 end
 
 function Game:showUploadSuccessMessage(origin, payload, mapDescriptor)
+    local resolvedPayload = type(payload) == "table" and payload or {}
+    if type(mapDescriptor) == "table" then
+        mapDescriptor.hasRemotePlayStats = true
+        mapDescriptor.revisionNumber = tonumber(resolvedPayload.revision_number or mapDescriptor.revisionNumber or 1) or 1
+        mapDescriptor.revisionLabel = mapRevision.formatRevisionLabel(mapDescriptor.revisionNumber)
+        mapDescriptor.totalPlayCount = tonumber(resolvedPayload.total_play_count or mapDescriptor.totalPlayCount or 0) or 0
+        mapDescriptor.playerTotalPlayCount = tonumber(
+            resolvedPayload.player_total_play_count or mapDescriptor.playerTotalPlayCount or 0
+        ) or 0
+        mapDescriptor.revisionPlayCount = tonumber(resolvedPayload.revision_play_count or mapDescriptor.revisionPlayCount or 0) or 0
+        mapDescriptor.playerRevisionPlayCount = tonumber(
+            resolvedPayload.player_revision_play_count or mapDescriptor.playerRevisionPlayCount or 0
+        ) or 0
+        mapDescriptor.remoteSource = mapDescriptor.remoteSource or {}
+        mapDescriptor.remoteSource.mapHash = tostring(resolvedPayload.map_hash or mapDescriptor.mapHash or "")
+        mapDescriptor.remoteSource.revisionNumber = mapDescriptor.revisionNumber
+        mapDescriptor.remoteSource.totalPlayCount = mapDescriptor.totalPlayCount
+        mapDescriptor.remoteSource.playerTotalPlayCount = mapDescriptor.playerTotalPlayCount
+        mapDescriptor.remoteSource.revisionPlayCount = mapDescriptor.revisionPlayCount
+        mapDescriptor.remoteSource.playerRevisionPlayCount = mapDescriptor.playerRevisionPlayCount
+    end
+
     if origin == "editor" then
-        local resolvedPayload = type(payload) == "table" and payload or {}
         local uploadedMapId = tostring(
             resolvedPayload.internal_identifier
                 or resolvedPayload.internalIdentifier
@@ -574,6 +597,11 @@ function Game:downloadMarketplaceMap(mapDescriptor)
             likedByPlayer = sourceEntry.liked_by_player == true,
             mapCategory = tostring(sourceEntry.map_category or ""),
             mapHash = tostring(sourceEntry.map_hash or ""),
+            playerTotalPlayCount = tonumber(sourceEntry.player_total_play_count or 0) or 0,
+            playerRevisionPlayCount = tonumber(sourceEntry.player_revision_play_count or 0) or 0,
+            revisionNumber = tonumber(sourceEntry.revision_number or 1) or 1,
+            revisionPlayCount = tonumber(sourceEntry.revision_play_count or 0) or 0,
+            totalPlayCount = tonumber(sourceEntry.total_play_count or 0) or 0,
             updatedAt = tostring(sourceEntry.updated_at or ""),
         },
     }

--- a/src/game/app/game_remote_services.lua
+++ b/src/game/app/game_remote_services.lua
@@ -38,10 +38,8 @@ function Game:isBackendTrackedMap(mapDescriptor)
         return false
     end
 
-    return resolvedMapDescriptor.isRemoteImport == true
-        or type(resolvedMapDescriptor.remoteSource) == "table"
-        or type(resolvedMapDescriptor.remoteSourceEntry) == "table"
-        or resolvedMapDescriptor.hasRemotePlayStats == true
+    return tostring(resolvedMapDescriptor.mapUuid or "") ~= ""
+        and tostring(resolvedMapDescriptor.mapHash or "") ~= ""
 end
 
 function Game:updateStoredMapPlayCounts(

--- a/src/game/app/game_remote_services.lua
+++ b/src/game/app/game_remote_services.lua
@@ -11,8 +11,11 @@ return function(Game, shared)
         end,
     }))
 
+local mapRevision = require("src.game.util.map_revision")
+
 local SCORE_SUBMIT_REQUEST_KIND_REPLAY = "replay_submit"
 local SCORE_SUBMIT_REQUEST_KIND_SCORE = "score_submit"
+local MAP_PLAY_REQUEST_KIND = "map_play"
 local RESULTS_MESSAGE_REPLAY_UPLOAD_PENDING = "Uploading replay..."
 local RESULTS_MESSAGE_REPLAY_UPLOAD_TIMEOUT = "The replay upload timed out."
 local RESULTS_MESSAGE_REPLAY_UPLOAD_FAILED = "The replay upload failed."
@@ -27,6 +30,135 @@ function Game:reloadOnlineConfig()
         self.onlineConfig = loadedConfig
     end
     return self.onlineConfig
+end
+
+function Game:isBackendTrackedMap(mapDescriptor)
+    local resolvedMapDescriptor = type(mapDescriptor) == "table" and mapDescriptor or nil
+    if not resolvedMapDescriptor then
+        return false
+    end
+
+    return resolvedMapDescriptor.isRemoteImport == true
+        or type(resolvedMapDescriptor.remoteSource) == "table"
+        or type(resolvedMapDescriptor.remoteSourceEntry) == "table"
+        or resolvedMapDescriptor.hasRemotePlayStats == true
+end
+
+function Game:updateStoredMapPlayCounts(
+    mapUuid,
+    mapHash,
+    revisionNumber,
+    totalPlayCount,
+    revisionPlayCount,
+    playerTotalPlayCount,
+    playerRevisionPlayCount
+)
+    local resolvedMapUuid = tostring(mapUuid or "")
+    local resolvedMapHash = tostring(mapHash or "")
+    if resolvedMapUuid == "" then
+        return
+    end
+
+    local function applyToDescriptor(descriptor)
+        if type(descriptor) ~= "table" then
+            return
+        end
+        if tostring(descriptor.mapUuid or "") ~= resolvedMapUuid then
+            return
+        end
+        if resolvedMapHash ~= "" and tostring(descriptor.mapHash or "") ~= resolvedMapHash then
+            return
+        end
+
+        descriptor.hasRemotePlayStats = true
+        descriptor.revisionNumber = tonumber(revisionNumber or descriptor.revisionNumber or 1) or 1
+        descriptor.revisionLabel = mapRevision.formatRevisionLabel(descriptor.revisionNumber)
+        descriptor.totalPlayCount = tonumber(totalPlayCount or descriptor.totalPlayCount or 0) or 0
+        descriptor.revisionPlayCount = tonumber(revisionPlayCount or descriptor.revisionPlayCount or 0) or 0
+        descriptor.playerTotalPlayCount = tonumber(playerTotalPlayCount or descriptor.playerTotalPlayCount or 0) or 0
+        descriptor.playerRevisionPlayCount = tonumber(playerRevisionPlayCount or descriptor.playerRevisionPlayCount or 0) or 0
+        descriptor.remoteSource = descriptor.remoteSource or {}
+        descriptor.remoteSource.revisionNumber = descriptor.revisionNumber
+        descriptor.remoteSource.totalPlayCount = descriptor.totalPlayCount
+        descriptor.remoteSource.revisionPlayCount = descriptor.revisionPlayCount
+        descriptor.remoteSource.playerTotalPlayCount = descriptor.playerTotalPlayCount
+        descriptor.remoteSource.playerRevisionPlayCount = descriptor.playerRevisionPlayCount
+    end
+
+    applyToDescriptor(self.currentMapDescriptor)
+
+    for _, descriptor in ipairs(self.availableMaps or {}) do
+        applyToDescriptor(descriptor)
+    end
+
+    for _, cacheEntry in pairs(self.marketplaceCacheByScope or {}) do
+        local payload = type(cacheEntry) == "table" and cacheEntry.payload or nil
+        local entries = type(payload) == "table" and payload.entries or nil
+        if type(entries) == "table" then
+            for _, entry in ipairs(entries) do
+                if type(entry) == "table"
+                    and tostring(entry.map_uuid or "") == resolvedMapUuid
+                    and (resolvedMapHash == "" or tostring(entry.map_hash or "") == resolvedMapHash)
+                then
+                    entry.revision_number = tonumber(revisionNumber or entry.revision_number or 1) or 1
+                    entry.total_play_count = tonumber(totalPlayCount or entry.total_play_count or 0) or 0
+                    entry.revision_play_count = tonumber(revisionPlayCount or entry.revision_play_count or 0) or 0
+                    entry.player_total_play_count = tonumber(playerTotalPlayCount or entry.player_total_play_count or 0) or 0
+                    entry.player_revision_play_count = tonumber(playerRevisionPlayCount or entry.player_revision_play_count or 0) or 0
+                end
+            end
+        end
+    end
+end
+
+function Game:beginMapPlayRecordRequest(onlineConfig, mapDescriptor)
+    local resolvedMapDescriptor = type(mapDescriptor) == "table" and mapDescriptor or nil
+    if not resolvedMapDescriptor then
+        return false
+    end
+
+    local mapUuid = tostring(resolvedMapDescriptor.mapUuid or "")
+    local mapHash = tostring(resolvedMapDescriptor.mapHash or "")
+    if mapUuid == "" or mapHash == "" then
+        return false
+    end
+
+    self:ensureLeaderboardWorker()
+    self.remoteWriteRequestSequence = self.remoteWriteRequestSequence + 1
+    self.leaderboardRequestChannel:push(json.encode({
+        kind = MAP_PLAY_REQUEST_KIND,
+        requestId = self.remoteWriteRequestSequence,
+        config = {
+            apiKey = onlineConfig.apiKey,
+            apiBaseUrl = onlineConfig.apiBaseUrl,
+            hmacSecret = onlineConfig.hmacSecret,
+            mapUuid = mapUuid,
+            mapHash = mapHash,
+            mode = MAP_PLAY_REQUEST_KIND,
+            playerDisplayName = self.profile and self.profile.playerDisplayName or "",
+            player_uuid = getProfilePlayerUuid(self.profile),
+        },
+    }))
+    return true
+end
+
+function Game:recordMapAttemptForDescriptor(mapDescriptor)
+    local resolvedMapDescriptor = type(mapDescriptor) == "table" and mapDescriptor or nil
+    if not resolvedMapDescriptor then
+        return false
+    end
+
+    if not self:isOnlineMode() or not self:isBackendTrackedMap(resolvedMapDescriptor) or self:isDebugModeEnabled() then
+        return true
+    end
+
+    local onlineConfig = self:reloadOnlineConfig()
+    if not onlineConfig.isConfigured then
+        return true
+    end
+
+    self:beginMapPlayRecordRequest(onlineConfig, resolvedMapDescriptor)
+    return true
 end
 
 function Game:getLeaderboardCacheEntry(scopeKey)
@@ -1913,6 +2045,18 @@ function Game:updateLeaderboardFetchState()
                     failureMessage = string.format("Map upload failed (HTTP %d): %s", statusCode, tostring(failureMessage))
                 end
                 self:showUploadFailureMessage(uploadOrigin, failureMessage)
+            end
+        elseif type(decodedResponse) == "table" and decodedResponse.kind == MAP_PLAY_REQUEST_KIND then
+            if decodedResponse.ok and type(decodedResponse.payload) == "table" then
+                self:updateStoredMapPlayCounts(
+                    decodedResponse.payload.map_uuid,
+                    decodedResponse.payload.map_hash,
+                    decodedResponse.payload.revision_number,
+                    decodedResponse.payload.total_play_count,
+                    decodedResponse.payload.revision_play_count,
+                    decodedResponse.payload.player_total_play_count,
+                    decodedResponse.payload.player_revision_play_count
+                )
             end
         elseif type(decodedResponse) == "table"
             and decodedResponse.requestId == self.activeScoreSubmitRequestId

--- a/src/game/app/game_screen_flow.lua
+++ b/src/game/app/game_screen_flow.lua
@@ -1117,6 +1117,7 @@ function Game:openResults()
     end
 
     self:finalizeReplayRecord()
+    self:recordMapAttemptForDescriptor(self.currentMapDescriptor)
     self.resultsSummary = self.world:getRunSummary()
     self.resultsHoverInfo = nil
     self.failureReason = self.resultsSummary.endReason == "level_clear" and nil or self.resultsSummary.endReason

--- a/src/game/network/leaderboard_client.lua
+++ b/src/game/network/leaderboard_client.lua
@@ -197,6 +197,29 @@ function leaderboardClient.submitReplay(submission, config)
     return postJson(resolvedConfig, endpointPath, payload)
 end
 
+function leaderboardClient.recordMapPlay(submission, config)
+    local resolvedConfig, configError = normalizeConfig(config)
+    if not resolvedConfig then
+        return nil, configError
+    end
+
+    local mapUuid = tostring(submission.mapUuid or "")
+    if mapUuid == "" then
+        return nil, "The play count could not be recorded because the map UUID is missing."
+    end
+
+    local mapHash = tostring(submission.mapHash or submission.map_hash or "")
+    if mapHash == "" then
+        return nil, "The play count could not be recorded because the map hash is missing."
+    end
+
+    return postJson(resolvedConfig, string.format("/api/maps/%s/plays", mapUuid), {
+        display_name = tostring(submission.playerDisplayName or ""),
+        map_hash = mapHash,
+        player_uuid = tostring(submission.player_uuid or ""),
+    })
+end
+
 function leaderboardClient.fetchReplayMetadata(requestOptions, config)
     local resolvedConfig, configError = normalizeConfig(config)
     if not resolvedConfig then

--- a/src/game/network/leaderboard_fetch_thread.lua
+++ b/src/game/network/leaderboard_fetch_thread.lua
@@ -9,6 +9,7 @@ local REQUEST_KIND_FETCH = "fetch"
 local REQUEST_KIND_PREVIEW = "preview"
 local REQUEST_KIND_MARKETPLACE = "marketplace"
 local REQUEST_KIND_FAVORITE_MAP = "favorite_map"
+local REQUEST_KIND_MAP_PLAY = "map_play"
 local REQUEST_KIND_REPLAY_SUBMIT = "replay_submit"
 local REQUEST_KIND_SCORE_SUBMIT = "score_submit"
 local REQUEST_KIND_REPLAY_FETCH = "replay_fetch"
@@ -259,6 +260,24 @@ local function favoriteMarketplaceMap(config, requestId)
     return runJsonDelete(config, endpointPath, payload, REQUEST_KIND_FAVORITE_MAP, requestId)
 end
 
+local function recordMapPlay(config, requestId)
+    local mapUuid = tostring(config.mapUuid or "")
+    if mapUuid == "" then
+        return nil, "The play count could not be recorded because the map UUID is missing."
+    end
+
+    local mapHash = tostring(config.mapHash or config.map_hash or "")
+    if mapHash == "" then
+        return nil, "The play count could not be recorded because the map hash is missing."
+    end
+
+    return runJsonPost(config, string.format("/api/maps/%s/plays", mapUuid), {
+        display_name = tostring(config.playerDisplayName or ""),
+        map_hash = mapHash,
+        player_uuid = tostring(config.player_uuid or ""),
+    }, REQUEST_KIND_MAP_PLAY, requestId)
+end
+
 local function submitReplay(config, requestId)
     local mapUuid = tostring(config.mapUuid or "")
     if mapUuid == "" then
@@ -369,6 +388,16 @@ while true do
         local payload, requestError, statusCode = favoriteMarketplaceMap(request.config or {}, request.requestId)
         responseChannel:push(json.encode({
             kind = REQUEST_KIND_FAVORITE_MAP,
+            requestId = request.requestId,
+            ok = payload ~= nil,
+            payload = payload,
+            error = requestError,
+            status = statusCode,
+        }))
+    elseif type(request) == "table" and request.kind == REQUEST_KIND_MAP_PLAY then
+        local payload, requestError, statusCode = recordMapPlay(request.config or {}, request.requestId)
+        responseChannel:push(json.encode({
+            kind = REQUEST_KIND_MAP_PLAY,
             requestId = request.requestId,
             ok = payload ~= nil,
             payload = payload,

--- a/src/game/storage/map_storage.lua
+++ b/src/game/storage/map_storage.lua
@@ -1,6 +1,7 @@
 local mapStorage = {}
 local mapCompiler = require("src.game.map_compiler.map_compiler")
 local mapHash = require("src.game.util.map_hash")
+local mapRevision = require("src.game.util.map_revision")
 local toml = require("src.game.util.toml")
 local uuid = require("src.game.util.uuid")
 
@@ -172,6 +173,37 @@ local function buildDescriptor(source, fileName, data, options)
     local descriptorOptions = options or {}
     local mapKind = descriptorOptions.mapKind or inferMapKind(source, data, descriptorOptions.directory)
     local isRemoteImport = type(data.remoteSource) == "table" or descriptorOptions.isFromDownloadedDir
+    local revisionNumber = mapRevision.sanitizeRevisionNumber(
+        data.revisionNumber
+            or data.revision_number
+            or data.remoteSource and (data.remoteSource.revisionNumber or data.remoteSource.revision_number)
+            or nil
+    )
+    local totalPlayCount = tonumber(
+        data.totalPlayCount
+            or data.total_play_count
+            or data.remoteSource and (data.remoteSource.totalPlayCount or data.remoteSource.total_play_count)
+            or 0
+    ) or 0
+    local playerTotalPlayCount = tonumber(
+        data.playerTotalPlayCount
+            or data.player_total_play_count
+            or data.remoteSource and (data.remoteSource.playerTotalPlayCount or data.remoteSource.player_total_play_count)
+            or 0
+    ) or 0
+    local revisionPlayCount = tonumber(
+        data.revisionPlayCount
+            or data.revision_play_count
+            or data.remoteSource and (data.remoteSource.revisionPlayCount or data.remoteSource.revision_play_count)
+            or 0
+    ) or 0
+    local playerRevisionPlayCount = tonumber(
+        data.playerRevisionPlayCount
+            or data.player_revision_play_count
+            or data.remoteSource and (data.remoteSource.playerRevisionPlayCount or data.remoteSource.player_revision_play_count)
+            or 0
+    ) or 0
+    local hasRemotePlayStats = type(data.remoteSource) == "table"
     local descriptorSourceId = source == "builtin"
         and source
         or (isRemoteImport and "downloaded" or "user")
@@ -188,6 +220,13 @@ local function buildDescriptor(source, fileName, data, options)
         builtinDirectory = descriptorOptions.directory,
         savedAt = data.savedAt,
         mapHash = data.mapHash,
+        revisionNumber = revisionNumber,
+        revisionLabel = mapRevision.formatRevisionLabel(revisionNumber),
+        totalPlayCount = totalPlayCount,
+        playerTotalPlayCount = playerTotalPlayCount,
+        revisionPlayCount = revisionPlayCount,
+        playerRevisionPlayCount = playerRevisionPlayCount,
+        hasRemotePlayStats = hasRemotePlayStats,
         hasEditor = data.editor ~= nil,
         hasLevel = data.level ~= nil,
         hasErrors = #((data.validationErrors) or {}) > 0,
@@ -295,6 +334,10 @@ function mapStorage.saveMap(name, payload)
     local path = USER_MAP_DIR .. "/" .. fileName
     local resolvedPayload = ensureMapPayload(payload)
     attachComputedMapHash(resolvedPayload)
+    resolvedPayload.revisionNumber = mapRevision.sanitizeRevisionNumber(
+        resolvedPayload.revisionNumber
+            or resolvedPayload.revision_number
+    )
 
     local ok, writeError = writeMapFile(path, createPersistedPayload(resolvedPayload))
     if not ok then

--- a/src/game/ui/screen_drawers.lua
+++ b/src/game/ui/screen_drawers.lua
@@ -1217,6 +1217,7 @@ function ui.drawResults(game)
     local graphics = love.graphics
     local summary = game.resultsSummary or {}
     local level = game.world and game.world:getLevel() or {}
+    local currentMapDescriptor = game.currentMapDescriptor or {}
     local finalScore = summary.finalScore or 0
     local onTimePointCap = summary.onTimePointCap or 0
     local panel = ui.getResultsPanelRect(game)
@@ -1297,6 +1298,7 @@ function ui.drawResults(game)
         string.format("Wrong destinations: %d", summary.wrongDestinationCount or 0),
         string.format("Elapsed time: %.1fs", summary.elapsedSeconds or 0),
         string.format("Interactions: %d", summary.interactionCount or 0),
+        string.format("Revision: %s", tostring(currentMapDescriptor.revisionLabel or "v0.0.1")),
         string.format("Map UUID: %s", summary.mapUuid or "n/a"),
     }
 

--- a/src/game/ui/screen_level_select.lua
+++ b/src/game/ui/screen_level_select.lua
@@ -1,4 +1,5 @@
 local junctionControls = require("src.game.junction_controls")
+local mapRevision = require("src.game.util.map_revision")
 
 return function(ui, shared)
     local moduleEnvironment = setmetatable({ ui = ui }, {
@@ -196,6 +197,7 @@ function buildMarketplaceDescriptor(entry)
     end
 
     local displayName = tostring(entry.map_name or "Untitled Map")
+    local revisionNumber = mapRevision.sanitizeRevisionNumber(entry.revision_number)
     return {
         id = string.format(
             "%s:%s:%s:%s",
@@ -212,6 +214,13 @@ function buildMarketplaceDescriptor(entry)
         likedByPlayer = entry.liked_by_player == true,
         mapKind = normalizeMarketplaceMapKind(entry.map_category),
         mapHash = tostring(entry.map_hash or ""),
+        playerTotalPlayCount = tonumber(entry.player_total_play_count or 0) or 0,
+        playerRevisionPlayCount = tonumber(entry.player_revision_play_count or 0) or 0,
+        revisionNumber = revisionNumber,
+        revisionLabel = mapRevision.formatRevisionLabel(revisionNumber),
+        totalPlayCount = tonumber(entry.total_play_count or 0) or 0,
+        revisionPlayCount = tonumber(entry.revision_play_count or 0) or 0,
+        hasRemotePlayStats = true,
         savedAt = entry.updated_at,
         hasEditor = false,
         hasLevel = type(entry.map) == "table",

--- a/src/game/ui/screen_level_select_draw.lua
+++ b/src/game/ui/screen_level_select_draw.lua
@@ -467,6 +467,14 @@ function getLevelSelectTitleText(game, selectedMap)
         )
     end
 
+    if tostring(selectedMap.mapUuid or "") ~= "" and tostring(selectedMap.mapHash or "") ~= "" then
+        return getMapDisplayName(selectedMap), string.format(
+            "%s  |  %s",
+            getMapKindLabel(selectedMap),
+            tostring(selectedMap.revisionLabel or "v0.0.1")
+        )
+    end
+
     return getMapDisplayName(selectedMap), getMapKindLabel(selectedMap)
 end
 

--- a/src/game/ui/screen_level_select_draw.lua
+++ b/src/game/ui/screen_level_select_draw.lua
@@ -439,9 +439,11 @@ function getLevelSelectTitleText(game, selectedMap)
 
         if selectedEntry then
             return selectedEntry.title, string.format(
-                "Online Maps  |  %s  |  %s votes  |  by %s",
+                "Online Maps  |  %s  |  %s  |  %s plays  |  You %s  |  by %s",
                 selectedEntry.positionLabel or sectionLabel,
-                tostring(selectedEntry.favoriteCount or 0),
+                tostring(selectedEntry.descriptor and selectedEntry.descriptor.revisionLabel or "v0.0.1"),
+                tostring(selectedEntry.descriptor and selectedEntry.descriptor.totalPlayCount or 0),
+                tostring(selectedEntry.descriptor and selectedEntry.descriptor.playerTotalPlayCount or 0),
                 selectedEntry.creatorDisplayName or "Unknown"
             )
         end
@@ -453,6 +455,16 @@ function getLevelSelectTitleText(game, selectedMap)
 
     if not selectedMap then
         return "Level Select", "Pick a map to start or edit."
+    end
+
+    if selectedMap.hasRemotePlayStats == true then
+        return getMapDisplayName(selectedMap), string.format(
+            "%s  |  %s  |  %d plays  |  You %d",
+            getMapKindLabel(selectedMap),
+            tostring(selectedMap.revisionLabel or "v0.0.1"),
+            tonumber(selectedMap.totalPlayCount or 0) or 0,
+            tonumber(selectedMap.playerTotalPlayCount or 0) or 0
+        )
     end
 
     return getMapDisplayName(selectedMap), getMapKindLabel(selectedMap)

--- a/src/game/util/map_revision.lua
+++ b/src/game/util/map_revision.lua
@@ -1,0 +1,31 @@
+local mapRevision = {}
+
+local DEFAULT_REVISION_NUMBER = 1
+local REVISION_BASE = 10
+local REVISION_PATCH_DIVISOR = 1
+local REVISION_MINOR_DIVISOR = 10
+local REVISION_MAJOR_DIVISOR = 100
+
+local function sanitizeRevisionNumber(value)
+    local revisionNumber = math.floor(tonumber(value) or DEFAULT_REVISION_NUMBER)
+    if revisionNumber < DEFAULT_REVISION_NUMBER then
+        return DEFAULT_REVISION_NUMBER
+    end
+
+    return revisionNumber
+end
+
+function mapRevision.sanitizeRevisionNumber(value)
+    return sanitizeRevisionNumber(value)
+end
+
+function mapRevision.formatRevisionLabel(value)
+    local revisionNumber = sanitizeRevisionNumber(value)
+    local patchNumber = math.floor(revisionNumber / REVISION_PATCH_DIVISOR) % REVISION_BASE
+    local minorNumber = math.floor(revisionNumber / REVISION_MINOR_DIVISOR) % REVISION_BASE
+    local majorNumber = math.floor(revisionNumber / REVISION_MAJOR_DIVISOR)
+
+    return string.format("v%d.%d.%d", majorNumber, minorNumber, patchNumber)
+end
+
+return mapRevision

--- a/tests/leaderboard_client_record_map_play_test.lua
+++ b/tests/leaderboard_client_record_map_play_test.lua
@@ -1,0 +1,48 @@
+package.path = "./?.lua;./?/init.lua;" .. package.path
+
+local function assertEqual(actual, expected, label)
+    if actual ~= expected then
+        error(string.format("%s expected %s but got %s", label, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local capturedRequest = nil
+
+package.loaded["src.game.network.http_transport"] = {
+    postJson = function(request)
+        capturedRequest = request
+        return {
+            ok = true,
+        }, nil, 200
+    end,
+}
+
+package.loaded["src.game.network.leaderboard_client"] = nil
+local leaderboardClient = require("src.game.network.leaderboard_client")
+
+local response, responseError = leaderboardClient.recordMapPlay({
+    mapUuid = "map-1",
+    mapHash = "hash-1",
+    playerDisplayName = "Player One",
+    player_uuid = "player-1",
+}, {
+    isConfigured = true,
+    apiKey = "api-key",
+    apiBaseUrl = "https://example.com",
+    hmacSecret = "hmac-secret",
+})
+
+if not response then
+    error(responseError or "recordMapPlay should succeed in the stubbed test", 2)
+end
+
+if type(capturedRequest) ~= "table" then
+    error("recordMapPlay should call the transport layer", 2)
+end
+
+assertEqual(capturedRequest.url, "https://example.com/api/maps/map-1/plays", "recordMapPlay uses the play endpoint")
+assertEqual(capturedRequest.payload.display_name, "Player One", "recordMapPlay sends the display name")
+assertEqual(capturedRequest.payload.map_hash, "hash-1", "recordMapPlay sends the map hash")
+assertEqual(capturedRequest.payload.player_uuid, "player-1", "recordMapPlay sends the player uuid")
+
+print("leaderboard client record map play tests passed")


### PR DESCRIPTION
## What changed
- added a shared revision formatter for the UI
- wired marketplace and downloaded remote map descriptors to keep backend `revision_number`, total plays, and player play counts
- sent `player_uuid` and `display_name` with online play events so backend player play tracking works
- updated the online map title bar and related remote map displays to show the current revision and player/community play counts
- kept the frontend scope focused on backend-driven online revision data and removed the earlier local attempt detour

## Why
The backend now owns online revision tracking. The frontend needed a minimal visible surface for that data so online maps show their revision immediately and the play event includes enough player identity to create backend profiles.

## Impact
- online maps now show a visible revision label in the existing level select design
- downloaded remote maps keep the backend revision metadata after import
- online play recording now sends the player identity fields required by the backend

## Validation
- `lua tests\leaderboard_client_record_map_play_test.lua`
- `lua tests\leaderboard_client_fetch_leaderboard_test.lua`
- `lua tests\leaderboard_client_submit_score_test.lua`
- `lua tests\leaderboard_client_submit_replay_test.lua`
- `lua tests\leaderboard_client_upload_map_category_test.lua`
- `lua tests\map_storage_directory_resolution_test.lua`
- syntax check with `loadfile(...)` for the modified Lua files

## Notes
`marketplace_descriptor_identity_test.lua` still does not run under the plain `lua.exe` in this environment because an existing parser issue in `src/game/rendering/track_scene_renderer.lua` is unrelated to this PR.